### PR TITLE
[HUDI-8842] Support skipping compaction and cluster for spark increme…

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
@@ -151,6 +151,20 @@ object DataSourceReadOptions {
     .withDocumentation("For the use-cases like users only want to incremental pull from certain partitions "
       + "instead of the full table. This option allows using glob pattern to directly filter on path.")
 
+  val INCREMENTAL_READ_SKIP_COMPACT: ConfigProperty[Boolean] = ConfigProperty
+    .key("hoodie.datasource.read.incr.skip_compact")
+    .defaultValue(false)
+    .markAdvanced()
+    .withDocumentation("Whether to skip compaction instants and avoid reading compacted base files for streaming "
+      + "read to improve read performance.")
+
+  val INCREMENTAL_READ_SKIP_CLUSTER: ConfigProperty[Boolean] = ConfigProperty
+    .key("hoodie.datasource.read.incr.skip_cluster")
+    .defaultValue(false)
+    .markAdvanced()
+    .withDocumentation("Whether to skip clustering instants to avoid reading base files of clustering operations "
+      + "for streaming read to improve read performance.")
+
   val TIME_TRAVEL_AS_OF_INSTANT: ConfigProperty[String] = HoodieCommonConfig.TIMESTAMP_AS_OF
 
   val ENABLE_DATA_SKIPPING: ConfigProperty[Boolean] = ConfigProperty

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelationV2.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/MergeOnReadIncrementalRelationV2.scala
@@ -200,6 +200,10 @@ trait HoodieIncrementalRelationV2Trait extends HoodieBaseRelation {
       .metaClient(metaClient)
       .startCompletionTime(optParams(DataSourceReadOptions.START_COMMIT.key))
       .endCompletionTime(optParams.getOrElse(DataSourceReadOptions.END_COMMIT.key, null))
+      .skipClustering(optParams.getOrElse(DataSourceReadOptions.INCREMENTAL_READ_SKIP_CLUSTER.key(),
+        String.valueOf(DataSourceReadOptions.INCREMENTAL_READ_SKIP_CLUSTER.defaultValue)).toBoolean)
+      .skipCompaction(optParams.getOrElse(DataSourceReadOptions.INCREMENTAL_READ_SKIP_COMPACT.key(),
+        String.valueOf(DataSourceReadOptions.INCREMENTAL_READ_SKIP_COMPACT.defaultValue)).toBoolean)
       .rangeType(rangeType)
       .build()
       .analyze()

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
@@ -17,12 +17,13 @@
 
 package org.apache.hudi.functional
 
+import org.apache.hudi.DataSourceReadOptions
 import org.apache.hudi.DataSourceReadOptions.{START_OFFSET, STREAMING_READ_TABLE_VERSION}
 import org.apache.hudi.DataSourceWriteOptions.{PRECOMBINE_FIELD, RECORDKEY_FIELD}
 import org.apache.hudi.common.model.HoodieTableType.{COPY_ON_WRITE, MERGE_ON_READ}
 import org.apache.hudi.common.table.{HoodieTableMetaClient, HoodieTableVersion}
 import org.apache.hudi.common.table.timeline.HoodieTimeline
-import org.apache.hudi.config.HoodieCompactionConfig
+import org.apache.hudi.config.{HoodieClusteringConfig, HoodieCompactionConfig}
 import org.apache.hudi.config.HoodieWriteConfig.{DELETE_PARALLELISM_VALUE, INSERT_PARALLELISM_VALUE, TBL_NAME, UPSERT_PARALLELISM_VALUE, WRITE_TABLE_VERSION}
 import org.apache.hudi.hadoop.fs.HadoopFSUtils
 import org.apache.hudi.util.JavaConversions
@@ -210,41 +211,89 @@ class TestStreamingSource extends StreamTest {
     }
   }
 
+  test("Test mor streaming source with clustering") {
+    Array("true", "false").foreach(skipCluster => {
+      withTempDir { inputDir =>
+        val tablePath = s"${inputDir.getCanonicalPath}/test_cow_stream_cluster"
+        val metaClient = HoodieTableMetaClient.newTableBuilder()
+          .setTableType(MERGE_ON_READ)
+          .setTableName(getTableName(tablePath))
+          .setRecordKeyFields("id")
+          .setPreCombineField("ts")
+          .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
+
+        addData(tablePath, Seq(("1", "a1", "10", "000")))
+        addData(tablePath, Seq(("2", "a1", "11", "001")))
+        addData(tablePath, Seq(("3", "a1", "12", "002")))
+        addData(tablePath, Seq(("4", "a1", "13", "003")), enableInlineCluster = true)
+        addData(tablePath, Seq(("5", "a1", "14", "004")))
+
+        val timestamp =
+          metaClient.getActiveTimeline.getCommitsTimeline.filterCompletedInstants()
+            .firstInstant().get().getCompletionTime
+
+        val df = spark.readStream
+          .format("org.apache.hudi")
+          .option(START_OFFSET.key(), timestamp)
+          .option(DataSourceReadOptions.INCREMENTAL_READ_SKIP_CLUSTER.key(), skipCluster)
+          .load(tablePath)
+          .select("id", "name", "price", "ts")
+
+        testStream(df)(
+          AssertOnQuery { q => q.processAllAvailable(); true },
+          // Start after the first commit
+          CheckAnswerRows(Seq(
+            Row("2", "a1", "11", "001"),
+            Row("3", "a1", "12", "002"),
+            Row("4", "a1", "13", "003"),
+            Row("5", "a1", "14", "004")), lastOnly = true, isSorted = false)
+        )
+        assertTrue(metaClient.reloadActiveTimeline
+          .filter(JavaConversions.getPredicate(
+            e => e.isCompleted && HoodieTimeline.REPLACE_COMMIT_ACTION.equals(e.getAction)))
+          .countInstants() > 0)
+      }
+    })
+  }
+
   test("test mor stream source with compaction") {
-    withTempDir { inputDir =>
-      val tablePath = s"${inputDir.getCanonicalPath}/test_mor_stream"
-      val metaClient = HoodieTableMetaClient.newTableBuilder()
-        .setTableType(MERGE_ON_READ)
-        .setTableName(getTableName(tablePath))
-        .setRecordKeyFields("id")
-        .setPreCombineField("ts")
-        .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
+    Array("true", "false").foreach(skipCompact => {
+      withTempDir { inputDir =>
+        val tablePath = s"${inputDir.getCanonicalPath}/test_mor_stream"
+        val metaClient = HoodieTableMetaClient.newTableBuilder()
+          .setTableType(MERGE_ON_READ)
+          .setTableName(getTableName(tablePath))
+          .setRecordKeyFields("id")
+          .setPreCombineField("ts")
+          .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
 
-      addData(tablePath, Seq(("1", "a1", "10", "000")))
-      val df = spark.readStream
-        .format("org.apache.hudi")
-        .load(tablePath)
-        .select("id", "name", "price", "ts")
+        addData(tablePath, Seq(("1", "a1", "10", "000")))
+        val df = spark.readStream
+          .format("org.apache.hudi")
+          .option(DataSourceReadOptions.INCREMENTAL_READ_SKIP_COMPACT.key(), skipCompact)
+          .load(tablePath)
+          .select("id", "name", "price", "ts")
 
-      addData(tablePath,
-        Seq(("1", "a2", "12", "000"),
-          ("2", "a3", "12", "000")))
-      addData(tablePath, Seq(("2", "a5", "12", "000"), ("1", "a6", "12", "001")))
-      // trigger compaction
-      addData(tablePath, Seq(("3", "a6", "12", "000")), true)
+        addData(tablePath,
+          Seq(("1", "a2", "12", "000"),
+            ("2", "a3", "12", "000")))
+        addData(tablePath, Seq(("2", "a5", "12", "000"), ("1", "a6", "12", "001")))
+        // trigger compaction
+        addData(tablePath, Seq(("3", "a6", "12", "000")), enableInlineCompaction = true)
 
-      testStream(df)(
-        AssertOnQuery {q => q.processAllAvailable(); true },
-        CheckAnswerRows(Seq(Row("1", "a6", "12", "001"),
-          Row("2", "a5", "12", "000"),
-          Row("3", "a6", "12", "000")), lastOnly = true, isSorted = false),
-        StopStream
-      )
-      assertTrue(metaClient.reloadActiveTimeline
-        .filter(JavaConversions.getPredicate(
-          e => e.isCompleted && HoodieTimeline.COMMIT_ACTION.equals(e.getAction)))
-        .countInstants() > 0)
-    }
+        testStream(df)(
+          AssertOnQuery {q => q.processAllAvailable(); true },
+          CheckAnswerRows(Seq(Row("1", "a6", "12", "001"),
+            Row("2", "a5", "12", "000"),
+            Row("3", "a6", "12", "000")), lastOnly = true, isSorted = false),
+          StopStream
+        )
+        assertTrue(metaClient.reloadActiveTimeline
+          .filter(JavaConversions.getPredicate(
+            e => e.isCompleted && HoodieTimeline.COMMIT_ACTION.equals(e.getAction)))
+          .countInstants() > 0)
+      }
+    })
   }
 
   test("Test checkpoint translation") {
@@ -289,7 +338,10 @@ class TestStreamingSource extends StreamTest {
     }
   }
 
-  private def addData(inputPath: String, rows: Seq[(String, String, String, String)], enableInlineCompaction: Boolean = false) : Unit = {
+  private def addData(inputPath: String,
+                      rows: Seq[(String, String, String, String)],
+                      enableInlineCompaction: Boolean = false,
+                      enableInlineCluster: Boolean = false) : Unit = {
     rows.toDF(columns: _*)
       .write
       .format("org.apache.hudi")
@@ -297,6 +349,8 @@ class TestStreamingSource extends StreamTest {
       .option(TBL_NAME.key, getTableName(inputPath))
       .option(HoodieCompactionConfig.INLINE_COMPACT.key(), enableInlineCompaction.toString)
       .option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "2")
+      .option(HoodieClusteringConfig.INLINE_CLUSTERING.key(), enableInlineCluster.toString)
+      .option(HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key(), "2")
       .mode(SaveMode.Append)
       .save(inputPath)
   }


### PR DESCRIPTION
…ntal reading on mor table

### Change Logs

_Describe context and summary for this change. Highlight if any code was copied._

### Impact

_Describe any public API or user-facing feature change or any performance impact._

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration options to skip compaction and clustering during incremental reads
  - Enhanced streaming source testing with new clustering-related test scenarios

- **Improvements**
  - Introduced more granular control for performance optimization in incremental data reading
  - Extended testing capabilities for streaming data sources

- **Tests**
  - Added new test method for Merge-On-Read streaming source with clustering support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->