### PR TITLE
Review hudi pull request 13718 and comment

### DIFF
--- a/hudi_pr_13718.diff
+++ b/hudi_pr_13718.diff
@@ -1,0 +1,4966 @@
+diff --git a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+index 84c0e20a475c1..4701bbb7b487a 100644
+--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
++++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+@@ -170,9 +170,11 @@ public class HoodieWriteConfig extends HoodieConfig {
+       .withDocumentation("Determine what level of persistence is used to cache write RDDs. "
+           + "Refer to org.apache.spark.storage.StorageLevel for different values");
+ 
++  @Deprecated
+   public static final ConfigProperty<String> PRECOMBINE_FIELD_NAME = ConfigProperty
+       .key("hoodie.datasource.write.precombine.field")
+       .noDefaultValue()
++      .withAlternatives("hoodie.datasource.write.precombine.field")
+       .withDocumentation("Comma separated list of fields used in preCombining before actual write. When two records have the same key value, "
+           + "we will pick the one with the largest value for the precombine field, determined by Object.compareTo(..). "
+           + "For multiple fields if first key comparison is same, second key comparison is made and so on. This config is used for combining records "
+@@ -1408,6 +1410,7 @@ public HoodieTableType getTableType() {
+         HoodieTableConfig.TYPE, HoodieTableConfig.TYPE.defaultValue().name()).toUpperCase());
+   }
+ 
++  @Deprecated
+   public List<String> getPreCombineFields() {
+     return Option.ofNullable(getString(PRECOMBINE_FIELD_NAME))
+         .map(preCombine -> Arrays.asList(preCombine.split(",")))
+@@ -3018,6 +3021,7 @@ public Builder forTable(String tableName) {
+       return this;
+     }
+ 
++    @Deprecated
+     public Builder withPreCombineField(String preCombineField) {
+       writeConfig.setValue(PRECOMBINE_FIELD_NAME, preCombineField);
+       return this;
+diff --git a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
+index aa2e36184259b..278dd1928ae97 100644
+--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
++++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
+@@ -168,7 +168,7 @@ static void upgradePartitionFields(HoodieWriteConfig config, HoodieTableConfig t
+ 
+   static void upgradeMergeMode(HoodieTableConfig tableConfig, Map<ConfigProperty, String> tablePropsToAdd) {
+     String payloadClass = tableConfig.getPayloadClass();
+-    String preCombineFields = tableConfig.getPreCombineFieldsStr().orElse(null);
++    String preCombineFields = tableConfig.getOrderingFieldsStr().orElse(null);
+     if (isCustomPayloadClass(payloadClass)) {
+       // This contains a special case: HoodieMetadataPayload.
+       tablePropsToAdd.put(
+diff --git a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestSevenToEightUpgradeHandler.java b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestSevenToEightUpgradeHandler.java
+index a8c2103e46d31..66d03811b76fc 100644
+--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestSevenToEightUpgradeHandler.java
++++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestSevenToEightUpgradeHandler.java
+@@ -97,7 +97,7 @@ void testPropertyUpgrade() {
+     // Mock record merge mode configuration for merging behavior
+     when(tableConfig.contains(isA(ConfigProperty.class))).thenAnswer(i -> i.getArguments()[0].equals(PAYLOAD_CLASS_NAME));
+     when(tableConfig.getPayloadClass()).thenReturn(OverwriteWithLatestAvroPayload.class.getName());
+-    when(tableConfig.getPreCombineFieldsStr()).thenReturn(Option.empty());
++    when(tableConfig.getOrderingFieldsStr()).thenReturn(Option.empty());
+     SevenToEightUpgradeHandler.upgradeMergeMode(tableConfig, tablePropsToAdd);
+     assertTrue(tablePropsToAdd.containsKey(RECORD_MERGE_MODE));
+     assertNotNull(tablePropsToAdd.get(RECORD_MERGE_MODE));
+@@ -140,7 +140,7 @@ void testUpgradeMergeMode(String payloadClass, String preCombineField, String ex
+     Map<ConfigProperty, String> tablePropsToAdd = new HashMap<>();
+ 
+     when(tableConfig.getPayloadClass()).thenReturn(payloadClass);
+-    when(tableConfig.getPreCombineFieldsStr()).thenReturn(Option.ofNullable(preCombineField));
++    when(tableConfig.getOrderingFieldsStr()).thenReturn(Option.ofNullable(preCombineField));
+ 
+     SevenToEightUpgradeHandler.upgradeMergeMode(tableConfig, tablePropsToAdd);
+ 
+diff --git a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/common/table/read/HoodieFileGroupReaderOnJavaTestBase.java b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/common/table/read/HoodieFileGroupReaderOnJavaTestBase.java
+index 4043f9c9153ab..c4e3adeff01f8 100644
+--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/common/table/read/HoodieFileGroupReaderOnJavaTestBase.java
++++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/common/table/read/HoodieFileGroupReaderOnJavaTestBase.java
+@@ -28,6 +28,7 @@
+ import org.apache.hudi.common.model.HoodieRecordPayload;
+ import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.common.table.HoodieTableMetaClient;
++import org.apache.hudi.common.util.ConfigUtils;
+ import org.apache.hudi.common.util.Option;
+ import org.apache.hudi.config.HoodieWriteConfig;
+ import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+@@ -89,7 +90,7 @@ public void commitToTable(List<HoodieRecord> recordList, String operation, boole
+             .setKeyGeneratorType(KeyGeneratorType.SIMPLE.name())
+             .setRecordKeyFields(writeConfigs.get(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key()))
+             .setPartitionFields(writeConfigs.get(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key()))
+-            .setPreCombineFields(writeConfigs.get("hoodie.datasource.write.precombine.field"))
++            .setOrderingFields(ConfigUtils.getOrderingFieldsStrDuringWrite(writeConfigs))
+             .setBaseFileFormat(writeConfigs.get(HoodieTableConfig.BASE_FILE_FORMAT.key()))
+             .set(initConfigs);
+         if (writeConfigs.containsKey("hoodie.datasource.write.payload.class")) {
+diff --git a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieDatasetBulkInsertHelper.scala b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieDatasetBulkInsertHelper.scala
+index e2f6cba93bde5..3b89a27962d9e 100644
+--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieDatasetBulkInsertHelper.scala
++++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieDatasetBulkInsertHelper.scala
+@@ -25,6 +25,7 @@ import org.apache.hudi.common.config.TypedProperties
+ import org.apache.hudi.common.data.HoodieData
+ import org.apache.hudi.common.engine.TaskContextSupplier
+ import org.apache.hudi.common.model.HoodieRecord
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.util.{OrderingValues, ReflectionUtils}
+ import org.apache.hudi.config.HoodieWriteConfig
+ import org.apache.hudi.data.HoodieJavaRDD
+@@ -36,7 +37,6 @@ import org.apache.hudi.keygen.{AutoRecordGenWrapperKeyGenerator, BuiltinKeyGener
+ import org.apache.hudi.table.action.commit.{BucketBulkInsertDataInternalWriterHelper, BulkInsertDataInternalWriterHelper, ConsistentBucketBulkInsertDataInternalWriterHelper, ParallelismHelper}
+ import org.apache.hudi.table.{BulkInsertPartitioner, HoodieTable}
+ import org.apache.hudi.util.JFunction.toJavaSerializableFunctionUnchecked
+-
+ import org.apache.spark.TaskContext
+ import org.apache.spark.internal.Logging
+ import org.apache.spark.rdd.RDD
+@@ -68,6 +68,7 @@ object HoodieDatasetBulkInsertHelper
+    */
+   def prepareForBulkInsert(df: DataFrame,
+                            config: HoodieWriteConfig,
++                           tableConfig: HoodieTableConfig,
+                            partitioner: BulkInsertPartitioner[Dataset[Row]],
+                            instantTime: String): Dataset[Row] = {
+     val populateMetaFields = config.populateMetaFields()
+@@ -121,7 +122,7 @@ object HoodieDatasetBulkInsertHelper
+       }
+ 
+       val dedupedRdd = if (config.shouldCombineBeforeInsert) {
+-        dedupeRows(prependedRdd, updatedSchema, config.getPreCombineFields.asScala.toList, SparkHoodieIndexFactory.isGlobalIndex(config), targetParallelism)
++        dedupeRows(prependedRdd, updatedSchema, tableConfig.getOrderingFields.asScala.toList, SparkHoodieIndexFactory.isGlobalIndex(config), targetParallelism)
+       } else {
+         prependedRdd
+       }
+diff --git a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
+index 120b7cef9fdf1..28e34c04ca693 100644
+--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
++++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
+@@ -274,13 +274,13 @@ private void initRecordMerger(TypedProperties properties, boolean isIngestion) {
+     // If the provided payload class differs from the table's payload class, we need to infer the correct merging behavior.
+     if (isIngestion && providedPayloadClass.map(className -> !className.equals(tableConfig.getPayloadClass())).orElse(false)) {
+       Triple<RecordMergeMode, String, String> triple = HoodieTableConfig.inferCorrectMergingBehavior(null, providedPayloadClass.get(), null,
+-          tableConfig.getPreCombineFieldsStr().orElse(null), tableVersion);
++          tableConfig.getOrderingFieldsStr().orElse(null), tableVersion);
+       recordMergeMode = triple.getLeft();
+       mergeStrategyId = triple.getRight();
+     } else if (!tableVersion.greaterThanOrEquals(HoodieTableVersion.EIGHT)) {
+       Triple<RecordMergeMode, String, String> triple = HoodieTableConfig.inferCorrectMergingBehavior(
+           recordMergeMode, tableConfig.getPayloadClass(),
+-          mergeStrategyId, tableConfig.getPreCombineFieldsStr().orElse(null), tableVersion);
++          mergeStrategyId, tableConfig.getOrderingFieldsStr().orElse(null), tableVersion);
+       recordMergeMode = triple.getLeft();
+       mergeStrategyId = triple.getRight();
+     }
+diff --git a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordMerger.java b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordMerger.java
+index d26147f856ae5..4bdd5613ff851 100644
+--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordMerger.java
++++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordMerger.java
+@@ -172,7 +172,7 @@ default String[] getMandatoryFieldsForMerging(Schema dataSchema, HoodieTableConf
+       }
+     }
+ 
+-    List<String> preCombineFields = cfg.getPreCombineFields();
++    List<String> preCombineFields = cfg.getOrderingFields();
+     requiredFields.addAll(preCombineFields);
+     return requiredFields.toArray(new String[0]);
+   }
+diff --git a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+index 450f7df7eb3d6..3e7e20ca8c892 100644
+--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
++++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+@@ -156,10 +156,16 @@ public class HoodieTableConfig extends HoodieConfig {
+           + " to identify what upgrade/downgrade paths happened on the table. This is only configured "
+           + "when the table is initially setup.");
+ 
+-  // TODO: is this this called precombine in 1.0. ..
+-  public static final ConfigProperty<String> PRECOMBINE_FIELDS = ConfigProperty
+-      .key("hoodie.table.precombine.field")
++  /**
++   * @deprecated Use {@link #ORDERING_FIELDS} instead
++   */
++  @Deprecated
++  public static final String PRECOMBINE_FIELD = "hoodie.table.precombine.field";
++
++  public static final ConfigProperty<String> ORDERING_FIELDS = ConfigProperty
++      .key("hoodie.table.ordering.fields")
+       .noDefaultValue()
++      .withAlternatives(PRECOMBINE_FIELD)
+       .withDocumentation("Comma separated fields used in preCombining before actual write. By default, when two records have the same key value, "
+           + "the largest value for the precombine field determined by Object.compareTo(..), is picked. If there are multiple fields configured, "
+           + "comparison is made on the first field. If the first field values are same, comparison is made on the second field and so on.");
+@@ -924,14 +930,14 @@ static RecordMergeMode inferRecordMergeModeFromMergeStrategyId(String recordMerg
+     }
+   }
+ 
+-  public List<String> getPreCombineFields() {
+-    return getPreCombineFieldsStr()
++  public List<String> getOrderingFields() {
++    return getOrderingFieldsStr()
+         .map(preCombine -> Arrays.stream(preCombine.split(",")).filter(StringUtils::nonEmpty).collect(Collectors.toList()))
+         .orElse(Collections.emptyList());
+   }
+ 
+-  public Option<String> getPreCombineFieldsStr() {
+-    return Option.ofNullable(getString(PRECOMBINE_FIELDS));
++  public Option<String> getOrderingFieldsStr() {
++    return Option.ofNullable(getString(ORDERING_FIELDS));
+   }
+ 
+   public Option<String[]> getRecordKeyFields() {
+@@ -1237,11 +1243,13 @@ public Map<String, String> propsMap() {
+    */
+   @Deprecated
+   public static final String HOODIE_TABLE_VERSION_PROP_NAME = VERSION.key();
++
+   /**
+-   * @deprecated Use {@link #PRECOMBINE_FIELDS} and its methods.
++   * @deprecated Use {@link #ORDERING_FIELDS} and its methods.
+    */
+   @Deprecated
+-  public static final String HOODIE_TABLE_PRECOMBINE_FIELD = PRECOMBINE_FIELDS.key();
++  public static final String HOODIE_TABLE_PRECOMBINE_FIELD = PRECOMBINE_FIELD;
++
+   /**
+    * @deprecated Use {@link #BASE_FILE_FORMAT} and its methods.
+    */
+diff --git a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+index 1b15c401103e7..e71f335c6172e 100644
+--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
++++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+@@ -1069,7 +1069,7 @@ public static class TableBuilder {
+     private String timelinePath;
+     private String timelineHistoryPath;
+     private String baseFileFormat;
+-    private String preCombineFields;
++    private String orderingFields;
+     private String partitionFields;
+     private Boolean cdcEnabled;
+     private String cdcSupplementalLoggingMode;
+@@ -1191,11 +1191,11 @@ public TableBuilder setBaseFileFormat(String baseFileFormat) {
+     }
+ 
+     /**
+-     * Sets preCombine fields as a comma separated string in the table
+-     * @param preCombineFieldsAsString - Comma separated preCombine fields which need to be set for the table
++     * Sets ordering fields as a comma separated string in the table
++     * @param orderingFieldsAsString - Comma separated ordering fields which need to be set for the table
+      */
+-    public TableBuilder setPreCombineFields(String preCombineFieldsAsString) {
+-      this.preCombineFields = preCombineFieldsAsString;
++    public TableBuilder setOrderingFields(String orderingFieldsAsString) {
++      this.orderingFields = orderingFieldsAsString;
+       return this;
+     }
+ 
+@@ -1398,8 +1398,8 @@ public TableBuilder fromProperties(Properties properties) {
+         setBootstrapIndexEnable(hoodieConfig.getBoolean(HoodieTableConfig.BOOTSTRAP_INDEX_ENABLE));
+       }
+ 
+-      if (hoodieConfig.contains(HoodieTableConfig.PRECOMBINE_FIELDS)) {
+-        setPreCombineFields(hoodieConfig.getString(HoodieTableConfig.PRECOMBINE_FIELDS));
++      if (hoodieConfig.contains(HoodieTableConfig.ORDERING_FIELDS)) {
++        setOrderingFields(hoodieConfig.getString(HoodieTableConfig.ORDERING_FIELDS));
+       }
+       if (hoodieConfig.contains(HoodieTableConfig.PARTITION_FIELDS)) {
+         setPartitionFields(
+@@ -1482,7 +1482,7 @@ public Properties build() {
+ 
+       Triple<RecordMergeMode, String, String> mergeConfigs =
+           HoodieTableConfig.inferCorrectMergingBehavior(
+-              recordMergeMode, payloadClassName, recordMergerStrategyId, preCombineFields,
++              recordMergeMode, payloadClassName, recordMergerStrategyId, orderingFields,
+               tableVersion);
+       tableConfig.setValue(RECORD_MERGE_MODE, mergeConfigs.getLeft().name());
+       tableConfig.setValue(PAYLOAD_CLASS_NAME.key(), mergeConfigs.getMiddle());
+@@ -1531,8 +1531,8 @@ public Properties build() {
+         tableConfig.setValue(HoodieTableConfig.BOOTSTRAP_BASE_PATH, bootstrapBasePath);
+       }
+ 
+-      if (StringUtils.nonEmpty(preCombineFields)) {
+-        tableConfig.setValue(HoodieTableConfig.PRECOMBINE_FIELDS, preCombineFields);
++      if (StringUtils.nonEmpty(orderingFields)) {
++        tableConfig.setValue(HoodieTableConfig.ORDERING_FIELDS, orderingFields);
+       }
+ 
+       if (null != partitionFields) {
+diff --git a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordScanner.java b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordScanner.java
+index 4266dd79d6bf8..97d0f41cca60d 100644
+--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordScanner.java
++++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordScanner.java
+@@ -104,8 +104,6 @@ public abstract class AbstractHoodieLogRecordScanner {
+   private final Option<String> partitionPathFieldOpt;
+   // Partition name override
+   private final Option<String> partitionNameOverrideOpt;
+-  // Pre-combining field
+-  protected final String preCombineFields;
+   // Stateless component for merging records
+   protected final HoodieRecordMerger recordMerger;
+   private final TypedProperties payloadProps;
+@@ -175,13 +173,12 @@ protected AbstractHoodieLogRecordScanner(HoodieStorage storage, String basePath,
+     // load class from the payload fully qualified class name
+     HoodieTableConfig tableConfig = this.hoodieTableMetaClient.getTableConfig();
+     this.payloadClassFQN = tableConfig.getPayloadClass();
+-    this.preCombineFields = tableConfig.getPreCombineFieldsStr().orElse(null);
++    String orderingFieldsStr = tableConfig.getOrderingFieldsStr().orElse(null);
+     // Log scanner merge log with precombine
+     TypedProperties props = new TypedProperties();
+-    if (preCombineFields != null) {
+-      props.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, preCombineFields);
+-      props.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), preCombineFields);
+-      props.setProperty("hoodie.datasource.write.precombine.field", preCombineFields);
++    if (orderingFieldsStr != null) {
++      props.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, orderingFieldsStr);
++      props.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), orderingFieldsStr);
+     }
+     this.tableVersion = tableConfig.getTableVersion();
+     this.payloadProps = props;
+diff --git a/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java b/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
+index 831a86ad3e9aa..a7d413c5477c5 100644
+--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
++++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
+@@ -151,7 +151,7 @@ protected BaseHoodieLogRecordReader(HoodieReaderContext<T> readerContext, Hoodie
+     // load class from the payload fully qualified class name
+     HoodieTableConfig tableConfig = this.hoodieTableMetaClient.getTableConfig();
+     this.payloadClassFQN = tableConfig.getPayloadClass();
+-    this.preCombineFields = tableConfig.getPreCombineFieldsStr().orElse(null);
++    this.preCombineFields = tableConfig.getOrderingFieldsStr().orElse(null);
+     // Log scanner merge log with precombine
+     TypedProperties props = new TypedProperties();
+     if (this.preCombineFields != null) {
+diff --git a/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupReaderSchemaHandler.java b/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupReaderSchemaHandler.java
+index a05fa38b29657..acd81697d8a11 100644
+--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupReaderSchemaHandler.java
++++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupReaderSchemaHandler.java
+@@ -191,7 +191,7 @@ private static String[] getMandatoryFieldsForMerging(HoodieTableConfig cfg,
+         cfg.getRecordMergeMode(),
+         cfg.getPayloadClass(),
+         cfg.getRecordMergeStrategyId(),
+-        cfg.getPreCombineFieldsStr().orElse(null),
++        cfg.getOrderingFieldsStr().orElse(null),
+         cfg.getTableVersion());
+ 
+     if (mergingConfigs.getLeft() == RecordMergeMode.CUSTOM) {
+@@ -216,7 +216,7 @@ private static String[] getMandatoryFieldsForMerging(HoodieTableConfig cfg,
+     }
+     // Add precombine field for event time ordering merge mode.
+     if (mergingConfigs.getLeft() == RecordMergeMode.EVENT_TIME_ORDERING) {
+-      List<String> preCombineFields = cfg.getPreCombineFields();
++      List<String> preCombineFields = cfg.getOrderingFields();
+       requiredFields.addAll(preCombineFields);
+     }
+     // Add `HOODIE_IS_DELETED_FIELD` field if exists.
+diff --git a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+index 937748677b450..271b735bb7ebe 100644
+--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
++++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+@@ -82,15 +82,48 @@ public class ConfigUtils {
+    */
+   @Nullable
+   public static String[] getOrderingFields(Properties properties) {
++    String orderField = getOrderingFieldsStr(properties);
++    return orderField == null ? null : orderField.split(",");
++  }
++
++  /**
++   * Get ordering fields as comma separated string.
++   */
++  @Nullable
++  public static String getOrderingFieldsStr(Properties properties) {
++    String orderField = getOrderingFieldsStrDuringWrite(properties);
++    if (orderField == null && properties.containsKey(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY)) {
++      orderField = properties.getProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY);
++    }
++    return orderField;
++  }
++
++  /**
++   * Get ordering fields as comma separated string.
++   */
++  @Nullable
++  public static String getOrderingFieldsStrDuringWrite(Properties properties) {
+     String orderField = null;
+-    if (properties.containsKey("hoodie.datasource.write.precombine.field")) {
++    if (containsConfigProperty(properties, HoodieTableConfig.ORDERING_FIELDS)) {
++      orderField = getStringWithAltKeys(properties, HoodieTableConfig.ORDERING_FIELDS);
++    } else if (properties.containsKey("hoodie.datasource.write.precombine.field")) {
+       orderField = properties.getProperty("hoodie.datasource.write.precombine.field");
+-    } else if (properties.containsKey(HoodieTableConfig.PRECOMBINE_FIELDS.key())) {
+-      orderField = properties.getProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key());
+-    } else if (properties.containsKey(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY)) {
+-      orderField = properties.getProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY);
+     }
+-    return orderField == null ? null : orderField.split(",");
++    return orderField;
++  }
++
++  /**
++   * Get ordering fields as comma separated string.
++   */
++  @Nullable
++  public static String getOrderingFieldsStrDuringWrite(Map<String, String> properties) {
++    String orderField = null;
++    if (containsConfigProperty(properties, HoodieTableConfig.ORDERING_FIELDS)) {
++      orderField = getStringWithAltKeys(properties, HoodieTableConfig.ORDERING_FIELDS);
++    } else if (properties.containsKey("hoodie.datasource.write.precombine.field")) {
++      orderField = properties.get("hoodie.datasource.write.precombine.field");
++    }
++    return orderField;
+   }
+ 
+   /**
+@@ -101,8 +134,7 @@ public static String[] getOrderingFields(Properties properties) {
+   public static TypedProperties supplementOrderingFields(TypedProperties props, List<String> orderingFields) {
+     String orderingFieldsAsString = String.join(",", orderingFields);
+     props.putIfAbsent(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, orderingFieldsAsString);
+-    props.putIfAbsent(HoodieTableConfig.PRECOMBINE_FIELDS.key(), orderingFieldsAsString);
+-    props.putIfAbsent("hoodie.datasource.write.precombine.field", orderingFieldsAsString);
++    props.putIfAbsent(HoodieTableConfig.ORDERING_FIELDS.key(), orderingFieldsAsString);
+     return props;
+   }
+ 
+@@ -253,11 +285,11 @@ public static Option<String> stripPrefix(String prop, ConfigProperty<String> pre
+    * Whether the properties contain a config. If any of the key or alternative keys of the
+    * {@link ConfigProperty} exists in the properties, this method returns {@code true}.
+    *
+-   * @param props          Configs in {@link TypedProperties}
++   * @param props          Configs in {@link Properties}
+    * @param configProperty Config to look up.
+    * @return {@code true} if exists; {@code false} otherwise.
+    */
+-  public static boolean containsConfigProperty(TypedProperties props,
++  public static boolean containsConfigProperty(Properties props,
+                                                ConfigProperty<?> configProperty) {
+     if (!props.containsKey(configProperty.key())) {
+       for (String alternative : configProperty.getAlternatives()) {
+@@ -278,7 +310,7 @@ public static boolean containsConfigProperty(TypedProperties props,
+    * @param configProperty Config to look up.
+    * @return {@code true} if exists; {@code false} otherwise.
+    */
+-  public static boolean containsConfigProperty(Map<String, Object> props,
++  public static boolean containsConfigProperty(Map<String, ?> props,
+                                                ConfigProperty<?> configProperty) {
+     return containsConfigProperty(props::containsKey, configProperty);
+   }
+@@ -450,8 +482,8 @@ public static String getStringWithAltKeys(Properties props,
+    * and there is default value defined in the {@link ConfigProperty} config and is convertible to
+    * String type; {@code null} otherwise.
+    */
+-  public static String getStringWithAltKeys(Map<String, Object> props,
+-                                            ConfigProperty<?> configProperty) {
++  public static <V> String getStringWithAltKeys(Map<String, V> props,
++                                                ConfigProperty<?> configProperty) {
+     return getStringWithAltKeys(props::get, configProperty);
+   }
+ 
+diff --git a/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordUtils.java b/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordUtils.java
+index dd0eccb32e301..4094adbe485b2 100644
+--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordUtils.java
++++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordUtils.java
+@@ -126,6 +126,6 @@ public static List<String> getOrderingFieldNames(RecordMergeMode mergeMode,
+                                                    HoodieTableMetaClient metaClient) {
+     return mergeMode == RecordMergeMode.COMMIT_TIME_ORDERING
+         ? Collections.emptyList()
+-        : Option.ofNullable(ConfigUtils.getOrderingFields(props)).map(Arrays::asList).orElseGet(() -> metaClient.getTableConfig().getPreCombineFields());
++        : Option.ofNullable(ConfigUtils.getOrderingFields(props)).map(Arrays::asList).orElseGet(() -> metaClient.getTableConfig().getOrderingFields());
+   }
+ }
+\ No newline at end of file
+diff --git a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+index 4bfeee6d8704f..2a6bf0cd91eee 100644
+--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
++++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+@@ -1047,7 +1047,7 @@ private static <T> ClosableIterator<BufferedRecord<T>> getLogRecords(List<String
+       readerContext.setSchemaHandler(new FileGroupReaderSchemaHandler<>(readerContext, writerSchemaOpt.get(), writerSchemaOpt.get(), Option.empty(), tableConfig, properties));
+       HoodieReadStats readStats = new HoodieReadStats();
+       KeyBasedFileGroupRecordBuffer<T> recordBuffer = new KeyBasedFileGroupRecordBuffer<>(readerContext, datasetMetaClient,
+-          readerContext.getMergeMode(), PartialUpdateMode.NONE, properties, tableConfig.getPreCombineFields(),
++          readerContext.getMergeMode(), PartialUpdateMode.NONE, properties, tableConfig.getOrderingFields(),
+           UpdateProcessor.create(readStats, readerContext, true, Option.empty()));
+ 
+       // CRITICAL: Ensure allowInflightInstants is set to true
+diff --git a/hudi-common/src/test/java/org/apache/hudi/common/table/read/SchemaHandlerTestBase.java b/hudi-common/src/test/java/org/apache/hudi/common/table/read/SchemaHandlerTestBase.java
+index 41d63434f5d76..fe9423cdc5536 100644
+--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/SchemaHandlerTestBase.java
++++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/SchemaHandlerTestBase.java
+@@ -251,11 +251,11 @@ private static void setupMORTable(RecordMergeMode mergeMode, boolean hasPrecombi
+     when(hoodieTableConfig.populateMetaFields()).thenReturn(true);
+     when(hoodieTableConfig.getRecordMergeMode()).thenReturn(mergeMode);
+     if (hasPrecombine) {
+-      when(hoodieTableConfig.getPreCombineFieldsStr()).thenReturn(Option.of("timestamp"));
+-      when(hoodieTableConfig.getPreCombineFields()).thenReturn(Collections.singletonList("timestamp"));
++      when(hoodieTableConfig.getOrderingFieldsStr()).thenReturn(Option.of("timestamp"));
++      when(hoodieTableConfig.getOrderingFields()).thenReturn(Collections.singletonList("timestamp"));
+     } else {
+-      when(hoodieTableConfig.getPreCombineFieldsStr()).thenReturn(Option.empty());
+-      when(hoodieTableConfig.getPreCombineFields()).thenReturn(Collections.emptyList());
++      when(hoodieTableConfig.getOrderingFieldsStr()).thenReturn(Option.empty());
++      when(hoodieTableConfig.getOrderingFields()).thenReturn(Collections.emptyList());
+     }
+     if (mergeMode == CUSTOM) {
+       when(hoodieTableConfig.getRecordMergeStrategyId()).thenReturn("asdf");
+diff --git a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestFileGroupReaderSchemaHandler.java b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestFileGroupReaderSchemaHandler.java
+index 39ff90cc05c5c..8df6c665a8f67 100644
+--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestFileGroupReaderSchemaHandler.java
++++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestFileGroupReaderSchemaHandler.java
+@@ -192,8 +192,8 @@ public void testSchemaForMandatoryFields(boolean setPrecombine,
+     HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+     when(tableConfig.getRecordMergeMode()).thenReturn(mergeMode);
+     when(tableConfig.populateMetaFields()).thenReturn(true);
+-    when(tableConfig.getPreCombineFieldsStr()).thenReturn(Option.of(setPrecombine ? preCombineField : StringUtils.EMPTY_STRING));
+-    when(tableConfig.getPreCombineFields()).thenReturn(setPrecombine ? Collections.singletonList(preCombineField) : Collections.emptyList());
++    when(tableConfig.getOrderingFieldsStr()).thenReturn(Option.of(setPrecombine ? preCombineField : StringUtils.EMPTY_STRING));
++    when(tableConfig.getOrderingFields()).thenReturn(setPrecombine ? Collections.singletonList(preCombineField) : Collections.emptyList());
+     when(tableConfig.getTableVersion()).thenReturn(tableVersion);
+     if (tableConfig.getTableVersion() == HoodieTableVersion.SIX) {
+       if (mergeMode == RecordMergeMode.EVENT_TIME_ORDERING) {
+diff --git a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
+index df9e7c4793a5a..1bb513d6c7d24 100644
+--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
++++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
+@@ -111,7 +111,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
+   private static final List<HoodieFileFormat> DEFAULT_SUPPORTED_FILE_FORMATS = Arrays.asList(HoodieFileFormat.PARQUET, HoodieFileFormat.ORC);
+   protected static List<HoodieFileFormat> supportedFileFormats;
+   private static final String KEY_FIELD_NAME = "_row_key";
+-  private static final String PRECOMBINE_FIELD_NAME = "timestamp";
++  private static final String ORDERING_FIELD_NAME = "timestamp";
+   private static final String PARTITION_FIELD_NAME = "partition_path";
+   private static final String RIDER_FIELD_NAME = "rider";
+   @TempDir
+@@ -208,7 +208,7 @@ public void testReadFileGroupWithMultipleOrderingFields() throws Exception {
+     writeConfigs.put("hoodie.datasource.write.table.type", HoodieTableType.MERGE_ON_READ.name());
+     // Use two precombine values - combination of timestamp and rider
+     String orderingValues = "timestamp,rider";
+-    writeConfigs.put("hoodie.datasource.write.precombine.field", orderingValues);
++    writeConfigs.put(HoodieTableConfig.ORDERING_FIELDS.key(), orderingValues);
+     writeConfigs.put("hoodie.payload.ordering.field", orderingValues);
+ 
+     try (HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator(0xDEEF)) {
+@@ -628,8 +628,8 @@ protected Map<String, String> getCommonConfigs(RecordMergeMode recordMergeMode,
+     Map<String, String> configMapping = new HashMap<>();
+     configMapping.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), KEY_FIELD_NAME);
+     configMapping.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), PARTITION_FIELD_NAME);
+-    configMapping.put("hoodie.datasource.write.precombine.field", PRECOMBINE_FIELD_NAME);
+-    configMapping.put("hoodie.payload.ordering.field", PRECOMBINE_FIELD_NAME);
++    configMapping.put(HoodieTableConfig.ORDERING_FIELDS.key(), ORDERING_FIELD_NAME);
++    configMapping.put("hoodie.payload.ordering.field", ORDERING_FIELD_NAME);
+     configMapping.put(HoodieTableConfig.HOODIE_TABLE_NAME_KEY, "hoodie_test");
+     configMapping.put("hoodie.insert.shuffle.parallelism", "4");
+     configMapping.put("hoodie.upsert.shuffle.parallelism", "4");
+@@ -713,7 +713,7 @@ private static List<HoodieRecord> getExpectedHoodieRecordsWithOrderingValue(List
+     return expectedHoodieRecords.stream().map(rec -> {
+       RawTripTestPayload oldPayload = (RawTripTestPayload) rec.getData();
+       try {
+-        List<String> orderingFields = metaClient.getTableConfig().getPreCombineFields();
++        List<String> orderingFields = metaClient.getTableConfig().getOrderingFields();
+         HoodieAvroRecord avroRecord = ((HoodieAvroRecord) rec);
+         Comparable orderingValue = OrderingValues.create(orderingFields, field -> (Comparable) avroRecord.getColumnValueAsJava(avroSchema, field, new TypedProperties()));
+         RawTripTestPayload newPayload = new RawTripTestPayload(Option.ofNullable(oldPayload.getJsonData()), oldPayload.getRowKey(), oldPayload.getPartitionPath(), null, false, orderingValue);
+@@ -739,20 +739,20 @@ private void validateOutputFromFileGroupReaderWithExistingRecords(StorageConfigu
+     boolean sortOutput = !containsBaseFile;
+     List<HoodieTestDataGenerator.RecordIdentifier> actualRecordList = convertEngineRecords(
+         readRecordsFromFileGroup(storageConf, tablePath, metaClient, fileSlices, avroSchema, recordMergeMode, false, sortOutput),
+-        avroSchema, readerContext, metaClient.getTableConfig().getPreCombineFields());
++        avroSchema, readerContext, metaClient.getTableConfig().getOrderingFields());
+     // validate size is equivalent to ensure no duplicates are returned
+     assertEquals(expectedRecords.size(), actualRecordList.size());
+     assertEquals(new HashSet<>(expectedRecords), new HashSet<>(actualRecordList));
+     // validate records can be read from file group as HoodieRecords
+     actualRecordList = convertHoodieRecords(
+         readHoodieRecordsFromFileGroup(storageConf, tablePath, metaClient, fileSlices, avroSchema, recordMergeMode),
+-        avroSchema, readerContext, metaClient.getTableConfig().getPreCombineFields());
++        avroSchema, readerContext, metaClient.getTableConfig().getOrderingFields());
+     assertEquals(expectedRecords.size(), actualRecordList.size());
+     assertEquals(new HashSet<>(expectedRecords), new HashSet<>(actualRecordList));
+     // validate unmerged records
+     actualRecordList = convertEngineRecords(
+         readRecordsFromFileGroup(storageConf, tablePath, metaClient, fileSlices, avroSchema, recordMergeMode, true, false),
+-        avroSchema, readerContext, metaClient.getTableConfig().getPreCombineFields());
++        avroSchema, readerContext, metaClient.getTableConfig().getOrderingFields());
+     assertEquals(expectedUnmergedRecords.size(), actualRecordList.size());
+     assertEquals(new HashSet<>(expectedUnmergedRecords), new HashSet<>(actualRecordList));
+   }
+@@ -888,8 +888,8 @@ private List<HoodieRecord<T>> readHoodieRecordsFromFileGroup(StorageConfiguratio
+ 
+   private TypedProperties buildProperties(HoodieTableMetaClient metaClient, RecordMergeMode recordMergeMode) {
+     TypedProperties props = new TypedProperties();
+-    props.setProperty("hoodie.datasource.write.precombine.field", metaClient.getTableConfig().getPreCombineFieldsStr().orElse(""));
+-    props.setProperty("hoodie.payload.ordering.field", metaClient.getTableConfig().getPreCombineFieldsStr().orElse(""));
++    props.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), metaClient.getTableConfig().getOrderingFieldsStr().orElse(""));
++    props.setProperty("hoodie.payload.ordering.field", metaClient.getTableConfig().getOrderingFieldsStr().orElse(""));
+     props.setProperty(RECORD_MERGE_MODE.key(), recordMergeMode.name());
+     if (recordMergeMode.equals(RecordMergeMode.CUSTOM)) {
+       props.setProperty(RECORD_MERGE_STRATEGY_ID.key(), PAYLOAD_BASED_MERGE_STRATEGY_UUID);
+@@ -949,14 +949,14 @@ private List<HoodieTestDataGenerator.RecordIdentifier> convertEngineRecords(List
+   }
+ 
+   private List<HoodieTestDataGenerator.RecordIdentifier> convertHoodieRecords(List<HoodieRecord<T>> records, Schema schema, HoodieReaderContext<T> readerContext,
+-                                                                              List<String> preCombineFields) {
++                                                                              List<String> orderingFields) {
+     TypedProperties props = new TypedProperties();
+-    props.setProperty("hoodie.datasource.write.precombine.field", String.join(",", preCombineFields));
++    props.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), String.join(",", orderingFields));
+     return records.stream()
+         .map(record -> new HoodieTestDataGenerator.RecordIdentifier(
+             record.getRecordKey(),
+             removeHiveStylePartition(record.getPartitionPath()),
+-            record.getOrderingValue(schema, props, preCombineFields.toArray(new String[0])).toString(),
++            record.getOrderingValue(schema, props, orderingFields.toArray(new String[0])).toString(),
+             readerContext.getRecordContext().getValue(record.getData(), schema, RIDER_FIELD_NAME).toString()))
+         .collect(Collectors.toList());
+   }
+diff --git a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestFileGroupRecordBufferLoader.java b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestFileGroupRecordBufferLoader.java
+index 3289614165afd..c8dae1e6dfe68 100644
+--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestFileGroupRecordBufferLoader.java
++++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestFileGroupRecordBufferLoader.java
+@@ -63,7 +63,7 @@ public void testDefaultFileGroupBufferRecordLoader(String fileGroupRecordBufferT
+     HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+     when(tableConfig.getRecordMergeMode()).thenReturn(RecordMergeMode.COMMIT_TIME_ORDERING);
+     when(tableConfig.getTableVersion()).thenReturn(HoodieTableVersion.NINE);
+-    when(tableConfig.getPreCombineFieldsStr()).thenReturn(Option.empty());
++    when(tableConfig.getOrderingFieldsStr()).thenReturn(Option.empty());
+     when(tableConfig.getRecordKeyFields()).thenReturn(Option.of(new String[] {"record_key"}));
+     StorageConfiguration<?> storageConfiguration = mock(StorageConfiguration.class);
+     HoodieReaderContext<IndexedRecord> readerContext = new HoodieAvroReaderContext(storageConfiguration, tableConfig, Option.empty(), Option.empty());
+diff --git a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestKeyBasedFileGroupRecordBuffer.java b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestKeyBasedFileGroupRecordBuffer.java
+index 50eaeb454df2a..d1d0b6e92290d 100644
+--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestKeyBasedFileGroupRecordBuffer.java
++++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestKeyBasedFileGroupRecordBuffer.java
+@@ -140,7 +140,7 @@ void readWithEventTimeOrderingAndDeleteBlock() throws IOException {
+   void readWithEventTimeOrderingWithRecords() throws IOException {
+     HoodieReadStats readStats = new HoodieReadStats();
+     TypedProperties properties = new TypedProperties();
+-    properties.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "ts");
++    properties.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), "ts");
+     properties.setProperty(DELETE_KEY, "counter");
+     properties.setProperty(DELETE_MARKER, "3");
+     HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+diff --git a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestSortedKeyBasedFileGroupRecordBuffer.java b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestSortedKeyBasedFileGroupRecordBuffer.java
+index 0cbf8c2017e51..065560e8b0fdc 100644
+--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestSortedKeyBasedFileGroupRecordBuffer.java
++++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestSortedKeyBasedFileGroupRecordBuffer.java
+@@ -112,7 +112,7 @@ void readBaseFileAndLogFile() throws IOException {
+   void readWithStreamingRecordBufferLoaderAndEventTimeOrdering() throws IOException {
+     HoodieReadStats readStats = new HoodieReadStats();
+     TypedProperties properties = new TypedProperties();
+-    properties.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "ts");
++    properties.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), "ts");
+     properties.setProperty(DELETE_KEY, "counter");
+     properties.setProperty(DELETE_MARKER, "3");
+     HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+diff --git a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestStreamingKeyBasedFileGroupRecordBuffer.java b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestStreamingKeyBasedFileGroupRecordBuffer.java
+index baf1140cfee2e..7bb7d751255a8 100644
+--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestStreamingKeyBasedFileGroupRecordBuffer.java
++++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestStreamingKeyBasedFileGroupRecordBuffer.java
+@@ -70,7 +70,7 @@ class TestStreamingKeyBasedFileGroupRecordBuffer extends BaseTestFileGroupRecord
+   void readWithEventTimeOrdering() throws IOException {
+     HoodieReadStats readStats = new HoodieReadStats();
+     TypedProperties properties = new TypedProperties();
+-    properties.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "ts");
++    properties.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), "ts");
+     properties.setProperty(DELETE_KEY, "counter");
+     properties.setProperty(DELETE_MARKER, "3");
+     HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+diff --git a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieAdaptablePayloadDataGenerator.java b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieAdaptablePayloadDataGenerator.java
+index 4d397e8bfac96..5a0106c1b340c 100644
+--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieAdaptablePayloadDataGenerator.java
++++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieAdaptablePayloadDataGenerator.java
+@@ -65,10 +65,10 @@ public static Properties getKeyGenProps(Class<?> payloadClass) {
+     Properties props = new Properties();
+     props.put("hoodie.datasource.write.recordkey.field", "id");
+     props.put("hoodie.datasource.write.partitionpath.field", "pt");
+-    props.put("hoodie.datasource.write.precombine.field", orderingField);
++    props.put(HoodieTableConfig.ORDERING_FIELDS.key(), orderingField);
+     props.put(HoodieTableConfig.RECORDKEY_FIELDS.key(), "id");
+     props.put(HoodieTableConfig.PARTITION_FIELDS.key(), "pt");
+-    props.put(HoodieTableConfig.PRECOMBINE_FIELDS.key(), orderingField);
++    props.put(HoodieTableConfig.ORDERING_FIELDS.key(), orderingField);
+     return props;
+   }
+ 
+diff --git a/hudi-common/src/test/java/org/apache/hudi/common/testutils/PreCombineTestUtils.java b/hudi-common/src/test/java/org/apache/hudi/common/testutils/PreCombineTestUtils.java
+index 1591433dd1ddd..2b5b5429e998a 100644
+--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/PreCombineTestUtils.java
++++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/PreCombineTestUtils.java
+@@ -30,8 +30,8 @@
+ 
+ public class PreCombineTestUtils {
+   private static String[] preCombineConfigs = new String[] {
+-      HoodieTableConfig.PRECOMBINE_FIELDS.key(),
+-      "hoodie.datasource.write.precombine.field",
++      HoodieTableConfig.ORDERING_FIELDS.key(),
++      "hoodie.datasource.write.precombine.fields",
+       HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY
+   };
+ 
+diff --git a/hudi-common/src/test/java/org/apache/hudi/common/util/TestHoodieRecordUtils.java b/hudi-common/src/test/java/org/apache/hudi/common/util/TestHoodieRecordUtils.java
+index 96a299c9e6ab4..bf1b633c29673 100644
+--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestHoodieRecordUtils.java
++++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestHoodieRecordUtils.java
+@@ -71,7 +71,7 @@ void testGetOrderingFields() {
+ 
+     // Assert table config precombine fields are returned when props are not set with event time merge mode
+     HoodieTableConfig tableConfig = new HoodieTableConfig();
+-    tableConfig.setValue(HoodieTableConfig.PRECOMBINE_FIELDS, "tbl");
++    tableConfig.setValue(HoodieTableConfig.ORDERING_FIELDS, "tbl");
+     when(metaClient.getTableConfig()).thenReturn(tableConfig);
+     assertEquals(Collections.singletonList("tbl"), HoodieRecordUtils.getOrderingFieldNames(RecordMergeMode.EVENT_TIME_ORDERING, props, metaClient));
+ 
+diff --git a/hudi-examples/hudi-examples-k8s/src/main/java/org/apache/hudi/examples/k8s/quickstart/HudiDataStreamWriter.java b/hudi-examples/hudi-examples-k8s/src/main/java/org/apache/hudi/examples/k8s/quickstart/HudiDataStreamWriter.java
+index fc3fd5bb642fc..c71d2a9865cc7 100644
+--- a/hudi-examples/hudi-examples-k8s/src/main/java/org/apache/hudi/examples/k8s/quickstart/HudiDataStreamWriter.java
++++ b/hudi-examples/hudi-examples-k8s/src/main/java/org/apache/hudi/examples/k8s/quickstart/HudiDataStreamWriter.java
+@@ -107,7 +107,7 @@ private static Map<String, String> createHudiOptions(String basePath) {
+     options.put(FlinkOptions.PATH.key(), basePath);
+     options.put(HoodieCommonConfig.HOODIE_FS_ATOMIC_CREATION_SUPPORT.key(), "s3a");
+     options.put(FlinkOptions.TABLE_TYPE.key(), HoodieTableType.MERGE_ON_READ.name());
+-    options.put(FlinkOptions.PRECOMBINE_FIELD.key(), "ts");
++    options.put(FlinkOptions.ORDERING_FIELDS.key(), "ts");
+     options.put(FlinkOptions.RECORD_KEY_FIELD.key(), "uuid");
+     options.put(FlinkOptions.IGNORE_FAILED.key(), "true");
+     return options;
+diff --git a/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/quickstart/HoodieSparkQuickstart.java b/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/quickstart/HoodieSparkQuickstart.java
+index 2a22334989983..fd002d4177eb4 100644
+--- a/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/quickstart/HoodieSparkQuickstart.java
++++ b/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/quickstart/HoodieSparkQuickstart.java
+@@ -21,6 +21,7 @@
+ import org.apache.hudi.QuickstartUtils;
+ import org.apache.hudi.common.model.HoodieAvroPayload;
+ import org.apache.hudi.common.model.WriteOperationType;
++import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.config.HoodieWriteConfig;
+ import org.apache.hudi.examples.common.HoodieExampleDataGenerator;
+ import org.apache.hudi.examples.common.HoodieExampleSparkUtils;
+@@ -115,7 +116,7 @@ public static Dataset<Row> insertData(SparkSession spark, JavaSparkContext jsc,
+ 
+     df.write().format("hudi")
+         .options(QuickstartUtils.getQuickstartWriteConfigs())
+-        .option(HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key(), "ts")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts")
+         .option(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "uuid")
+         .option(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partitionpath")
+         .option(TBL_NAME.key(), tableName)
+@@ -136,7 +137,7 @@ public static Dataset<Row> insertOverwriteData(SparkSession spark, JavaSparkCont
+     df.write().format("hudi")
+         .options(QuickstartUtils.getQuickstartWriteConfigs())
+         .option("hoodie.datasource.write.operation", WriteOperationType.INSERT_OVERWRITE.name())
+-        .option(HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key(), "ts")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts")
+         .option(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "uuid")
+         .option(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partitionpath")
+         .option(TBL_NAME.key(), tableName)
+@@ -183,7 +184,7 @@ public static Dataset<Row> updateData(SparkSession spark, JavaSparkContext jsc,
+     Dataset<Row> df = spark.read().json(jsc.parallelize(updates, 1));
+     df.write().format("hudi")
+         .options(QuickstartUtils.getQuickstartWriteConfigs())
+-        .option(HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key(), "ts")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts")
+         .option(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "uuid")
+         .option(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partitionpath")
+         .option(TBL_NAME.key(), tableName)
+@@ -204,7 +205,7 @@ public static Dataset<Row> delete(SparkSession spark, String tablePath, String t
+ 
+     df.write().format("hudi")
+         .options(QuickstartUtils.getQuickstartWriteConfigs())
+-        .option(HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key(), "ts")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts")
+         .option(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "uuid")
+         .option(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partitionpath")
+         .option(TBL_NAME.key(), tableName)
+@@ -221,7 +222,7 @@ public static void deleteByPartition(SparkSession spark, String tablePath, Strin
+     Dataset<Row> df = spark.emptyDataFrame();
+     df.write().format("hudi")
+         .options(QuickstartUtils.getQuickstartWriteConfigs())
+-        .option(HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key(), "ts")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts")
+         .option(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "uuid")
+         .option(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partitionpath")
+         .option(TBL_NAME.key(), tableName)
+diff --git a/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/spark/HoodieSparkBootstrapExample.java b/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/spark/HoodieSparkBootstrapExample.java
+index 31f93601f9275..888817641622e 100644
+--- a/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/spark/HoodieSparkBootstrapExample.java
++++ b/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/spark/HoodieSparkBootstrapExample.java
+@@ -61,7 +61,7 @@ public static void main(String[] args) throws Exception {
+     df.write().format("hudi").option(HoodieWriteConfig.TBL_NAME.key(), tableName)
+         .option(DataSourceWriteOptions.OPERATION().key(), DataSourceWriteOptions.BOOTSTRAP_OPERATION_OPT_VAL())
+         .option(DataSourceWriteOptions.RECORDKEY_FIELD().key(), recordKey)
+-        .option(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), preCombineField)
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), preCombineField)
+         .option(HoodieTableConfig.BASE_FILE_FORMAT.key(), HoodieFileFormat.ORC.name())
+         .option(HoodieBootstrapConfig.BASE_PATH.key(), basePath)
+         .option(HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key(), NonpartitionedKeyGenerator.class.getCanonicalName())
+diff --git a/hudi-examples/hudi-examples-spark/src/main/scala/org/apache/hudi/examples/spark/HoodieDataSourceExample.scala b/hudi-examples/hudi-examples-spark/src/main/scala/org/apache/hudi/examples/spark/HoodieDataSourceExample.scala
+index a319bc1812288..0bfa4c2106222 100644
+--- a/hudi-examples/hudi-examples-spark/src/main/scala/org/apache/hudi/examples/spark/HoodieDataSourceExample.scala
++++ b/hudi-examples/hudi-examples-spark/src/main/scala/org/apache/hudi/examples/spark/HoodieDataSourceExample.scala
+@@ -22,9 +22,9 @@ import org.apache.hudi.DataSourceReadOptions.{END_COMMIT, QUERY_TYPE, QUERY_TYPE
+ import org.apache.hudi.DataSourceWriteOptions.{DELETE_OPERATION_OPT_VAL, DELETE_PARTITION_OPERATION_OPT_VAL, OPERATION, PARTITIONPATH_FIELD, PARTITIONS_TO_DELETE, PRECOMBINE_FIELD, RECORDKEY_FIELD}
+ import org.apache.hudi.QuickstartUtils.getQuickstartWriteConfigs
+ import org.apache.hudi.common.model.HoodieAvroPayload
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.config.HoodieWriteConfig.TBL_NAME
+ import org.apache.hudi.examples.common.{HoodieExampleDataGenerator, HoodieExampleSparkUtils}
+-
+ import org.apache.spark.sql.SaveMode.{Append, Overwrite}
+ import org.apache.spark.sql.SparkSession
+ 
+@@ -78,7 +78,7 @@ object HoodieDataSourceExample {
+     val df = spark.read.json(spark.sparkContext.parallelize(inserts, 1))
+     df.write.format("hudi").
+       options(getQuickstartWriteConfigs).
+-      option(PRECOMBINE_FIELD.key, "ts").
++      option(HoodieTableConfig.ORDERING_FIELDS.key, "ts").
+       option(RECORDKEY_FIELD.key, "uuid").
+       option(PARTITIONPATH_FIELD.key, "partitionpath").
+       option(TBL_NAME.key, tableName).
+@@ -120,7 +120,7 @@ object HoodieDataSourceExample {
+     val df = spark.read.json(spark.sparkContext.parallelize(updates, 1))
+     df.write.format("hudi").
+       options(getQuickstartWriteConfigs).
+-      option(PRECOMBINE_FIELD.key, "ts").
++      option(HoodieTableConfig.ORDERING_FIELDS.key, "ts").
+       option(RECORDKEY_FIELD.key, "uuid").
+       option(PARTITIONPATH_FIELD.key, "partitionpath").
+       option(TBL_NAME.key, tableName).
+@@ -139,7 +139,7 @@ object HoodieDataSourceExample {
+ 
+     df.write.format("hudi").
+       options(getQuickstartWriteConfigs).
+-      option(PRECOMBINE_FIELD.key, "ts").
++      option(HoodieTableConfig.ORDERING_FIELDS.key, "ts").
+       option(RECORDKEY_FIELD.key, "uuid").
+       option(PARTITIONPATH_FIELD.key, "partitionpath").
+       option(TBL_NAME.key, tableName).
+@@ -155,7 +155,7 @@ object HoodieDataSourceExample {
+     val df = spark.emptyDataFrame
+     df.write.format("hudi").
+       options(getQuickstartWriteConfigs).
+-      option(PRECOMBINE_FIELD.key, "ts").
++      option(HoodieTableConfig.ORDERING_FIELDS.key, "ts").
+       option(RECORDKEY_FIELD.key, "uuid").
+       option(PARTITIONPATH_FIELD.key, "partitionpath").
+       option(TBL_NAME.key, tableName).
+diff --git a/hudi-examples/hudi-examples-spark/src/main/scala/org/apache/hudi/examples/spark/HoodieMorCompactionJob.scala b/hudi-examples/hudi-examples-spark/src/main/scala/org/apache/hudi/examples/spark/HoodieMorCompactionJob.scala
+index 0fbb2a007a2c1..269480a58783f 100644
+--- a/hudi-examples/hudi-examples-spark/src/main/scala/org/apache/hudi/examples/spark/HoodieMorCompactionJob.scala
++++ b/hudi-examples/hudi-examples-spark/src/main/scala/org/apache/hudi/examples/spark/HoodieMorCompactionJob.scala
+@@ -24,6 +24,7 @@ import org.apache.hudi.QuickstartUtils.getQuickstartWriteConfigs
+ import org.apache.hudi.client.SparkRDDWriteClient
+ import org.apache.hudi.client.common.HoodieSparkEngineContext
+ import org.apache.hudi.common.model.{HoodieAvroPayload, HoodieRecordPayload, HoodieTableType}
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.util.Option
+ import org.apache.hudi.config.HoodieWriteConfig.TBL_NAME
+ import org.apache.hudi.config.{HoodieCompactionConfig, HoodieWriteConfig}
+@@ -89,7 +90,7 @@ object HoodieMorCompactionJob {
+     val df = spark.read.json(spark.sparkContext.parallelize(inserts, 1))
+     df.write.format("hudi").
+       options(getQuickstartWriteConfigs).
+-      option(PRECOMBINE_FIELD.key, "ts").
++      option(HoodieTableConfig.ORDERING_FIELDS.key, "ts").
+       option(RECORDKEY_FIELD.key, "uuid").
+       option(PARTITIONPATH_FIELD.key, "partitionpath").
+       option(TBL_NAME.key, tableName).
+@@ -105,7 +106,7 @@ object HoodieMorCompactionJob {
+     val df = spark.read.json(spark.sparkContext.parallelize(updates, 1))
+     df.write.format("hudi").
+       options(getQuickstartWriteConfigs).
+-      option(PRECOMBINE_FIELD.key, "ts").
++      option(HoodieTableConfig.ORDERING_FIELDS.key, "ts").
+       option(RECORDKEY_FIELD.key, "uuid").
+       option(PARTITIONPATH_FIELD.key, "partitionpath").
+       option(TBL_NAME.key, tableName).
+diff --git a/hudi-examples/hudi-examples-spark/src/test/python/HoodiePySparkQuickstart.py b/hudi-examples/hudi-examples-spark/src/test/python/HoodiePySparkQuickstart.py
+index 9505e3217850c..d3b7be749e6be 100644
+--- a/hudi-examples/hudi-examples-spark/src/test/python/HoodiePySparkQuickstart.py
++++ b/hudi-examples/hudi-examples-spark/src/test/python/HoodiePySparkQuickstart.py
+@@ -35,7 +35,7 @@ def __init__(self, spark: sql.SparkSession, tableName: str, basePath: str):
+             'hoodie.datasource.write.recordkey.field': 'uuid',
+             'hoodie.datasource.write.partitionpath.field': 'partitionpath',
+             'hoodie.datasource.write.operation': 'upsert',
+-            'hoodie.datasource.write.precombine.field': 'ts',
++            'hoodie.datasource.write.precombine.fields': 'ts',
+             'hoodie.upsert.shuffle.parallelism': 2,
+             'hoodie.insert.shuffle.parallelism': 2
+         }
+@@ -162,7 +162,7 @@ def softDeletes(self):
+         'hoodie.datasource.write.recordkey.field': 'uuid',
+         'hoodie.datasource.write.partitionpath.field': 'partitionpath',
+         'hoodie.datasource.write.operation': 'upsert',
+-        'hoodie.datasource.write.precombine.field': 'ts',
++        'hoodie.datasource.write.precombine.fields': 'ts',
+         'hoodie.upsert.shuffle.parallelism': 2, 
+         'hoodie.insert.shuffle.parallelism': 2
+         }
+@@ -196,7 +196,7 @@ def hardDeletes(self):
+             'hoodie.datasource.write.recordkey.field': 'uuid',
+             'hoodie.datasource.write.partitionpath.field': 'partitionpath',
+             'hoodie.datasource.write.operation': 'delete',
+-            'hoodie.datasource.write.precombine.field': 'ts',
++            'hoodie.datasource.write.precombine.fields': 'ts',
+             'hoodie.upsert.shuffle.parallelism': 2, 
+             'hoodie.insert.shuffle.parallelism': 2
+         }
+@@ -223,7 +223,7 @@ def insertOverwrite(self):
+             'hoodie.datasource.write.recordkey.field': 'uuid',
+             'hoodie.datasource.write.partitionpath.field': 'partitionpath',
+             'hoodie.datasource.write.operation': 'insert_overwrite',
+-            'hoodie.datasource.write.precombine.field': 'ts',
++            'hoodie.datasource.write.precombine.fields': 'ts',
+             'hoodie.upsert.shuffle.parallelism': 2,
+             'hoodie.insert.shuffle.parallelism': 2
+         }
+diff --git a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+index a2a43566231cb..fa060d71fb78e 100644
+--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
++++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+@@ -110,14 +110,15 @@ private FlinkOptions() {
+       .withDescription("Type of table to write. COPY_ON_WRITE (or) MERGE_ON_READ");
+ 
+   public static final String NO_PRE_COMBINE = "no_precombine";
+-  public static final ConfigOption<String> PRECOMBINE_FIELD = ConfigOptions
+-      .key("precombine.field")
++  public static final ConfigOption<String> ORDERING_FIELDS = ConfigOptions
++      .key("ordering.fields")
+       .stringType()
+       .defaultValue("ts")
+-      .withFallbackKeys("write.precombine.field", HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key())
++      .withFallbackKeys("precombine.field", "write.precombine.field", HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key())
+       .withDescription("Comma separated list of fields used in preCombining before actual write. When two records have the same\n"
+           + "key value, we will pick the one with the largest value for the precombine field,\n"
+-          + "determined by Object.compareTo(..). For multiple fields if first key comparison is same, second key comparison is made and so on");
++          + "determined by Object.compareTo(..). For multiple fields if first key comparison is same, second key comparison is made and so on.\n"
++          + "Config precombine.field is now deprecated, please use precombine.fields instead.");
+ 
+   @AdvancedConfig
+   public static final ConfigOption<String> PAYLOAD_CLASS_NAME = ConfigOptions
+diff --git a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+index aa453fe54cdb0..375c3de809a04 100644
+--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
++++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+@@ -152,12 +152,12 @@ public static boolean isDefaultHoodieRecordPayloadClazz(Configuration conf) {
+   }
+ 
+   /**
+-   * Returns the preCombine field
++   * Returns the preCombine fields as comma separated string
+    * or null if the value is set as {@link FlinkOptions#NO_PRE_COMBINE}.
+    */
+-  public static String getPreCombineField(Configuration conf) {
+-    final String preCombineField = conf.get(FlinkOptions.PRECOMBINE_FIELD);
+-    return preCombineField.equals(FlinkOptions.NO_PRE_COMBINE) ? null : preCombineField;
++  public static String getOrderingFieldsStr(Configuration conf) {
++    final String orderingFields = conf.get(FlinkOptions.ORDERING_FIELDS);
++    return orderingFields.equals(FlinkOptions.NO_PRE_COMBINE) ? null : orderingFields;
+   }
+ 
+   /**
+diff --git a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/HoodieFlinkCompactor.java b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/HoodieFlinkCompactor.java
+index b686017996547..669195e46a339 100644
+--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/HoodieFlinkCompactor.java
++++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/HoodieFlinkCompactor.java
+@@ -175,7 +175,7 @@ public AsyncCompactionService(FlinkCompactionConfig cfg, Configuration conf) thr
+       // set table schema
+       CompactionUtil.setAvroSchema(conf, metaClient);
+ 
+-      CompactionUtil.setPreCombineField(conf, metaClient);
++      CompactionUtil.setOrderingFields(conf, metaClient);
+ 
+       // infer changelog mode
+       CompactionUtil.inferChangelogMode(conf, metaClient);
+diff --git a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/streamer/FlinkStreamerConfig.java b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/streamer/FlinkStreamerConfig.java
+index fc7444e2c2415..278daacb081e3 100644
+--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/streamer/FlinkStreamerConfig.java
++++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/streamer/FlinkStreamerConfig.java
+@@ -114,9 +114,10 @@ public class FlinkStreamerConfig extends Configuration {
+       + "By default `SIMPLE`.")
+   public String keygenType = KeyGeneratorType.SIMPLE.name();
+ 
+-  @Parameter(names = {"--source-ordering-field"}, description = "Field within source record to decide how"
+-      + " to break ties between records with same key in input data. Default: 'ts' holding unix timestamp of record.")
+-  public String sourceOrderingField = "ts";
++  @Parameter(names = {"--source-ordering-fields", "--source-ordering-field"}, description = "Field within source record to decide how"
++      + " to break ties between records with same key in input data. Default: 'ts' holding unix timestamp of record. "
++      + "Option --source-ordering-field is deprecated, please use --source-ordering-fields instead.")
++  public String sourceOrderingFields = "ts";
+ 
+   @Parameter(names = {"--write-table-version"}, description = "Version of table written")
+   public Integer writeTableVersion = HoodieTableVersion.current().versionCode();
+@@ -425,7 +426,7 @@ public static org.apache.flink.configuration.Configuration toFlinkConfig(FlinkSt
+     conf.set(FlinkOptions.TABLE_TYPE, config.tableType.toUpperCase());
+     conf.set(FlinkOptions.INSERT_CLUSTER, config.insertCluster);
+     conf.set(FlinkOptions.OPERATION, config.operation.value());
+-    conf.set(FlinkOptions.PRECOMBINE_FIELD, config.sourceOrderingField);
++    conf.set(FlinkOptions.ORDERING_FIELDS, config.sourceOrderingFields);
+     conf.set(FlinkOptions.WRITE_TABLE_VERSION, config.writeTableVersion);
+     conf.set(FlinkOptions.PAYLOAD_CLASS_NAME, config.payloadClassName);
+     conf.set(FlinkOptions.RECORD_MERGER_IMPLS, config.recordMergerImpls);
+diff --git a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
+index cd10f8edb29a8..726b6fef5ef8a 100644
+--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
++++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
+@@ -117,9 +117,9 @@ private void setupTableOptions(String basePath, Configuration conf) {
+               && !conf.contains(FlinkOptions.RECORD_KEY_FIELD)) {
+             conf.set(FlinkOptions.RECORD_KEY_FIELD, tableConfig.getString(HoodieTableConfig.RECORDKEY_FIELDS));
+           }
+-          if (tableConfig.contains(HoodieTableConfig.PRECOMBINE_FIELDS)
+-              && !conf.contains(FlinkOptions.PRECOMBINE_FIELD)) {
+-            conf.set(FlinkOptions.PRECOMBINE_FIELD, tableConfig.getString(HoodieTableConfig.PRECOMBINE_FIELDS));
++          if (tableConfig.contains(HoodieTableConfig.ORDERING_FIELDS)
++              && !conf.contains(FlinkOptions.ORDERING_FIELDS)) {
++            conf.set(FlinkOptions.ORDERING_FIELDS, tableConfig.getString(HoodieTableConfig.ORDERING_FIELDS));
+           }
+           if (tableConfig.contains(HoodieTableConfig.HIVE_STYLE_PARTITIONING_ENABLE)
+               && !conf.contains(FlinkOptions.HIVE_STYLE_PARTITIONING)) {
+diff --git a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/TableOptionProperties.java b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/TableOptionProperties.java
+index de6b6bc4111f4..c7781171b9992 100644
+--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/TableOptionProperties.java
++++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/TableOptionProperties.java
+@@ -90,13 +90,13 @@ public class TableOptionProperties {
+ 
+     KEY_MAPPING.put("type", FlinkOptions.TABLE_TYPE.key());
+     KEY_MAPPING.put("primaryKey", FlinkOptions.RECORD_KEY_FIELD.key());
+-    KEY_MAPPING.put("preCombineField", FlinkOptions.PRECOMBINE_FIELD.key());
++    KEY_MAPPING.put("preCombineField", FlinkOptions.ORDERING_FIELDS.key());
+     KEY_MAPPING.put("payloadClass", FlinkOptions.PAYLOAD_CLASS_NAME.key());
+     KEY_MAPPING.put(SPARK_SOURCE_PROVIDER, CONNECTOR.key());
+     KEY_MAPPING.put(FlinkOptions.KEYGEN_CLASS_NAME.key(), FlinkOptions.KEYGEN_CLASS_NAME.key());
+     KEY_MAPPING.put(FlinkOptions.TABLE_TYPE.key(), "type");
+     KEY_MAPPING.put(FlinkOptions.RECORD_KEY_FIELD.key(), "primaryKey");
+-    KEY_MAPPING.put(FlinkOptions.PRECOMBINE_FIELD.key(), "preCombineField");
++    KEY_MAPPING.put(FlinkOptions.ORDERING_FIELDS.key(), "preCombineField");
+     KEY_MAPPING.put(FlinkOptions.PAYLOAD_CLASS_NAME.key(), "payloadClass");
+   }
+ 
+diff --git a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/CompactionUtil.java b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/CompactionUtil.java
+index 42df2ced0cdd4..4c482835d2035 100644
+--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/CompactionUtil.java
++++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/CompactionUtil.java
+@@ -100,10 +100,10 @@ public static void setAvroSchema(HoodieWriteConfig writeConfig, HoodieTableMetaC
+    *
+    * @param conf The configuration
+    */
+-  public static void setPreCombineField(Configuration conf, HoodieTableMetaClient metaClient) {
+-    String preCombineField = metaClient.getTableConfig().getPreCombineFieldsStr().orElse(null);
+-    if (preCombineField != null) {
+-      conf.set(FlinkOptions.PRECOMBINE_FIELD, preCombineField);
++  public static void setOrderingFields(Configuration conf, HoodieTableMetaClient metaClient) {
++    String orderingFields = metaClient.getTableConfig().getOrderingFieldsStr().orElse(null);
++    if (orderingFields != null) {
++      conf.set(FlinkOptions.ORDERING_FIELDS, orderingFields);
+     }
+   }
+ 
+diff --git a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+index 0369d0e168032..355bb19011319 100644
+--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
++++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+@@ -175,8 +175,8 @@ public static DFSPropertiesConfiguration readConfig(org.apache.hadoop.conf.Confi
+   public static HoodiePayloadConfig getPayloadConfig(Configuration conf) {
+     return HoodiePayloadConfig.newBuilder()
+         .withPayloadClass(conf.get(FlinkOptions.PAYLOAD_CLASS_NAME))
+-        .withPayloadOrderingFields(conf.get(FlinkOptions.PRECOMBINE_FIELD))
+-        .withPayloadEventTimeField(conf.get(FlinkOptions.PRECOMBINE_FIELD))
++        .withPayloadOrderingFields(conf.get(FlinkOptions.ORDERING_FIELDS))
++        .withPayloadEventTimeField(conf.get(FlinkOptions.ORDERING_FIELDS))
+         .build();
+   }
+ 
+@@ -296,7 +296,7 @@ public static HoodieTableMetaClient initTableIfNotExists(
+           .setPayloadClassName(getPayloadClass(conf))
+           .setDatabaseName(conf.get(FlinkOptions.DATABASE_NAME))
+           .setRecordKeyFields(conf.getString(FlinkOptions.RECORD_KEY_FIELD.key(), null))
+-          .setPreCombineFields(OptionsResolver.getPreCombineField(conf))
++          .setOrderingFields(OptionsResolver.getOrderingFieldsStr(conf))
+           .setArchiveLogFolder(TIMELINE_HISTORY_PATH.defaultValue())
+           .setPartitionFields(conf.getString(FlinkOptions.PARTITION_PATH_FIELD.key(), null))
+           .setKeyGeneratorClassProp(
+@@ -404,7 +404,7 @@ public static void addFlinkCheckpointIdIntoMetaData(
+    */
+   public static Triple<RecordMergeMode, String, String> inferMergingBehavior(Configuration conf) {
+     return HoodieTableConfig.inferCorrectMergingBehavior(
+-        getMergeMode(conf), getPayloadClass(conf), getMergeStrategyId(conf), OptionsResolver.getPreCombineField(conf), HoodieTableVersion.EIGHT);
++        getMergeMode(conf), getPayloadClass(conf), getMergeStrategyId(conf), OptionsResolver.getOrderingFieldsStr(conf), HoodieTableVersion.EIGHT);
+   }
+ 
+   /**
+@@ -657,17 +657,17 @@ public static boolean isWriteCommit(HoodieTableType tableType, HoodieInstant ins
+    * Validate pre_combine key.
+    */
+   public static void checkPreCombineKey(Configuration conf, List<String> fields) {
+-    String preCombineField = conf.get(FlinkOptions.PRECOMBINE_FIELD);
+-    if (!fields.contains(preCombineField)) {
++    String orderingFields = conf.get(FlinkOptions.ORDERING_FIELDS);
++    if (!fields.contains(orderingFields)) {
+       if (OptionsResolver.isDefaultHoodieRecordPayloadClazz(conf)) {
+-        throw new HoodieValidationException("Option '" + FlinkOptions.PRECOMBINE_FIELD.key()
++        throw new HoodieValidationException("Option '" + FlinkOptions.ORDERING_FIELDS.key()
+                 + "' is required for payload class: " + DefaultHoodieRecordPayload.class.getName());
+       }
+-      if (preCombineField.equals(FlinkOptions.PRECOMBINE_FIELD.defaultValue())) {
+-        conf.set(FlinkOptions.PRECOMBINE_FIELD, FlinkOptions.NO_PRE_COMBINE);
+-      } else if (!preCombineField.equals(FlinkOptions.NO_PRE_COMBINE)) {
+-        throw new HoodieValidationException("Field " + preCombineField + " does not exist in the table schema."
+-                + "Please check '" + FlinkOptions.PRECOMBINE_FIELD.key() + "' option.");
++      if (orderingFields.equals(FlinkOptions.ORDERING_FIELDS.defaultValue())) {
++        conf.set(FlinkOptions.ORDERING_FIELDS, FlinkOptions.NO_PRE_COMBINE);
++      } else if (!orderingFields.equals(FlinkOptions.NO_PRE_COMBINE)) {
++        throw new HoodieValidationException("Field " + orderingFields + " does not exist in the table schema."
++                + "Please check '" + FlinkOptions.ORDERING_FIELDS.key() + "' option.");
+       }
+     }
+   }
+diff --git a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnRead.java b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnRead.java
+index fc7dd4a3d2da9..6deef95901700 100644
+--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnRead.java
++++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnRead.java
+@@ -99,7 +99,7 @@ public void testEventTimeAvroPayloadMergeRead() throws Exception {
+     conf.set(FlinkOptions.CHANGELOG_ENABLED, false);
+     conf.set(FlinkOptions.COMPACTION_DELTA_COMMITS, 2);
+     conf.set(FlinkOptions.PRE_COMBINE, true);
+-    conf.set(FlinkOptions.PRECOMBINE_FIELD, "ts");
++    conf.set(FlinkOptions.ORDERING_FIELDS, "ts");
+     conf.set(FlinkOptions.PAYLOAD_CLASS_NAME, EventTimeAvroPayload.class.getName());
+     HashMap<String, String> mergedExpected = new HashMap<>(EXPECTED1);
+     mergedExpected.put("par1", "[id1,par1,id1,Danny,22,4,par1, id2,par1,id2,Stephen,33,2,par1]");
+diff --git a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
+index 5462ce3892ef8..0a317c5f40b66 100644
+--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
++++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
+@@ -689,7 +689,7 @@ void testWriteAndReadWithProctimeSequenceWithTsColumnExisting(HoodieTableType ta
+         .option(FlinkOptions.PATH, tempFile.getAbsolutePath())
+         .option(FlinkOptions.TABLE_TYPE, tableType)
+         .option(FlinkOptions.HIVE_STYLE_PARTITIONING, hiveStylePartitioning)
+-        .option(FlinkOptions.PRECOMBINE_FIELD, FlinkOptions.NO_PRE_COMBINE)
++        .option(FlinkOptions.ORDERING_FIELDS, FlinkOptions.NO_PRE_COMBINE)
+         .end();
+     tableEnv.executeSql(hoodieTableDDL);
+ 
+@@ -1541,7 +1541,7 @@ void testWriteReadDecimals(String operation) {
+         .field("f3 decimal(38, 18)")
+         .option(FlinkOptions.PATH, tempFile.getAbsolutePath())
+         .option(FlinkOptions.OPERATION, operation)
+-        .option(FlinkOptions.PRECOMBINE_FIELD, "f1")
++        .option(FlinkOptions.ORDERING_FIELDS, "f1")
+         .pkField("f0")
+         .noPartition()
+         .end();
+@@ -2098,7 +2098,7 @@ void testBuiltinFunctionWithHMSCatalog() {
+         .pkField("f_int")
+         .partitionField("f_par")
+         .option(FlinkOptions.RECORD_KEY_FIELD, "f_int")
+-        .option(FlinkOptions.PRECOMBINE_FIELD, "f_date")
++        .option(FlinkOptions.ORDERING_FIELDS, "f_date")
+         .end();
+     tableEnv.executeSql(hoodieTableDDL);
+ 
+@@ -2126,7 +2126,7 @@ void testWriteReadWithComputedColumns() {
+         .field("f2 bigint")
+         .field("f3 as f0 + f2")
+         .option(FlinkOptions.PATH, tempFile.getAbsolutePath())
+-        .option(FlinkOptions.PRECOMBINE_FIELD, "f1")
++        .option(FlinkOptions.ORDERING_FIELDS, "f1")
+         .pkField("f0")
+         .noPartition()
+         .end();
+@@ -2154,7 +2154,7 @@ void testWriteReadWithComputedColumnsInTheMiddle() {
+         .field("f2 as f0 + f1")
+         .field("f3 varchar(10)")
+         .option(FlinkOptions.PATH, tempFile.getAbsolutePath())
+-        .option(FlinkOptions.PRECOMBINE_FIELD, "f1")
++        .option(FlinkOptions.ORDERING_FIELDS, "f1")
+         .pkField("f0")
+         .noPartition()
+         .end();
+@@ -2184,7 +2184,7 @@ void testWriteReadWithLocalTimestamp(HoodieTableType tableType) {
+         .field("f2 TIMESTAMP_LTZ(3)")
+         .field("f4 TIMESTAMP_LTZ(6)")
+         .option(FlinkOptions.PATH, tempFile.getAbsolutePath())
+-        .option(FlinkOptions.PRECOMBINE_FIELD, "f1")
++        .option(FlinkOptions.ORDERING_FIELDS, "f1")
+         .option(FlinkOptions.TABLE_TYPE, tableType)
+         .pkField("f0")
+         .noPartition()
+@@ -2215,7 +2215,7 @@ void testWriteReadWithTimestampWithoutTZ(HoodieTableType tableType, boolean read
+         .field("f2 TIMESTAMP(3)")
+         .field("f3 TIMESTAMP(6)")
+         .option(FlinkOptions.PATH, tempFile.getAbsolutePath())
+-        .option(FlinkOptions.PRECOMBINE_FIELD, "f1")
++        .option(FlinkOptions.ORDERING_FIELDS, "f1")
+         .option(FlinkOptions.TABLE_TYPE, tableType)
+         .option(FlinkOptions.WRITE_UTC_TIMEZONE, false)
+         .option(FlinkOptions.READ_UTC_TIMEZONE, readUtcTimezone)
+diff --git a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieFileGroupReaderOnFlink.java b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieFileGroupReaderOnFlink.java
+index dc66a0e6a74c0..5c169f62cb9f6 100644
+--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieFileGroupReaderOnFlink.java
++++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieFileGroupReaderOnFlink.java
+@@ -33,6 +33,7 @@
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+ import org.apache.hudi.common.testutils.HoodieTestUtils;
+ import org.apache.hudi.common.util.CollectionUtils;
++import org.apache.hudi.common.util.ConfigUtils;
+ import org.apache.hudi.common.util.Option;
+ import org.apache.hudi.common.util.OrderingValues;
+ import org.apache.hudi.common.util.collection.ClosableIterator;
+@@ -140,7 +141,7 @@ protected void readWithFileGroupReader(
+   @Override
+   public void commitToTable(List<HoodieRecord> recordList, String operation, boolean firstCommit, Map<String, String> writeConfigs, String schemaStr) {
+     writeConfigs.forEach((key, value) -> conf.setString(key, value));
+-    conf.set(FlinkOptions.PRECOMBINE_FIELD, writeConfigs.get("hoodie.datasource.write.precombine.field"));
++    conf.set(FlinkOptions.ORDERING_FIELDS, ConfigUtils.getOrderingFieldsStrDuringWrite(writeConfigs));
+     conf.set(FlinkOptions.OPERATION, operation);
+     Schema localSchema = getRecordAvroSchema(schemaStr);
+     conf.set(FlinkOptions.SOURCE_AVRO_SCHEMA, localSchema.toString());
+diff --git a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
+index 2a4eb3d61d6a7..a4a69706e4fe2 100644
+--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
++++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
+@@ -112,7 +112,7 @@ void testRequiredOptions() {
+     assertDoesNotThrow(() -> new HoodieTableFactory().createDynamicTableSink(sourceContext11));
+     //miss the pre combine key will be ok
+     HoodieTableSink tableSink11 = (HoodieTableSink) new HoodieTableFactory().createDynamicTableSink(sourceContext11);
+-    assertThat(tableSink11.getConf().get(FlinkOptions.PRECOMBINE_FIELD), is(FlinkOptions.NO_PRE_COMBINE));
++    assertThat(tableSink11.getConf().get(FlinkOptions.ORDERING_FIELDS), is(FlinkOptions.NO_PRE_COMBINE));
+     this.conf.set(FlinkOptions.OPERATION, FlinkOptions.OPERATION.defaultValue());
+ 
+     // a non-exists precombine key will throw exception
+@@ -121,12 +121,12 @@ void testRequiredOptions() {
+         .field("f1", DataTypes.VARCHAR(20))
+         .field("f2", DataTypes.TIMESTAMP(3))
+         .build();
+-    this.conf.set(FlinkOptions.PRECOMBINE_FIELD, "non_exist_field");
++    this.conf.set(FlinkOptions.ORDERING_FIELDS, "non_exist_field");
+     final MockContext sourceContext2 = MockContext.getInstance(this.conf, schema2, "f2");
+     // createDynamicTableSource doesn't call sanity check, will not throw exception
+     assertDoesNotThrow(() -> new HoodieTableFactory().createDynamicTableSource(sourceContext2));
+     assertThrows(HoodieValidationException.class, () -> new HoodieTableFactory().createDynamicTableSink(sourceContext2));
+-    this.conf.set(FlinkOptions.PRECOMBINE_FIELD, FlinkOptions.PRECOMBINE_FIELD.defaultValue());
++    this.conf.set(FlinkOptions.ORDERING_FIELDS, FlinkOptions.ORDERING_FIELDS.defaultValue());
+ 
+     // given the pk but miss the pre combine key will be ok
+     ResolvedSchema schema3 = SchemaBuilder.instance()
+@@ -139,7 +139,7 @@ void testRequiredOptions() {
+     HoodieTableSource tableSource = (HoodieTableSource) new HoodieTableFactory().createDynamicTableSource(sourceContext3);
+     HoodieTableSink tableSink = (HoodieTableSink) new HoodieTableFactory().createDynamicTableSink(sourceContext3);
+     // the precombine field is overwritten
+-    assertThat(tableSink.getConf().get(FlinkOptions.PRECOMBINE_FIELD), is(FlinkOptions.NO_PRE_COMBINE));
++    assertThat(tableSink.getConf().get(FlinkOptions.ORDERING_FIELDS), is(FlinkOptions.NO_PRE_COMBINE));
+     // precombine field not specified, use the default payload clazz
+     assertThat(tableSource.getConf().get(FlinkOptions.PAYLOAD_CLASS_NAME), is(FlinkOptions.PAYLOAD_CLASS_NAME.defaultValue()));
+     assertThat(tableSink.getConf().get(FlinkOptions.PAYLOAD_CLASS_NAME), is(FlinkOptions.PAYLOAD_CLASS_NAME.defaultValue()));
+@@ -147,7 +147,7 @@ void testRequiredOptions() {
+     // append mode given the pk but miss the pre combine key will be ok
+     this.conf.set(FlinkOptions.OPERATION, "insert");
+     HoodieTableSink tableSink3 = (HoodieTableSink) new HoodieTableFactory().createDynamicTableSink(sourceContext3);
+-    assertThat(tableSink3.getConf().get(FlinkOptions.PRECOMBINE_FIELD), is(FlinkOptions.NO_PRE_COMBINE));
++    assertThat(tableSink3.getConf().get(FlinkOptions.ORDERING_FIELDS), is(FlinkOptions.NO_PRE_COMBINE));
+     this.conf.set(FlinkOptions.OPERATION, FlinkOptions.OPERATION.defaultValue());
+ 
+     this.conf.set(FlinkOptions.PAYLOAD_CLASS_NAME, DefaultHoodieRecordPayload.class.getName());
+@@ -185,7 +185,7 @@ void testRequiredOptions() {
+         .field("ts", DataTypes.TIMESTAMP(3))
+         .primaryKey("f0")
+         .build();
+-    this.conf.set(FlinkOptions.PRECOMBINE_FIELD, FlinkOptions.NO_PRE_COMBINE);
++    this.conf.set(FlinkOptions.ORDERING_FIELDS, FlinkOptions.NO_PRE_COMBINE);
+     final MockContext sourceContext6 = MockContext.getInstance(this.conf, schema5, "f2");
+ 
+     assertDoesNotThrow(() -> new HoodieTableFactory().createDynamicTableSource(sourceContext6));
+@@ -266,7 +266,7 @@ void testSupplementTableConfig() throws Exception {
+     tableConf.set(FlinkOptions.PATH, tablePath);
+     tableConf.set(FlinkOptions.TABLE_NAME, "t2");
+     tableConf.set(FlinkOptions.RECORD_KEY_FIELD, "f0,f1");
+-    tableConf.set(FlinkOptions.PRECOMBINE_FIELD, "f2");
++    tableConf.set(FlinkOptions.ORDERING_FIELDS, "f2");
+     tableConf.set(FlinkOptions.TABLE_TYPE, FlinkOptions.TABLE_TYPE_MERGE_ON_READ);
+     tableConf.set(FlinkOptions.PAYLOAD_CLASS_NAME, "my_payload");
+     tableConf.set(FlinkOptions.PARTITION_PATH_FIELD, "partition");
+@@ -292,9 +292,9 @@ void testSupplementTableConfig() throws Exception {
+     assertThat("pk not provided, fallback to table config",
+         sink1.getConf().get(FlinkOptions.RECORD_KEY_FIELD), is("f0,f1"));
+     assertThat("pre-combine key not provided, fallback to table config",
+-        source1.getConf().get(FlinkOptions.PRECOMBINE_FIELD), is("f2"));
++        source1.getConf().get(FlinkOptions.ORDERING_FIELDS), is("f2"));
+     assertThat("pre-combine key not provided, fallback to table config",
+-        sink1.getConf().get(FlinkOptions.PRECOMBINE_FIELD), is("f2"));
++        sink1.getConf().get(FlinkOptions.ORDERING_FIELDS), is("f2"));
+     assertThat("table type not provided, fallback to table config",
+         source1.getConf().get(FlinkOptions.TABLE_TYPE), is(FlinkOptions.TABLE_TYPE_MERGE_ON_READ));
+     assertThat("table type not provided, fallback to table config",
+@@ -307,7 +307,7 @@ void testSupplementTableConfig() throws Exception {
+     // write config always has higher priority
+     // set up a different primary key and pre_combine key with table config options
+     writeConf.set(FlinkOptions.RECORD_KEY_FIELD, "f0");
+-    writeConf.set(FlinkOptions.PRECOMBINE_FIELD, "f1");
++    writeConf.set(FlinkOptions.ORDERING_FIELDS, "f1");
+ 
+     final MockContext sourceContext2 = MockContext.getInstance(writeConf, schema1, "f2");
+     HoodieTableSource source2 = (HoodieTableSource) new HoodieTableFactory().createDynamicTableSource(sourceContext2);
+@@ -317,12 +317,12 @@ void testSupplementTableConfig() throws Exception {
+     assertThat("choose pk from write config",
+         sink2.getConf().get(FlinkOptions.RECORD_KEY_FIELD), is("f0"));
+     assertThat("choose preCombine key from write config",
+-        source2.getConf().get(FlinkOptions.PRECOMBINE_FIELD), is("f1"));
++        source2.getConf().get(FlinkOptions.ORDERING_FIELDS), is("f1"));
+     assertThat("choose preCombine pk from write config",
+-        sink2.getConf().get(FlinkOptions.PRECOMBINE_FIELD), is("f1"));
++        sink2.getConf().get(FlinkOptions.ORDERING_FIELDS), is("f1"));
+ 
+     writeConf.removeConfig(FlinkOptions.RECORD_KEY_FIELD);
+-    writeConf.removeConfig(FlinkOptions.PRECOMBINE_FIELD);
++    writeConf.removeConfig(FlinkOptions.ORDERING_FIELDS);
+ 
+     // pk defined in table config but missing in schema will throw
+     ResolvedSchema schema2 = SchemaBuilder.instance()
+diff --git a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableSource.java b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableSource.java
+index ae6320606b2b7..f12fc0b832f75 100644
+--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableSource.java
++++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableSource.java
+@@ -270,7 +270,7 @@ void testBucketPruningSpecialKeyDataType(boolean logicalTimestamp) throws Except
+     final String f1 = "f_timestamp";
+     conf1.set(FlinkOptions.INDEX_TYPE, "BUCKET");
+     conf1.set(FlinkOptions.RECORD_KEY_FIELD, f1);
+-    conf1.set(FlinkOptions.PRECOMBINE_FIELD, f1);
++    conf1.set(FlinkOptions.ORDERING_FIELDS, f1);
+     conf1.removeConfig(FlinkOptions.PARTITION_PATH_FIELD);
+     conf1.setString(KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key(), logicalTimestamp + "");
+     int numBuckets = (int)FlinkOptions.BUCKET_INDEX_NUM_BUCKETS.defaultValue();
+@@ -292,7 +292,7 @@ void testBucketPruningSpecialKeyDataType(boolean logicalTimestamp) throws Except
+     String tablePath2 = new Path(tempFile.getAbsolutePath(), "tbl2").toString();
+     conf2.set(FlinkOptions.PATH, tablePath2);
+     conf2.set(FlinkOptions.RECORD_KEY_FIELD, f2);
+-    conf2.set(FlinkOptions.PRECOMBINE_FIELD, f2);
++    conf2.set(FlinkOptions.ORDERING_FIELDS, f2);
+     TestData.writeDataAsBatch(TestData.DATA_SET_INSERT_HOODIE_KEY_SPECIAL_DATA_TYPE, conf2);
+     HoodieTableSource tableSource2 = createHoodieTableSource(conf2);
+     tableSource2.applyFilters(Collections.singletonList(
+@@ -308,7 +308,7 @@ void testBucketPruningSpecialKeyDataType(boolean logicalTimestamp) throws Except
+     String tablePath3 = new Path(tempFile.getAbsolutePath(), "tbl3").toString();
+     conf3.set(FlinkOptions.PATH, tablePath3);
+     conf3.set(FlinkOptions.RECORD_KEY_FIELD, f3);
+-    conf3.set(FlinkOptions.PRECOMBINE_FIELD, f3);
++    conf3.set(FlinkOptions.ORDERING_FIELDS, f3);
+     TestData.writeDataAsBatch(TestData.DATA_SET_INSERT_HOODIE_KEY_SPECIAL_DATA_TYPE, conf3);
+     HoodieTableSource tableSource3 = createHoodieTableSource(conf3);
+     tableSource3.applyFilters(Collections.singletonList(
+diff --git a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieCatalog.java b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieCatalog.java
+index 3d202be87c4d0..272b54b56f15c 100644
+--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieCatalog.java
++++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieCatalog.java
+@@ -383,7 +383,7 @@ void testCreateTableWithoutPreCombineKey() {
+             + "org.apache.hudi.common.model.DefaultHoodieRecordPayload");
+ 
+     Map<String, String> options2 = getDefaultCatalogOption();
+-    options2.put(FlinkOptions.PRECOMBINE_FIELD.key(), "not_exists");
++    options2.put(FlinkOptions.ORDERING_FIELDS.key(), "not_exists");
+     catalog = new HoodieCatalog("hudi", Configuration.fromMap(options2));
+     catalog.open();
+     ObjectPath tablePath2 = new ObjectPath(TEST_DEFAULT_DATABASE, "tb2");
+diff --git a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieHiveCatalog.java b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieHiveCatalog.java
+index a25cf3a84bb14..98ded34cb2b72 100644
+--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieHiveCatalog.java
++++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieHiveCatalog.java
+@@ -76,7 +76,7 @@
+ import java.util.stream.Collectors;
+ 
+ import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
+-import static org.apache.hudi.configuration.FlinkOptions.PRECOMBINE_FIELD;
++import static org.apache.hudi.configuration.FlinkOptions.ORDERING_FIELDS;
+ import static org.apache.hudi.keygen.constant.KeyGeneratorOptions.RECORDKEY_FIELD_NAME;
+ import static org.apache.hudi.table.catalog.HoodieCatalogTestUtils.createStorageConf;
+ import static org.hamcrest.CoreMatchers.containsString;
+@@ -208,7 +208,7 @@ public void testCreateAndGetHoodieTable(HoodieTableType tableType) throws Except
+     assertEquals("hudi", table1.getOptions().get(CONNECTOR.key()));
+     assertEquals(tableType.toString(), table1.getOptions().get(FlinkOptions.TABLE_TYPE.key()));
+     assertEquals("uuid", table1.getOptions().get(FlinkOptions.RECORD_KEY_FIELD.key()));
+-    assertNull(table1.getOptions().get(PRECOMBINE_FIELD.key()), "preCombine key is not declared");
++    assertNull(table1.getOptions().get(ORDERING_FIELDS.key()), "preCombine key is not declared");
+     String tableSchema = table1.getUnresolvedSchema().getColumns().stream()
+         .map(Schema.UnresolvedColumn::toString)
+         .collect(Collectors.joining(","));
+@@ -331,12 +331,12 @@ void testCreateTableWithoutPreCombineKey() throws TableAlreadyExistException, Da
+     options.put(FactoryUtil.CONNECTOR.key(), "hudi");
+ 
+     TypedProperties props = createTableAndReturnTableProperties(options, new ObjectPath(db, "tmptb1"));
+-    assertFalse(props.containsKey("hoodie.table.precombine.field"));
++    assertFalse(props.containsKey(HoodieTableConfig.ORDERING_FIELDS.key()));
+ 
+-    options.put(PRECOMBINE_FIELD.key(), "ts_3");
++    options.put(ORDERING_FIELDS.key(), "ts_3");
+     props = createTableAndReturnTableProperties(options, new ObjectPath(db, "tmptb2"));
+-    assertTrue(props.containsKey("hoodie.table.precombine.field"));
+-    assertEquals("ts_3", props.get("hoodie.table.precombine.field"));
++    assertTrue(props.containsKey(HoodieTableConfig.ORDERING_FIELDS.key()));
++    assertEquals("ts_3", props.get(HoodieTableConfig.ORDERING_FIELDS.key()));
+   }
+ 
+   private TypedProperties createTableAndReturnTableProperties(Map<String, String> options, ObjectPath tablePath)
+diff --git a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java
+index d3d9b46708baf..1635278dc08d3 100644
+--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java
++++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java
+@@ -77,7 +77,7 @@ void testInitTableIfNotExists() throws IOException {
+     Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
+ 
+     // Test for partitioned table.
+-    conf.set(FlinkOptions.PRECOMBINE_FIELD, "ts");
++    conf.set(FlinkOptions.ORDERING_FIELDS, "ts");
+     conf.set(FlinkOptions.PARTITION_PATH_FIELD, "p0,p1");
+     StreamerUtil.initTableIfNotExists(conf);
+ 
+@@ -86,7 +86,7 @@ void testInitTableIfNotExists() throws IOException {
+     assertTrue(metaClient1.getTableConfig().getPartitionFields().isPresent(),
+         "Missing partition columns in the hoodie.properties.");
+     assertArrayEquals(metaClient1.getTableConfig().getPartitionFields().get(), new String[] {"p0", "p1"});
+-    assertEquals(metaClient1.getTableConfig().getPreCombineFieldsStr().get(), "ts");
++    assertEquals(metaClient1.getTableConfig().getOrderingFieldsStr().get(), "ts");
+     assertEquals(metaClient1.getTableConfig().getKeyGeneratorClassName(), SimpleAvroKeyGenerator.class.getName());
+     assertEquals(HoodieTableVersion.current(), metaClient1.getTableConfig().getTableVersion());
+ 
+diff --git a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+index 8b37c89a3a6c2..cc70833e560b2 100644
+--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
++++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+@@ -120,7 +120,7 @@ void testCreate() throws IOException {
+   void testUpdate() throws IOException {
+     Properties updatedProps = new Properties();
+     updatedProps.setProperty(HoodieTableConfig.NAME.key(), "test-table2");
+-    updatedProps.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "new_field");
++    updatedProps.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), "new_field");
+     HoodieTableConfig.update(storage, metaPath, updatedProps);
+ 
+     assertTrue(storage.exists(cfgPath));
+@@ -128,8 +128,8 @@ void testUpdate() throws IOException {
+     HoodieTableConfig config = new HoodieTableConfig(storage, metaPath, null, null, null);
+     assertEquals(8, config.getProps().size());
+     assertEquals("test-table2", config.getTableName());
+-    assertEquals(Collections.singletonList("new_field"), config.getPreCombineFields());
+-    assertEquals(Option.of("new_field"), config.getPreCombineFieldsStr());
++    assertEquals(Collections.singletonList("new_field"), config.getOrderingFields());
++    assertEquals(Option.of("new_field"), config.getOrderingFieldsStr());
+   }
+ 
+   @Test
+@@ -219,7 +219,7 @@ void testConcurrentlyUpdate() throws ExecutionException, InterruptedException {
+       for (int i = 0; i < 100; i++) {
+         Properties updatedProps = new Properties();
+         updatedProps.setProperty(HoodieTableConfig.NAME.key(), "test-table" + i);
+-        updatedProps.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "new_field" + i);
++        updatedProps.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), "new_field" + i);
+         HoodieTableConfig.update(storage, metaPath, updatedProps);
+       }
+     });
+diff --git a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
+index dc7c022472c95..fd85ea2581788 100644
+--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
++++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
+@@ -204,7 +204,7 @@ void testCreateMetaClientFromProperties() throws IOException {
+     Properties props = new Properties();
+     props.setProperty(HoodieTableConfig.NAME.key(), "test-table");
+     props.setProperty(HoodieTableConfig.TYPE.key(), HoodieTableType.COPY_ON_WRITE.name());
+-    props.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "timestamp");
++    props.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+ 
+     HoodieTableMetaClient metaClient1 = HoodieTableMetaClient.newTableBuilder()
+         .fromProperties(props)
+@@ -218,7 +218,7 @@ void testCreateMetaClientFromProperties() throws IOException {
+     // test table name and type and precombine field also match
+     assertEquals(metaClient1.getTableConfig().getTableName(), metaClient2.getTableConfig().getTableName());
+     assertEquals(metaClient1.getTableConfig().getTableType(), metaClient2.getTableConfig().getTableType());
+-    assertEquals(metaClient1.getTableConfig().getPreCombineFields(), metaClient2.getTableConfig().getPreCombineFields());
++    assertEquals(metaClient1.getTableConfig().getOrderingFields(), metaClient2.getTableConfig().getOrderingFields());
+     // default table version should be current version
+     assertEquals(HoodieTableVersion.current(), metaClient2.getTableConfig().getTableVersion());
+   }
+diff --git a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestCustomRecordMerger.java b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestCustomRecordMerger.java
+index a1a73a3d20a90..b7eae52ad4b3c 100644
+--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestCustomRecordMerger.java
++++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestCustomRecordMerger.java
+@@ -53,7 +53,7 @@
+ 
+ import static org.apache.hudi.common.config.HoodieReaderConfig.RECORD_MERGE_IMPL_CLASSES_WRITE_CONFIG_KEY;
+ import static org.apache.hudi.common.model.HoodieRecord.HoodieRecordType.AVRO;
+-import static org.apache.hudi.common.table.HoodieTableConfig.PRECOMBINE_FIELDS;
++import static org.apache.hudi.common.table.HoodieTableConfig.ORDERING_FIELDS;
+ import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.AVRO_SCHEMA;
+ import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.DELETE;
+ import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.INSERT;
+@@ -68,7 +68,7 @@ protected Properties getMetaProps() {
+     Properties metaProps = super.getMetaProps();
+     metaProps.setProperty(HoodieTableConfig.RECORD_MERGE_MODE.key(), RecordMergeMode.CUSTOM.name());
+     metaProps.setProperty(HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key(), CustomAvroMerger.KEEP_CERTAIN_TIMESTAMP_VALUE_ONLY);
+-    metaProps.setProperty(PRECOMBINE_FIELDS.key(), "timestamp");
++    metaProps.setProperty(ORDERING_FIELDS.key(), "timestamp");
+     return metaProps;
+   }
+ 
+diff --git a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestEventTimeMerging.java b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestEventTimeMerging.java
+index debbb57954398..0610dd4d8f837 100644
+--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestEventTimeMerging.java
++++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestEventTimeMerging.java
+@@ -44,7 +44,7 @@
+ import java.util.Properties;
+ import java.util.stream.Stream;
+ 
+-import static org.apache.hudi.common.table.HoodieTableConfig.PRECOMBINE_FIELDS;
++import static org.apache.hudi.common.table.HoodieTableConfig.ORDERING_FIELDS;
+ import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.AVRO_SCHEMA;
+ import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.DELETE;
+ import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.INSERT;
+@@ -58,7 +58,7 @@ public class TestEventTimeMerging extends HoodieFileGroupReaderTestHarness {
+   protected Properties getMetaProps() {
+     Properties metaProps =  super.getMetaProps();
+     metaProps.setProperty(HoodieTableConfig.RECORD_MERGE_MODE.key(), RecordMergeMode.EVENT_TIME_ORDERING.name());
+-    metaProps.setProperty(PRECOMBINE_FIELDS.key(), "timestamp");
++    metaProps.setProperty(ORDERING_FIELDS.key(), "timestamp");
+     return metaProps;
+   }
+ 
+diff --git a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
+index fc4795d987639..f09898cb25914 100644
+--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
++++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
+@@ -90,8 +90,8 @@ public AbstractRealtimeRecordReader(RealtimeSplit split, JobConf job) {
+       metaClient = HoodieTableMetaClient.builder()
+           .setConf(HadoopFSUtils.getStorageConfWithCopy(jobConf)).setBasePath(split.getBasePath()).build();
+       payloadProps.putAll(metaClient.getTableConfig().getProps(true));
+-      if (metaClient.getTableConfig().getPreCombineFieldsStr().isPresent()) {
+-        this.payloadProps.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, metaClient.getTableConfig().getPreCombineFieldsStr().orElse(null));
++      if (metaClient.getTableConfig().getOrderingFieldsStr().isPresent()) {
++        this.payloadProps.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, metaClient.getTableConfig().getOrderingFieldsStr().orElse(null));
+       }
+       this.usesCustomPayload = usesCustomPayload(metaClient);
+       LOG.info("usesCustomPayload ==> " + this.usesCustomPayload);
+diff --git a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieParquetRealtimeInputFormat.java b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieParquetRealtimeInputFormat.java
+index cdeacaada6afe..1abb604b52f0c 100644
+--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieParquetRealtimeInputFormat.java
++++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieParquetRealtimeInputFormat.java
+@@ -114,7 +114,7 @@ void addProjectionToJobConf(final RealtimeSplit realtimeSplit, final JobConf job
+           List<String> fieldsToAdd = new ArrayList<>();
+           if (!realtimeSplit.getDeltaLogPaths().isEmpty()) {
+             HoodieRealtimeInputFormatUtils.addVirtualKeysProjection(jobConf, realtimeSplit.getVirtualKeyInfo());
+-            fieldsToAdd.addAll(tableConfig.getPreCombineFields());
++            fieldsToAdd.addAll(tableConfig.getOrderingFields());
+           }
+ 
+           Option<String[]> partitions = tableConfig.getPartitionFields();
+diff --git a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/SparkDataSourceContinuousIngestTool.java b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/SparkDataSourceContinuousIngestTool.java
+index a98415fa372cb..59533772a9690 100644
+--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/SparkDataSourceContinuousIngestTool.java
++++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/SparkDataSourceContinuousIngestTool.java
+@@ -61,7 +61,7 @@
+  * hoodie.datasource.write.recordkey.field=VendorID
+  * hoodie.datasource.write.partitionpath.field=date_col
+  * hoodie.datasource.write.operation=upsert
+- * hoodie.datasource.write.precombine.field=tpep_pickup_datetime
++ * hoodie.datasource.write.precombine.fields=tpep_pickup_datetime
+  * hoodie.metadata.enable=false
+  * hoodie.table.name=hudi_tbl
+  */
+diff --git a/hudi-integ-test/src/main/scala/org/apache/hudi/integ/testsuite/dag/nodes/SparkInsertNode.scala b/hudi-integ-test/src/main/scala/org/apache/hudi/integ/testsuite/dag/nodes/SparkInsertNode.scala
+index b4d028c79c85a..f35ed92785121 100644
+--- a/hudi-integ-test/src/main/scala/org/apache/hudi/integ/testsuite/dag/nodes/SparkInsertNode.scala
++++ b/hudi-integ-test/src/main/scala/org/apache/hudi/integ/testsuite/dag/nodes/SparkInsertNode.scala
+@@ -68,7 +68,7 @@ class SparkInsertNode(dagNodeConfig: Config) extends DagNode[RDD[WriteStatus]] {
+ 
+     inputDF.write.format("hudi")
+       .options(DataSourceWriteOptions.mayBeDerivePartitionPath(context.getWriterContext.getProps.asScala.toMap))
+-      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key(), "test_suite_source_ordering_field")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key(), "test_suite_source_ordering_field")
+       .option(DataSourceWriteOptions.TABLE_NAME.key, context.getHoodieTestSuiteWriter.getCfg.targetTableName)
+       .option(DataSourceWriteOptions.TABLE_TYPE.key, context.getHoodieTestSuiteWriter.getCfg.tableType)
+       .option(HoodieIndexConfig.INDEX_TYPE.key, context.getHoodieTestSuiteWriter.getCfg.indexType)
+diff --git a/hudi-integ-test/src/main/scala/org/apache/hudi/integ/testsuite/dag/nodes/SparkUpsertNode.scala b/hudi-integ-test/src/main/scala/org/apache/hudi/integ/testsuite/dag/nodes/SparkUpsertNode.scala
+index 9e85fc38d8e3c..ff983741b1971 100644
+--- a/hudi-integ-test/src/main/scala/org/apache/hudi/integ/testsuite/dag/nodes/SparkUpsertNode.scala
++++ b/hudi-integ-test/src/main/scala/org/apache/hudi/integ/testsuite/dag/nodes/SparkUpsertNode.scala
+@@ -68,7 +68,7 @@ class SparkUpsertNode(dagNodeConfig: Config) extends SparkInsertNode(dagNodeConf
+ 
+     inputDF.write.format("hudi")
+       .options(DataSourceWriteOptions.translateSqlOptions(context.getWriterContext.getProps.asScala.toMap))
+-      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key(), "test_suite_source_ordering_field")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key(), "test_suite_source_ordering_field")
+       .option(DataSourceWriteOptions.TABLE_NAME.key, context.getHoodieTestSuiteWriter.getCfg.targetTableName)
+       .option(DataSourceWriteOptions.TABLE_TYPE.key, context.getHoodieTestSuiteWriter.getCfg.tableType)
+       .option(DataSourceWriteOptions.OPERATION.key, getOperation())
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
+index fd65233f1e36d..5176df32e7753 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
+@@ -34,6 +34,7 @@
+ import org.apache.hudi.common.model.HoodieRecordPayload;
+ import org.apache.hudi.common.model.WriteOperationType;
+ import org.apache.hudi.common.table.HoodieTableConfig;
++import org.apache.hudi.common.util.ConfigUtils;
+ import org.apache.hudi.common.util.Option;
+ import org.apache.hudi.common.util.ReflectionUtils;
+ import org.apache.hudi.common.util.StringUtils;
+@@ -206,7 +207,7 @@ public static HoodieWriteConfig createHoodieConfig(String schemaStr, String base
+             .withPayloadClass(parameters.getOrDefault(DataSourceWriteOptions.PAYLOAD_CLASS_NAME().key(),
+                 parameters.getOrDefault(HoodieTableConfig.PAYLOAD_CLASS_NAME.key(), HoodieTableConfig.DEFAULT_PAYLOAD_CLASS_NAME)))
+             .withPayloadOrderingFields(parameters.getOrDefault(DataSourceWriteOptions.PRECOMBINE_FIELD().key(),
+-                parameters.get(HoodieTableConfig.PRECOMBINE_FIELDS)))
++                ConfigUtils.getStringWithAltKeys(parameters, HoodieTableConfig.ORDERING_FIELDS)))
+             .build())
+         // override above with Hoodie configs specified as options.
+         .withProps(parameters).build();
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
+index 16041fdae5a52..7612ad95fe3c9 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
+@@ -105,7 +105,7 @@ public final HoodieWriteResult execute(Dataset<Row> records, boolean isTablePart
+     preExecute();
+ 
+     BulkInsertPartitioner<Dataset<Row>> bulkInsertPartitionerRows = getPartitioner(populateMetaFields, isTablePartitioned);
+-    Dataset<Row> hoodieDF = HoodieDatasetBulkInsertHelper.prepareForBulkInsert(records, writeConfig, bulkInsertPartitionerRows, instantTime);
++    Dataset<Row> hoodieDF = HoodieDatasetBulkInsertHelper.prepareForBulkInsert(records, writeConfig, table.getMetaClient().getTableConfig(), bulkInsertPartitionerRows, instantTime);
+ 
+     HoodieWriteMetadata<JavaRDD<WriteStatus>> result = buildHoodieWriteMetadata(doExecute(hoodieDF, bulkInsertPartitionerRows.arePartitionRecordsSorted()));
+     afterExecute(result);
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+index f1ab811b07673..8e8381b8a0c68 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+@@ -85,6 +85,7 @@ object DataSourceReadOptions {
+     .markAdvanced()
+     .withDocumentation("Comma separated list of file paths to read within a Hudi table.")
+ 
++  @Deprecated
+   val READ_PRE_COMBINE_FIELD = HoodieWriteConfig.PRECOMBINE_FIELD_NAME
+ 
+   val ENABLE_HOODIE_FILE_INDEX: ConfigProperty[Boolean] = ConfigProperty
+@@ -1031,9 +1032,6 @@ object DataSourceOptionsHelper {
+     if (!params.contains(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key()) && tableConfig.getKeyGeneratorClassName != null) {
+       missingWriteConfigs ++= Map(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key() -> tableConfig.getKeyGeneratorClassName)
+     }
+-    if (!params.contains(HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key()) && tableConfig.getPreCombineFieldsStr.isPresent) {
+-      missingWriteConfigs ++= Map(HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key -> tableConfig.getPreCombineFieldsStr.orElse(null))
+-    }
+     if (!params.contains(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key()) && tableConfig.getPayloadClass != null) {
+       missingWriteConfigs ++= Map(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key() -> tableConfig.getPayloadClass)
+     }
+@@ -1073,6 +1071,7 @@ object DataSourceOptionsHelper {
+   /**
+    * Returns optional list of precombine fields from the provided parameteres.
+    */
++  @deprecated("Use preCombine key in table config", "1.1.0")
+   def getPreCombineFields(params: Map[String, String]): Option[java.util.List[String]] = params.get(DataSourceWriteOptions.PRECOMBINE_FIELD.key) match {
+     // NOTE: This is required to compensate for cases when empty string is used to stub
+     //       property value to avoid it being set with the default value
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+index 9269315de982d..54ca53794e346 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+@@ -135,8 +135,8 @@ class DefaultSource extends RelationProvider
+       .setBasePath(tablePath).build()
+ 
+     // Add preCombineField to options for buildReaderWithPartitionValues properly
+-    val options = if (metaClient.getTableConfig.getPreCombineFieldsStr.isPresent) {
+-      parameters ++ Map(HoodieTableConfig.PRECOMBINE_FIELDS.key -> metaClient.getTableConfig.getPreCombineFieldsStr.orElse(null))
++    val options = if (metaClient.getTableConfig.getOrderingFieldsStr.isPresent) {
++      parameters ++ Map(HoodieTableConfig.ORDERING_FIELDS.key -> metaClient.getTableConfig.getOrderingFieldsStr.orElse(null))
+     } else {
+       parameters
+     }
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+index 54a3577f7f6c8..5cbfdcef050e4 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+@@ -136,7 +136,7 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
+     }
+ 
+   protected lazy val preCombineFields: List[String] = {
+-    val tablePrecombineFields = tableConfig.getPreCombineFields
++    val tablePrecombineFields = tableConfig.getOrderingFields
+     if (tablePrecombineFields.isEmpty) {
+       DataSourceOptionsHelper.getPreCombineFields(optParams)
+         .orElse(java.util.Collections.emptyList[String])
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCreateRecordUtils.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCreateRecordUtils.scala
+index 5466a790772f9..0c4f87a244fd0 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCreateRecordUtils.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCreateRecordUtils.scala
+@@ -58,7 +58,8 @@ object HoodieCreateRecordUtils {
+                                        instantTime: String,
+                                        preppedSparkSqlWrites: Boolean,
+                                        preppedSparkSqlMergeInto: Boolean,
+-                                       preppedWriteOperation: Boolean)
++                                       preppedWriteOperation: Boolean,
++                                       orderingFields: java.util.List[String])
+ 
+   def createHoodieRecordRdd(args: createHoodieRecordRddArgs) = {
+     val df = args.df
+@@ -73,6 +74,7 @@ object HoodieCreateRecordUtils {
+     val preppedSparkSqlWrites = args.preppedSparkSqlWrites
+     val preppedSparkSqlMergeInto = args.preppedSparkSqlMergeInto
+     val preppedWriteOperation = args.preppedWriteOperation
++    val orderingFields = args.orderingFields
+ 
+     val shouldDropPartitionColumns = config.getBoolean(DataSourceWriteOptions.DROP_PARTITION_COLUMNS)
+     val recordType = config.getRecordMerger.getRecordType
+@@ -125,7 +127,6 @@ object HoodieCreateRecordUtils {
+           val consistentLogicalTimestampEnabled = parameters.getOrElse(
+             DataSourceWriteOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key(),
+             DataSourceWriteOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.defaultValue()).toBoolean
+-          val precombineFields = config.getPreCombineFields()
+ 
+           // handle dropping partition columns
+           it.map { avroRec =>
+@@ -143,9 +144,9 @@ object HoodieCreateRecordUtils {
+               avroRecWithoutMeta
+             }
+ 
+-            val hoodieRecord = if (shouldCombine && !precombineFields.isEmpty) {
++            val hoodieRecord = if (shouldCombine && !orderingFields.isEmpty) {
+               val orderingVal = OrderingValues.create(
+-                precombineFields,
++                orderingFields,
+                 JFunction.toJavaFunction[String, Comparable[_]](
+                   field => HoodieAvroUtils.getNestedFieldVal(avroRec, field, false,
+                     consistentLogicalTimestampEnabled).asInstanceOf[Comparable[_]]))
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+index 135ade4bf4cc6..48718ff514de7 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+@@ -529,7 +529,6 @@ object HoodieFileIndex extends Logging {
+ 
+     if (tableConfig != null) {
+       properties.setProperty(RECORDKEY_FIELD.key, tableConfig.getRecordKeyFields.orElse(Array.empty).mkString(","))
+-      properties.setProperty(PRECOMBINE_FIELD.key, tableConfig.getPreCombineFieldsStr.orElse(""))
+       properties.setProperty(PARTITIONPATH_FIELD.key, HoodieTableConfig.getPartitionFieldPropForKeyGenerator(tableConfig).orElse(""))
+ 
+       // for simple bucket index, we need to set the INDEX_TYPE, BUCKET_INDEX_HASH_FIELD, BUCKET_INDEX_NUM_BUCKETS
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieHadoopFsRelationFactory.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieHadoopFsRelationFactory.scala
+index 0a9bef1ab30c1..1bd61407412dc 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieHadoopFsRelationFactory.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieHadoopFsRelationFactory.scala
+@@ -186,7 +186,7 @@ abstract class HoodieBaseHadoopFsRelationFactory(val sqlContext: SQLContext,
+   }
+ 
+   protected lazy val preCombineFields: List[String] = {
+-    val tablePrecombineFields = tableConfig.getPreCombineFields
++    val tablePrecombineFields = tableConfig.getOrderingFields
+     if (tablePrecombineFields.isEmpty) {
+       DataSourceOptionsHelper.getPreCombineFields(optParams)
+         .orElse(java.util.Collections.emptyList[String])
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+index 1ac3a3fb0f3ce..b74467e3ab446 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+@@ -40,7 +40,7 @@ import org.apache.hudi.common.model.HoodieTableType.{COPY_ON_WRITE, MERGE_ON_REA
+ import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, HoodieTableVersion, TableSchemaResolver}
+ import org.apache.hudi.common.table.log.block.HoodieLogBlock.HoodieLogBlockType
+ import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator
+-import org.apache.hudi.common.util.{CommitUtils, Option => HOption, StringUtils}
++import org.apache.hudi.common.util.{CommitUtils, ConfigUtils, Option => HOption, StringUtils}
+ import org.apache.hudi.common.util.ConfigUtils.getAllConfigKeys
+ import org.apache.hudi.config.{HoodieCompactionConfig, HoodieIndexConfig, HoodieInternalConfig, HoodieWriteConfig}
+ import org.apache.hudi.config.HoodieBootstrapConfig.{BASE_PATH, INDEX_CLASS_NAME}
+@@ -310,7 +310,7 @@ class HoodieSparkSqlWriterInternal {
+           .setArchiveLogFolder(archiveLogFolder)
+           // we can't fetch preCombine field from hoodieConfig object, since it falls back to "ts" as default value,
+           // but we are interested in what user has set, hence fetching from optParams.
+-          .setPreCombineFields(optParams.getOrElse(PRECOMBINE_FIELD.key(), null))
++          .setOrderingFields(ConfigUtils.getOrderingFieldsStrDuringWrite(optParams.asJava))
+           .setPartitionFields(partitionColumnsForKeyGenerator)
+           .setPopulateMetaFields(populateMetaFields)
+           .setRecordKeyFields(hoodieConfig.getString(RECORDKEY_FIELD))
+@@ -517,7 +517,7 @@ class HoodieSparkSqlWriterInternal {
+             val hoodieRecords = Try(HoodieCreateRecordUtils.createHoodieRecordRdd(
+               HoodieCreateRecordUtils.createHoodieRecordRddArgs(df, writeConfig, parameters, avroRecordName,
+                 avroRecordNamespace, writerSchema, processedDataSchema, operation, instantTime, preppedSparkSqlWrites,
+-                preppedSparkSqlMergeInto, preppedWriteOperation))) match {
++                preppedSparkSqlMergeInto, preppedWriteOperation, tableConfig.getOrderingFields))) match {
+               case Success(recs) => recs
+               case Failure(e) => throw new HoodieRecordCreationException("Failed to create Hoodie Spark Record", e)
+             }
+@@ -772,7 +772,7 @@ class HoodieSparkSqlWriterInternal {
+           .setPayloadClassName(payloadClass)
+           .setRecordMergeMode(RecordMergeMode.getValue(hoodieConfig.getString(HoodieWriteConfig.RECORD_MERGE_MODE)))
+           .setRecordMergeStrategyId(recordMergerStrategy)
+-          .setPreCombineFields(hoodieConfig.getStringOrDefault(PRECOMBINE_FIELD, null))
++          .setOrderingFields(ConfigUtils.getOrderingFieldsStrDuringWrite(hoodieConfig.getProps))
+           .setBootstrapIndexClass(bootstrapIndexClass)
+           .setBaseFileFormat(baseFileFormat)
+           .setBootstrapBasePath(bootstrapBasePath)
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+index b4be1229605e4..83c4dcd8495dc 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+@@ -55,7 +55,6 @@ object HoodieWriterUtils {
+     val hoodieConfig: HoodieConfig = new HoodieConfig(props)
+     hoodieConfig.setDefaultValue(OPERATION)
+     hoodieConfig.setDefaultValue(TABLE_TYPE)
+-    hoodieConfig.setDefaultValue(PRECOMBINE_FIELD)
+     hoodieConfig.setDefaultValue(KEYGENERATOR_CLASS_NAME)
+     hoodieConfig.setDefaultValue(ENABLE)
+     hoodieConfig.setDefaultValue(COMMIT_METADATA_KEYPREFIX)
+@@ -248,9 +247,9 @@ object HoodieWriterUtils {
+         }
+ 
+         val datasourcePreCombineKey = params.getOrElse(PRECOMBINE_FIELD.key(), null)
+-        val tableConfigPreCombineKey = tableConfig.getString(HoodieTableConfig.PRECOMBINE_FIELDS)
+-        if (null != datasourcePreCombineKey && null != tableConfigPreCombineKey && datasourcePreCombineKey != tableConfigPreCombineKey) {
+-          diffConfigs.append(s"PreCombineKey:\t$datasourcePreCombineKey\t$tableConfigPreCombineKey\n")
++        val tableConfigOrderingKey = tableConfig.getString(HoodieTableConfig.ORDERING_FIELDS)
++        if (null != datasourcePreCombineKey && null != tableConfigOrderingKey && datasourcePreCombineKey != tableConfigOrderingKey) {
++          diffConfigs.append(s"PreCombineKey:\t$datasourcePreCombineKey\t$tableConfigOrderingKey\n")
+         }
+ 
+         val datasourceKeyGen = getOriginKeyGenerator(params)
+@@ -340,7 +339,7 @@ object HoodieWriterUtils {
+   private val sparkDatasourceConfigsToTableConfigsMap = Map(
+     TABLE_NAME -> HoodieTableConfig.NAME,
+     TABLE_TYPE -> HoodieTableConfig.TYPE,
+-    PRECOMBINE_FIELD -> HoodieTableConfig.PRECOMBINE_FIELDS,
++    PRECOMBINE_FIELD -> HoodieTableConfig.ORDERING_FIELDS,
+     PARTITIONPATH_FIELD -> HoodieTableConfig.PARTITION_FIELDS,
+     RECORDKEY_FIELD -> HoodieTableConfig.RECORDKEY_FIELDS,
+     PAYLOAD_CLASS_NAME -> HoodieTableConfig.PAYLOAD_CLASS_NAME,
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
+index 99e3fb23b5942..3b548630c72a0 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
+@@ -505,7 +505,7 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
+         Option.empty(), metaClient.getTableConfig, readerProperties))
+     val stats = new HoodieReadStats
+     val recordBuffer = new KeyBasedFileGroupRecordBuffer[InternalRow](readerContext, metaClient, readerContext.getMergeMode,
+-      metaClient.getTableConfig.getPartialUpdateMode, readerProperties, metaClient.getTableConfig.getPreCombineFields,
++      metaClient.getTableConfig.getPartialUpdateMode, readerProperties, metaClient.getTableConfig.getOrderingFields,
+       UpdateProcessor.create(stats, readerContext, true, Option.empty()))
+ 
+     HoodieMergedLogRecordReader.newBuilder[InternalRow]
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/HoodieCDCRDD.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/HoodieCDCRDD.scala
+index 0f5f90d49efc2..eedcc98ab25fe 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/HoodieCDCRDD.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/HoodieCDCRDD.scala
+@@ -92,7 +92,7 @@ class HoodieCDCRDD(
+ 
+   private val props = HoodieFileIndex.getConfigProperties(spark, Map.empty, metaClient.getTableConfig)
+ 
+-  protected val payloadProps: Properties = metaClient.getTableConfig.getPreCombineFieldsStr
++  protected val payloadProps: Properties = metaClient.getTableConfig.getOrderingFieldsStr
+     .map[TypedProperties](JFunction.toJavaFunction(preCombineFields =>
+       HoodiePayloadConfig.newBuilder
+         .withPayloadOrderingFields(preCombineFields)
+@@ -138,7 +138,7 @@ class HoodieCDCRDD(
+       keyFields.head
+     }
+ 
+-    private lazy val preCombineFields: List[String] = metaClient.getTableConfig.getPreCombineFields.asScala.toList
++    private lazy val preCombineFields: List[String] = metaClient.getTableConfig.getOrderingFields.asScala.toList
+ 
+     private lazy val tableState = {
+       val metadataConfig = HoodieMetadataConfig.newBuilder()
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+index ceb55b9fd94c9..f3fdc5db225d0 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+@@ -130,7 +130,7 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
+   /**
+    * Comparables Field
+    */
+-  lazy val preCombineKeys: java.util.List[String] = tableConfig.getPreCombineFields
++  lazy val orderingFields: java.util.List[String] = tableConfig.getOrderingFields
+ 
+   /**
+    * Partition Fields
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieOptionConfig.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieOptionConfig.scala
+index 89472466a2db7..27a1639c710ac 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieOptionConfig.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieOptionConfig.scala
+@@ -61,7 +61,7 @@ object HoodieOptionConfig {
+   val SQL_KEY_PRECOMBINE_FIELD: HoodieSQLOption[String] = buildConf()
+     .withSqlKey("preCombineField")
+     .withHoodieKey(DataSourceWriteOptions.PRECOMBINE_FIELD.key)
+-    .withTableConfigKey(HoodieTableConfig.PRECOMBINE_FIELDS.key)
++    .withTableConfigKey(HoodieTableConfig.ORDERING_FIELDS.key)
+     .build()
+ 
+   val SQL_PAYLOAD_CLASS: HoodieSQLOption[String] = buildConf()
+@@ -181,11 +181,6 @@ object HoodieOptionConfig {
+       DataSourceWriteOptions.TABLE_TYPE.defaultValue)
+   }
+ 
+-  def getPreCombineField(options: Map[String, String]): Option[String] = {
+-    val params = mapSqlOptionsToDataSourceWriteConfigs(options)
+-    params.get(DataSourceWriteOptions.PRECOMBINE_FIELD.key).filter(_.nonEmpty)
+-  }
+-
+   def deleteHoodieOptions(options: Map[String, String]): Map[String, String] = {
+     options.filterNot(_._1.startsWith("hoodie.")).filterNot(kv => sqlOptionKeyToWriteConfigKey.contains(kv._1))
+   }
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+index b087e711dd7a5..ad1bfd30d98a4 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+@@ -25,7 +25,7 @@ import org.apache.hudi.common.config.{DFSPropertiesConfiguration, HoodieCommonCo
+ import org.apache.hudi.common.model.WriteOperationType
+ import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.table.HoodieTableConfig.DATABASE_NAME
+-import org.apache.hudi.common.util.{ReflectionUtils, StringUtils}
++import org.apache.hudi.common.util.{ConfigUtils, ReflectionUtils, StringUtils}
+ import org.apache.hudi.config.{HoodieIndexConfig, HoodieInternalConfig, HoodieWriteConfig}
+ import org.apache.hudi.config.HoodieWriteConfig.TBL_NAME
+ import org.apache.hudi.hive.{HiveSyncConfig, HiveSyncConfigHolder, MultiPartKeysValueExtractor}
+@@ -53,6 +53,7 @@ import org.slf4j.LoggerFactory
+ 
+ import java.util.Locale
+ 
++import scala.collection.JavaConverters
+ import scala.collection.JavaConverters._
+ 
+ trait ProvidesHoodieConfig extends Logging {
+@@ -64,7 +65,7 @@ trait ProvidesHoodieConfig extends Logging {
+     // NOTE: Here we fallback to "" to make sure that null value is not overridden with
+     // default value ("ts")
+     // TODO(HUDI-3456) clean up
+-    val preCombineFields = tableConfig.getPreCombineFieldsStr.orElse("")
++    val orderingFields = tableConfig.getOrderingFieldsStr.orElse("")
+     val hiveSyncConfig = buildHiveSyncConfig(sparkSession, hoodieCatalogTable, tableConfig)
+ 
+     val defaultOpts = Map[String, String](
+@@ -82,7 +83,7 @@ trait ProvidesHoodieConfig extends Logging {
+       HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE.key -> hiveSyncConfig.getBoolean(HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE).toString
+     )
+ 
+-    val overridingOpts = buildOverridingOpts(hoodieCatalogTable, preCombineFields)
++    val overridingOpts = buildOverridingOpts(hoodieCatalogTable, orderingFields)
+     combineOptions(hoodieCatalogTable, tableConfig, sparkSession.sqlContext.conf,
+       defaultOpts = defaultOpts, overridingOpts = overridingOpts)
+   }
+@@ -90,7 +91,7 @@ trait ProvidesHoodieConfig extends Logging {
+   def buildBucketRescaleHoodieConfig(hoodieCatalogTable: HoodieCatalogTable): Map[String, String] = {
+     val sparkSession: SparkSession = hoodieCatalogTable.spark
+     val tableConfig = hoodieCatalogTable.tableConfig
+-    val preCombineFields = tableConfig.getPreCombineFieldsStr.orElse("")
++    val orderingFields = tableConfig.getOrderingFieldsStr.orElse("")
+     val hiveSyncConfig = buildHiveSyncConfig(sparkSession, hoodieCatalogTable, tableConfig)
+ 
+     val defaultOpts = Map[String, String](
+@@ -103,7 +104,7 @@ trait ProvidesHoodieConfig extends Logging {
+       HiveSyncConfigHolder.HIVE_SYNC_ENABLED.key -> "false"
+     )
+ 
+-    val overridingOpts = buildOverridingOpts(hoodieCatalogTable, preCombineFields)
++    val overridingOpts = buildOverridingOpts(hoodieCatalogTable, orderingFields)
+     combineOptions(hoodieCatalogTable, tableConfig, sparkSession.sqlContext.conf,
+       defaultOpts = defaultOpts, overridingOpts = overridingOpts)
+   }
+@@ -190,8 +191,7 @@ trait ProvidesHoodieConfig extends Logging {
+     // NOTE: Here we fallback to "" to make sure that null value is not overridden with
+     // default value ("ts")
+     // TODO(HUDI-3456) clean up
+-    val preCombineField = combinedOpts.getOrElse(HoodieTableConfig.PRECOMBINE_FIELDS.key,
+-      combinedOpts.getOrElse(PRECOMBINE_FIELD.key, ""))
++    val orderingFieldsStr = Option.apply(ConfigUtils.getOrderingFieldsStrDuringWrite(combinedOpts.asJava)).getOrElse("")
+ 
+     val hiveStylePartitioningEnable = Option(tableConfig.getHiveStylePartitioningEnable).getOrElse("true")
+     val urlEncodePartitioning = Option(tableConfig.getUrlEncodePartitioning).getOrElse("false")
+@@ -215,7 +215,7 @@ trait ProvidesHoodieConfig extends Logging {
+     val insertDupPolicy = combinedOpts.getOrElse(INSERT_DUP_POLICY.key(), INSERT_DUP_POLICY.defaultValue())
+     val isNonStrictMode = insertMode == InsertMode.NON_STRICT
+     val isPartitionedTable = hoodieCatalogTable.partitionFields.nonEmpty
+-    val combineBeforeInsert = !hoodieCatalogTable.preCombineKeys.isEmpty && hoodieCatalogTable.primaryKeys.nonEmpty
++    val combineBeforeInsert = !hoodieCatalogTable.orderingFields.isEmpty && hoodieCatalogTable.primaryKeys.nonEmpty
+ 
+     /*
+      * The sql write operation has higher precedence than the legacy insert mode.
+@@ -232,7 +232,7 @@ trait ProvidesHoodieConfig extends Logging {
+           isNonStrictMode, isPartitionedTable, combineBeforeInsert, insertMode, shouldAutoKeyGen)
+       } else {
+         deduceSparkSqlInsertIntoWriteOperation(isOverwritePartition, isOverwriteTable,
+-          shouldAutoKeyGen, preCombineField, sparkSqlInsertIntoOperationSet, sparkSqlInsertIntoOperation)
++          shouldAutoKeyGen, orderingFieldsStr, sparkSqlInsertIntoOperationSet, sparkSqlInsertIntoOperation)
+       }
+     )
+ 
+@@ -301,7 +301,7 @@ trait ProvidesHoodieConfig extends Logging {
+       HIVE_STYLE_PARTITIONING.key -> hiveStylePartitioningEnable,
+       URL_ENCODE_PARTITIONING.key -> urlEncodePartitioning,
+       RECORDKEY_FIELD.key -> recordKeyConfigValue,
+-      PRECOMBINE_FIELD.key -> preCombineField,
++      HoodieTableConfig.ORDERING_FIELDS.key -> orderingFieldsStr,
+       PARTITIONPATH_FIELD.key -> getPartitionPathFieldWriteConfig(
+         keyGeneratorClassName, partitionFieldsStr, hoodieCatalogTable)
+     ) ++ overwriteTableOpts ++ getDropDupsConfig(useLegacyInsertModeFlow, combinedOpts) ++ staticOverwritePartitionPathOptions
+@@ -398,7 +398,6 @@ trait ProvidesHoodieConfig extends Logging {
+       OPERATION.key -> DataSourceWriteOptions.DELETE_PARTITION_OPERATION_OPT_VAL,
+       PARTITIONS_TO_DELETE.key -> partitionsToDrop,
+       RECORDKEY_FIELD.key -> hoodieCatalogTable.primaryKeys.mkString(","),
+-      PRECOMBINE_FIELD.key -> String.join(",", hoodieCatalogTable.preCombineKeys),
+       PARTITIONPATH_FIELD.key -> getPartitionPathFieldWriteConfig(
+         tableConfig.getKeyGeneratorClassName, partitionFields, hoodieCatalogTable),
+       HoodieSyncConfig.META_SYNC_ENABLED.key -> hiveSyncConfig.getString(HoodieSyncConfig.META_SYNC_ENABLED.key),
+@@ -560,9 +559,9 @@ object ProvidesHoodieConfig {
+     opts.filter { case (_, v) => v != null }
+ 
+   private def buildOverridingOpts(hoodieCatalogTable: HoodieCatalogTable,
+-                                  preCombineFields: String): Map[String, String] = {
++                                  orderingFields: String): Map[String, String] = {
+     buildCommonOverridingOpts(hoodieCatalogTable) ++ Map(
+-      PRECOMBINE_FIELD.key -> preCombineFields
++      HoodieTableConfig.ORDERING_FIELDS.key -> orderingFields
+     )
+   }
+ 
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
+index 69e09598f7c0e..39d3b9417e106 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
+@@ -125,7 +125,7 @@ object CreateHoodieTableCommand {
+       val originTableConfig = hoodieCatalogTable.tableConfig.getProps.asScala.toMap
+       val tableOptions = hoodieCatalogTable.catalogProperties
+ 
+-      checkTableConfigEqual(originTableConfig, tableOptions, HoodieTableConfig.PRECOMBINE_FIELDS.key)
++      checkTableConfigEqual(originTableConfig, tableOptions, HoodieTableConfig.ORDERING_FIELDS.key)
+       checkTableConfigEqual(originTableConfig, tableOptions, HoodieTableConfig.PARTITION_FIELDS.key)
+       checkTableConfigEqual(originTableConfig, tableOptions, HoodieTableConfig.RECORDKEY_FIELDS.key)
+       checkTableConfigEqual(originTableConfig, tableOptions, HoodieTableConfig.KEY_GENERATOR_CLASS_NAME.key)
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestProvidesHoodieConfig.scala b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestProvidesHoodieConfig.scala
+index 670d96b6b9c10..3f20b67609467 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestProvidesHoodieConfig.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestProvidesHoodieConfig.scala
+@@ -94,7 +94,7 @@ class TestProvidesHoodieConfig {
+     // catalogProperties won't be passed in correctly, because they were not synced properly
+     when(mockCatalog.catalogProperties).thenReturn(Map.empty[String, String])
+     when(mockCatalog.partitionFields).thenReturn(Array("partition"))
+-    when(mockCatalog.preCombineKeys).thenCallRealMethod()
++    when(mockCatalog.orderingFields).thenCallRealMethod()
+     when(mockCatalog.partitionSchema).thenReturn(StructType(Nil))
+     when(mockCatalog.primaryKeys).thenReturn(Array("key"))
+     when(mockCatalog.table).thenReturn(CatalogTable.apply(
+@@ -103,7 +103,7 @@ class TestProvidesHoodieConfig {
+       CatalogStorageFormat.empty,
+       StructType(Nil)))
+     val props = new TypedProperties()
+-    props.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key, "segment")
++    props.setProperty(HoodieTableConfig.ORDERING_FIELDS.key, "segment")
+     val mockTableConfig = spy(classOf[HoodieTableConfig])
+     when(mockTableConfig.getProps).thenReturn(props)
+     when(mockCatalog.tableConfig).thenReturn(mockTableConfig)
+@@ -140,7 +140,7 @@ class TestProvidesHoodieConfig {
+ 
+     assertEquals(
+       "segment",
+-      combinedConfig.getOrElse(HoodieTableConfig.PRECOMBINE_FIELDS.key, "")
++      combinedConfig.getOrElse(HoodieTableConfig.ORDERING_FIELDS.key, "")
+     )
+ 
+     // write config precombine field should be inferred from table config
+diff --git a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/bootstrap/SparkFullBootstrapDataProviderBase.java b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/bootstrap/SparkFullBootstrapDataProviderBase.java
+index 65af0c3543409..bccebeb2db469 100644
+--- a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/bootstrap/SparkFullBootstrapDataProviderBase.java
++++ b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/bootstrap/SparkFullBootstrapDataProviderBase.java
+@@ -72,7 +72,7 @@ public JavaRDD<HoodieRecord> generateInputRecords(String tableName, String sourc
+     HoodieRecordType recordType =  config.getRecordMerger().getRecordType();
+     Dataset inputDataset = sparkSession.read().format(getFormat()).option("basePath", sourceBasePath).load(filePaths);
+     KeyGenerator keyGenerator = HoodieSparkKeyGeneratorFactory.createKeyGenerator(props);
+-    String precombineKey = props.getString("hoodie.datasource.write.precombine.field");
++    String orderingFieldsStr = ConfigUtils.getOrderingFieldsStrDuringWrite(props);
+     String structName = tableName + "_record";
+     String namespace = "hoodie." + tableName;
+     if (recordType == HoodieRecordType.AVRO) {
+@@ -80,7 +80,7 @@ public JavaRDD<HoodieRecord> generateInputRecords(String tableName, String sourc
+           Option.empty());
+       return genericRecords.toJavaRDD().map(gr -> {
+         String orderingVal = HoodieAvroUtils.getNestedFieldValAsString(
+-            gr, precombineKey, false, props.getBoolean(
++            gr, orderingFieldsStr, false, props.getBoolean(
+                 KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key(),
+                 Boolean.parseBoolean(KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.defaultValue())));
+         try {
+diff --git a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java
+index bd2c44e4370f5..a3be757c377b1 100644
+--- a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java
++++ b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java
+@@ -25,6 +25,7 @@
+ import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.common.table.HoodieTableMetaClient;
+ import org.apache.hudi.common.table.HoodieTableVersion;
++import org.apache.hudi.common.util.ConfigUtils;
+ import org.apache.hudi.common.util.Option;
+ import org.apache.hudi.common.util.ReflectionUtils;
+ import org.apache.hudi.common.util.StringUtils;
+@@ -67,7 +68,6 @@
+ import static org.apache.hudi.common.util.ConfigUtils.filterProperties;
+ import static org.apache.hudi.config.HoodieIndexConfig.BUCKET_INDEX_HASH_FIELD;
+ import static org.apache.hudi.config.HoodieIndexConfig.BUCKET_INDEX_NUM_BUCKETS;
+-import static org.apache.hudi.config.HoodieWriteConfig.PRECOMBINE_FIELD_NAME;
+ import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_BUCKET_SYNC;
+ import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_BUCKET_SYNC_SPEC;
+ import static org.apache.hudi.keygen.constant.KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE;
+@@ -237,7 +237,7 @@ private void initializeTable() throws IOException {
+         .setTableName(cfg.tableName)
+         .setTableVersion(bootstrapConfig.getWriteVersion())
+         .setRecordKeyFields(props.getString(RECORDKEY_FIELD_NAME.key()))
+-        .setPreCombineFields(props.getString(PRECOMBINE_FIELD_NAME.key(), null))
++        .setOrderingFields(ConfigUtils.getOrderingFieldsStrDuringWrite(props))
+         .setPopulateMetaFields(props.getBoolean(
+             POPULATE_META_FIELDS.key(), POPULATE_META_FIELDS.defaultValue()))
+         .setArchiveLogFolder(props.getString(
+diff --git a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+index 56507994fa69d..398e3f766c1ee 100644
+--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
++++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+@@ -268,7 +268,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable,
+       sparkSession.sessionState.conf.resolver,
+       mergeInto.targetTable,
+       mergeInto.sourceTable,
+-      hoodieCatalogTable.preCombineKeys.asScala.toSeq,
++      hoodieCatalogTable.orderingFields.asScala.toSeq,
+       "precombine field",
+       updatingActions.flatMap(_.assignments))
+ 
+@@ -761,7 +761,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable,
+     // NOTE: Here we fallback to "" to make sure that null value is not overridden with
+     // default value ("ts")
+     // TODO(HUDI-3456) clean up
+-    val preCombineFieldsAsString = String.join(",", hoodieCatalogTable.preCombineKeys)
++    val orderingFieldsAsString = String.join(",", hoodieCatalogTable.orderingFields)
+     val hiveSyncConfig = buildHiveSyncConfig(sparkSession, hoodieCatalogTable, tableConfig)
+     // for pkless tables, we need to enable optimized merge
+     val isPrimaryKeylessTable = !hasPrimaryKey()
+@@ -776,7 +776,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable,
+         tableConfig.getRecordMergeMode,
+         tableConfig.getPayloadClass,
+         tableConfig.getRecordMergeStrategyId,
+-        tableConfig.getPreCombineFieldsStr.orElse(null),
++        tableConfig.getOrderingFieldsStr.orElse(null),
+         tableConfig.getTableVersion)
+       inferredMergeConfigs.getLeft.name()
+     } else {
+@@ -785,7 +785,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable,
+     val overridingOpts = Map(
+       "path" -> path,
+       RECORDKEY_FIELD.key -> tableConfig.getRawRecordKeyFieldProp,
+-      PRECOMBINE_FIELD.key -> preCombineFieldsAsString,
++      HoodieTableConfig.ORDERING_FIELDS.key -> orderingFieldsAsString,
+       TBL_NAME.key -> hoodieCatalogTable.tableName,
+       PARTITIONPATH_FIELD.key -> getPartitionPathFieldWriteConfig(
+         tableConfig.getKeyGeneratorClassName, tableConfig.getPartitionFieldProp, hoodieCatalogTable),
+@@ -819,7 +819,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable,
+       HoodieSparkSqlWriter.SQL_MERGE_INTO_WRITES.key -> "true",
+       // Only primary keyless table requires prepped keys and upsert
+       HoodieWriteConfig.SPARK_SQL_MERGE_INTO_PREPPED_KEY -> isPrimaryKeylessTable.toString,
+-      HoodieWriteConfig.COMBINE_BEFORE_UPSERT.key() -> (!StringUtils.isNullOrEmpty(preCombineFieldsAsString)).toString
++      HoodieWriteConfig.COMBINE_BEFORE_UPSERT.key() -> (!StringUtils.isNullOrEmpty(orderingFieldsAsString)).toString
+     )
+ 
+     combineOptions(hoodieCatalogTable, tableConfig, sparkSession.sqlContext.conf,
+@@ -851,7 +851,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable,
+         validateTargetTableAttrExistsInAssignments(
+           sparkSession.sessionState.conf.resolver,
+           mergeInto.targetTable,
+-          hoodieCatalogTable.preCombineKeys.asScala.toSeq,
++          hoodieCatalogTable.orderingFields.asScala.toSeq,
+           "precombine field",
+           action.assignments)
+       )
+@@ -921,7 +921,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable,
+             sparkSession.sessionState.conf.resolver,
+             mergeInto.targetTable,
+             mergeInto.sourceTable,
+-            hoodieCatalogTable.preCombineKeys.asScala.toSeq,
++            hoodieCatalogTable.orderingFields.asScala.toSeq,
+             "precombine field",
+             assignments)
+           associations.foreach(association => validateDataTypes(association._1, association._2, "Precombine field"))
+@@ -934,7 +934,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable,
+   }
+ 
+   private def checkUpdatingActions(updateActions: Seq[UpdateAction], props: Map[String, String]): Unit = {
+-    if (hoodieCatalogTable.preCombineKeys.isEmpty && updateActions.nonEmpty) {
++    if (hoodieCatalogTable.orderingFields.isEmpty && updateActions.nonEmpty) {
+       logWarning(s"Updates without precombine can have nondeterministic behavior")
+     }
+     updateActions.foreach(update =>
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaApp.java b/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaApp.java
+index 55a986a80c912..c250d15adcee2 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaApp.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaApp.java
+@@ -21,6 +21,7 @@
+ import org.apache.hudi.HoodieDataSourceHelpers;
+ import org.apache.hudi.common.model.HoodieRecord;
+ import org.apache.hudi.common.model.HoodieTableType;
++import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+ import org.apache.hudi.config.HoodieCompactionConfig;
+ import org.apache.hudi.config.HoodieWriteConfig;
+@@ -155,7 +156,7 @@ public void run() throws Exception {
+         // this is the partition to place it into
+         .option(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition")
+         // use to combine duplicate records in input/with disk val
+-        .option(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp")
+         // Used by hive sync and queries
+         .option(HoodieWriteConfig.TBL_NAME.key(), tableName)
+         .option(DataSourceWriteOptions.ASYNC_COMPACT_ENABLE().key(), "false")
+@@ -183,7 +184,7 @@ public void run() throws Exception {
+         .option(DataSourceWriteOptions.TABLE_TYPE().key(), tableType) // Hoodie Table Type
+         .option(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key")
+         .option(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition")
+-        .option(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp")
+         .option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "1")
+         .option(DataSourceWriteOptions.ASYNC_COMPACT_ENABLE().key(), "false")
+         .option(DataSourceWriteOptions.ASYNC_CLUSTERING_ENABLE().key(), "true")
+@@ -208,7 +209,7 @@ public void run() throws Exception {
+         .option(DataSourceWriteOptions.OPERATION().key(), "delete")
+         .option(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key")
+         .option(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition")
+-        .option(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp")
+         .option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "1")
+         .option(DataSourceWriteOptions.ASYNC_COMPACT_ENABLE().key(), "false")
+         .option(DataSourceWriteOptions.ASYNC_CLUSTERING_ENABLE().key(), "true")
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaGenerateApp.java b/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaGenerateApp.java
+index a41db540ec40f..0f325a0f2f743 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaGenerateApp.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaGenerateApp.java
+@@ -20,6 +20,7 @@
+ import org.apache.hudi.HoodieDataSourceHelpers;
+ import org.apache.hudi.common.model.HoodieRecord;
+ import org.apache.hudi.common.model.HoodieTableType;
++import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+ import org.apache.hudi.common.testutils.InProcessTimeGenerator;
+ import org.apache.hudi.config.HoodieWriteConfig;
+@@ -183,7 +184,7 @@ private void insert(SparkSession spark) throws IOException {
+         // this is the partition to place it into
+         .option(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition")
+         // use to combine duplicate records in input/with disk val
+-        .option(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp")
+         // Used by hive sync and queries
+         .option(HoodieWriteConfig.TBL_NAME.key(), tableName)
+         .mode(commitType);
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaStreamingApp.java b/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaStreamingApp.java
+index 54a64895c6de7..b18a47dcc443e 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaStreamingApp.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaStreamingApp.java
+@@ -20,6 +20,7 @@
+ import org.apache.hudi.DataSourceWriteOptions;
+ import org.apache.hudi.HoodieDataSourceHelpers;
+ import org.apache.hudi.common.model.HoodieTableType;
++import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.common.table.HoodieTableMetaClient;
+ import org.apache.hudi.common.table.timeline.HoodieTimeline;
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+@@ -372,7 +373,7 @@ public void stream(Dataset<Row> streamingInput, String operationType, String che
+         .option(DataSourceWriteOptions.TABLE_TYPE().key(), tableType)
+         .option(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key")
+         .option(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition")
+-        .option(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp")
+         .option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "1")
+         .option(DataSourceWriteOptions.ASYNC_COMPACT_ENABLE().key(), "true")
+         .option(DataSourceWriteOptions.ASYNC_CLUSTERING_ENABLE().key(), "true")
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDecimalTypeDataWorkflow.scala b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDecimalTypeDataWorkflow.scala
+index c4014bc5719ac..54815dd394a93 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDecimalTypeDataWorkflow.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDecimalTypeDataWorkflow.scala
+@@ -21,6 +21,7 @@ package org.apache.hudi
+ 
+ import org.apache.hudi.DataSourceWriteOptions._
+ import org.apache.hudi.common.config.{HoodieReaderConfig, HoodieStorageConfig}
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.config.HoodieWriteConfig
+ import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+ import org.apache.spark.sql.types.{Decimal, DecimalType, IntegerType, StructField, StructType}
+@@ -66,7 +67,7 @@ class TestDecimalTypeDataWorkflow extends SparkClientFunctionalTestHarness{
+       .toDF("id", "decimal_col").sort("id")
+     insertDf.write.format("hudi")
+       .option(RECORDKEY_FIELD.key(), "id")
+-      .option(PRECOMBINE_FIELD.key(), "decimal_col")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key(), "decimal_col")
+       .option(TABLE_TYPE.key, "MERGE_ON_READ")
+       .option(TABLE_NAME.key, "test_table")
+       .options(opts)
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDefaultSparkRecordMerger.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDefaultSparkRecordMerger.java
+index ccdcd1878055d..eaa31036a8726 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDefaultSparkRecordMerger.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDefaultSparkRecordMerger.java
+@@ -42,7 +42,7 @@
+ import java.util.List;
+ 
+ import static org.apache.hudi.common.model.HoodieRecord.HoodieRecordType.SPARK;
+-import static org.apache.hudi.common.table.HoodieTableConfig.PRECOMBINE_FIELDS;
++import static org.apache.hudi.common.table.HoodieTableConfig.ORDERING_FIELDS;
+ import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertThrows;
+@@ -100,7 +100,7 @@ void testMergerWithNewRecordAccepted() throws IOException {
+ 
+     DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
+     TypedProperties props = new TypedProperties();
+-    props.setProperty(PRECOMBINE_FIELDS.key(), INT_COLUMN_NAME);
++    props.setProperty(ORDERING_FIELDS.key(), INT_COLUMN_NAME);
+     Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
+         SPARK_SCHEMA, ANY_NAME, ANY_NAMESPACE);
+     Option<Pair<HoodieRecord, Schema>> merged =
+@@ -127,7 +127,7 @@ void testMergerWithOldRecordAccepted() throws IOException {
+ 
+     DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
+     TypedProperties props = new TypedProperties();
+-    props.setProperty(PRECOMBINE_FIELDS.key(), INT_COLUMN_NAME);
++    props.setProperty(ORDERING_FIELDS.key(), INT_COLUMN_NAME);
+     Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
+         SPARK_SCHEMA, ANY_NAME, ANY_NAMESPACE);
+     Option<Pair<HoodieRecord, Schema>> r =
+@@ -151,7 +151,7 @@ void testMergerWithNewRecordAsDelete() throws IOException {
+ 
+     DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
+     TypedProperties props = new TypedProperties();
+-    props.setProperty(PRECOMBINE_FIELDS.key(), INT_COLUMN_NAME);
++    props.setProperty(ORDERING_FIELDS.key(), INT_COLUMN_NAME);
+     Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
+         SPARK_SCHEMA, ANY_NAME, ANY_NAMESPACE);
+     Option<Pair<HoodieRecord, Schema>> r =
+@@ -172,7 +172,7 @@ void testMergerWithOldRecordAsDelete() throws IOException {
+ 
+     DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
+     TypedProperties props = new TypedProperties();
+-    props.setProperty(PRECOMBINE_FIELDS.key(), INT_COLUMN_NAME);
++    props.setProperty(ORDERING_FIELDS.key(), INT_COLUMN_NAME);
+     Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
+         SPARK_SCHEMA, ANY_NAME, ANY_NAMESPACE);
+     Option<Pair<HoodieRecord, Schema>> r =
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestHoodieMergeHandleWithSparkMerger.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestHoodieMergeHandleWithSparkMerger.java
+index 8cdd41803a85a..633326bbe283e 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestHoodieMergeHandleWithSparkMerger.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestHoodieMergeHandleWithSparkMerger.java
+@@ -86,7 +86,7 @@ public void setUp() throws IOException {
+     properties.setProperty(
+         HoodieTableConfig.BASE_FILE_FORMAT.key(),
+         HoodieTableConfig.BASE_FILE_FORMAT.defaultValue().toString());
+-    properties.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "record_key");
++    properties.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), "record_key");
+     properties.setProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(),"partition_path");
+     properties.setProperty(HoodieTableConfig.PARTITION_FIELDS.key(), "partition_path");
+     metaClient = getHoodieMetaClient(storageConf(), basePath(), HoodieTableType.MERGE_ON_READ, properties);
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestPositionBasedFileGroupRecordBuffer.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestPositionBasedFileGroupRecordBuffer.java
+index 7b2d825b55db8..f7107fc1e78fc 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestPositionBasedFileGroupRecordBuffer.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestPositionBasedFileGroupRecordBuffer.java
+@@ -95,7 +95,7 @@ private void prepareBuffer(RecordMergeMode mergeMode, String baseFileInstantTime
+     writeConfigs.put(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key(), "parquet");
+     writeConfigs.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "_row_key");
+     writeConfigs.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partition_path");
+-    writeConfigs.put("hoodie.datasource.write.precombine.field", mergeMode.equals(RecordMergeMode.COMMIT_TIME_ORDERING) ? "" : "timestamp");
++    writeConfigs.put(HoodieTableConfig.ORDERING_FIELDS.key(), mergeMode.equals(RecordMergeMode.COMMIT_TIME_ORDERING) ? "" : "timestamp");
+     writeConfigs.put("hoodie.payload.ordering.field", "timestamp");
+     writeConfigs.put(HoodieTableConfig.HOODIE_TABLE_NAME_KEY, "hoodie_test");
+     writeConfigs.put("hoodie.insert.shuffle.parallelism", "4");
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
+index 3f2ffcb36704b..cd8b2c9cdc274 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
+@@ -209,7 +209,7 @@ public void testRecordGenerationAPIsForMOR() throws IOException {
+     HoodieTableType tableType = HoodieTableType.MERGE_ON_READ;
+     cleanupClients();
+     Properties props = new Properties();
+-    props.put(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "timestamp");
++    props.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     initMetaClient(tableType, props);
+     cleanupTimelineService();
+     initTimelineService();
+@@ -307,7 +307,7 @@ public void testSecondaryIndexRecordGenerationForMOR() throws IOException {
+     HoodieTableType tableType = HoodieTableType.MERGE_ON_READ;
+     cleanupClients();
+     Properties props = new Properties();
+-    props.put(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "timestamp");
++    props.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     initMetaClient(tableType, props);
+     cleanupTimelineService();
+     initTimelineService();
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrap.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrap.java
+index e833919c30ac4..50c8c551f161a 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrap.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrap.java
+@@ -35,6 +35,7 @@
+ import org.apache.hudi.common.model.HoodieKey;
+ import org.apache.hudi.common.model.HoodieRecord;
+ import org.apache.hudi.common.model.HoodieTableType;
++import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.common.table.timeline.HoodieInstant.State;
+ import org.apache.hudi.common.table.timeline.HoodieTimeline;
+ import org.apache.hudi.common.table.timeline.TimelineUtils;
+@@ -255,7 +256,6 @@ private void testBootstrapCommon(boolean partitioned, boolean deltaCommit, Effec
+     long timestamp = Instant.now().toEpochMilli();
+     Schema schema = generateNewDataSetAndReturnSchema(timestamp, totalRecords, partitions, bootstrapBasePath);
+     HoodieWriteConfig config = getConfigBuilder(schema.toString())
+-        .withPreCombineField("timestamp")
+         .withSchema(schema.toString())
+         .withKeyGenerator(keyGeneratorClass)
+         .withCompactionConfig(HoodieCompactionConfig.newBuilder()
+@@ -270,6 +270,7 @@ private void testBootstrapCommon(boolean partitioned, boolean deltaCommit, Effec
+         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(true).withMaxNumDeltaCommitsBeforeCompaction(3)
+             .withMetadataIndexColumnStats(false).build()) // HUDI-8774
+         .build();
++    config.setValue(HoodieTableConfig.ORDERING_FIELDS, "timestamp");
+ 
+     SparkRDDWriteClient client = new SparkRDDWriteClient(context, config);
+     client.bootstrap(Option.empty());
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrapReadBase.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrapReadBase.java
+index e32ddc698a398..33011276c9bdd 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrapReadBase.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrapReadBase.java
+@@ -25,6 +25,7 @@
+ import org.apache.hudi.client.bootstrap.translator.DecodedBootstrapPartitionPathTranslator;
+ import org.apache.hudi.common.config.HoodieMetadataConfig;
+ import org.apache.hudi.common.model.HoodieTableType;
++import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+ import org.apache.hudi.config.HoodieBootstrapConfig;
+ import org.apache.hudi.config.HoodieCompactionConfig;
+@@ -105,7 +106,7 @@ protected Map<String, String> basicOptions() {
+         options.put(HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key(), ComplexKeyGenerator.class.getName());
+       }
+     }
+-    options.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++    options.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     if (tableType.equals(MERGE_ON_READ)) {
+       options.put(HoodieCompactionConfig.INLINE_COMPACT.key(), "true");
+     }
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBufferedRecordMerger.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBufferedRecordMerger.java
+index ccc507aba3447..0b3047bc3d858 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBufferedRecordMerger.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBufferedRecordMerger.java
+@@ -76,7 +76,7 @@
+ import static org.apache.hudi.common.config.RecordMergeMode.COMMIT_TIME_ORDERING;
+ import static org.apache.hudi.common.config.RecordMergeMode.EVENT_TIME_ORDERING;
+ import static org.apache.hudi.common.table.HoodieTableConfig.PARTIAL_UPDATE_CUSTOM_MARKER;
+-import static org.apache.hudi.common.table.HoodieTableConfig.PRECOMBINE_FIELDS;
++import static org.apache.hudi.common.table.HoodieTableConfig.ORDERING_FIELDS;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertFalse;
+ import static org.junit.jupiter.api.Assertions.assertNotNull;
+@@ -113,7 +113,7 @@ void setUp() throws IOException {
+     when(tableConfig.getRecordKeyFields()).thenReturn(Option.of(new String[]{"id"}));
+     // Create reader context.
+     props = new TypedProperties();
+-    props.put(PRECOMBINE_FIELDS.key(), "precombine");
++    props.put(ORDERING_FIELDS.key(), "precombine");
+     readerContext = new DummyInternalRowReaderContext(
+         storageConfig, tableConfig, Option.empty(), Option.empty(), new DummyRecordContext(tableConfig));
+   }
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestColStatsRecordWithMetadataRecord.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestColStatsRecordWithMetadataRecord.java
+index 967508927e430..43bae063ba0ac 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestColStatsRecordWithMetadataRecord.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestColStatsRecordWithMetadataRecord.java
+@@ -220,7 +220,7 @@ public int compare(HoodieRecord<HoodieMetadataPayload> o1, HoodieRecord<HoodieMe
+     while (itr.hasNext()) {
+       GenericRecord genericRecord = (GenericRecord) ((HoodieRecord) itr.next()).getData();
+       HoodieRecord<HoodieMetadataPayload> mdtRec = SpillableMapUtils.convertToHoodieRecordPayload(genericRecord,
+-          mdtWriteConfig.getPayloadClass(), mdtWriteConfig.getPreCombineFields().toArray(new String[0]),
++          mdtWriteConfig.getPayloadClass(), new String[0],
+           Pair.of(mdtMetaClient.getTableConfig().getRecordKeyFieldProp(), mdtMetaClient.getTableConfig().getPartitionFieldProp()),
+           false, Option.of(COLUMN_STATS.getPartitionPath()), Option.empty());
+       allRecords.add(mdtRec);
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestDataSkippingWithMORColstats.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestDataSkippingWithMORColstats.java
+index beb7141470904..e16ab9fb96c51 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestDataSkippingWithMORColstats.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestDataSkippingWithMORColstats.java
+@@ -25,6 +25,7 @@
+ import org.apache.hudi.common.config.HoodieMetadataConfig;
+ import org.apache.hudi.common.fs.FSUtils;
+ import org.apache.hudi.common.model.HoodieTableType;
++import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.common.table.HoodieTableMetaClient;
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+ import org.apache.hudi.common.util.Option;
+@@ -333,7 +334,7 @@ private Map<String, String> getOptions() {
+     options.put(DataSourceReadOptions.ENABLE_DATA_SKIPPING().key(), "true");
+     options.put(DataSourceWriteOptions.TABLE_TYPE().key(), DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL());
+     options.put(HoodieWriteConfig.TBL_NAME.key(), "testTable");
+-    options.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++    options.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     options.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+     options.put("hoodie.datasource.write.keygenerator.class", "org.apache.hudi.keygen.NonpartitionedKeyGenerator");
+     options.put(HoodieCompactionConfig.PARQUET_SMALL_FILE_LIMIT.key(), "0");
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
+index ecd3dd3f45f98..af6cc16a608b4 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
+@@ -437,7 +437,7 @@ public void testTurnOffMetadataTableAfterEnable() throws Exception {
+     Triple<RecordMergeMode, String, String> inferredMergeConfs =
+         HoodieTableConfig.inferCorrectMergingBehavior(
+             writeConfig.getRecordMergeMode(), writeConfig.getPayloadClass(),
+-            writeConfig.getRecordMergeStrategyId(), String.join(",", writeConfig.getPreCombineFields()),
++            writeConfig.getRecordMergeStrategyId(), String.join(",", table.getMetaClient().getTableConfig().getOrderingFields()),
+             metaClient.getTableConfig().getTableVersion());
+     HoodieTableConfig hoodieTableConfig =
+         new HoodieTableConfig(this.storage, metaClient.getMetaPath(), inferredMergeConfs.getLeft(), inferredMergeConfs.getMiddle(), inferredMergeConfs.getRight());
+@@ -460,7 +460,7 @@ public void testTurnOffMetadataTableAfterEnable() throws Exception {
+     Triple<RecordMergeMode, String, String> inferredMergeConfs2 =
+         HoodieTableConfig.inferCorrectMergingBehavior(
+             writeConfig2.getRecordMergeMode(), writeConfig2.getPayloadClass(),
+-            writeConfig2.getRecordMergeStrategyId(), String.join(",", writeConfig2.getPreCombineFields()),
++            writeConfig2.getRecordMergeStrategyId(), String.join(",", table2.getMetaClient().getTableConfig().getOrderingFields()),
+             metaClient.getTableConfig().getTableVersion());
+     HoodieTableConfig hoodieTableConfig2 =
+         new HoodieTableConfig(this.storage, metaClient.getMetaPath(),
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieDatasetBulkInsertHelper.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieDatasetBulkInsertHelper.java
+index 21b1a9be870ea..6f08491f61702 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieDatasetBulkInsertHelper.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieDatasetBulkInsertHelper.java
+@@ -23,6 +23,7 @@
+ import org.apache.hudi.SparkAdapterSupport$;
+ import org.apache.hudi.common.config.TypedProperties;
+ import org.apache.hudi.common.model.HoodieRecord;
++import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.common.util.FileIOUtils;
+ import org.apache.hudi.config.HoodieWriteConfig;
+ import org.apache.hudi.execution.bulkinsert.NonSortPartitionerWithRows;
+@@ -132,7 +133,7 @@ private void testBulkInsertHelperFor(String keyGenClass, String recordKeyField)
+     List<Row> rows = DataSourceTestUtils.generateRandomRows(10);
+     Dataset<Row> dataset = sqlContext.createDataFrame(rows, structType);
+     Dataset<Row> result = HoodieDatasetBulkInsertHelper.prepareForBulkInsert(dataset, config,
+-        new NonSortPartitionerWithRows(), "0000000001");
++        new HoodieTableConfig(), new NonSortPartitionerWithRows(), "0000000001");
+     StructType resultSchema = result.schema();
+ 
+     assertEquals(result.count(), 10);
+@@ -176,7 +177,7 @@ public void testBulkInsertHelperNoMetaFields() {
+         .build();
+     Dataset<Row> dataset = sqlContext.createDataFrame(rows, structType);
+     Dataset<Row> result = HoodieDatasetBulkInsertHelper.prepareForBulkInsert(dataset, config,
+-        new NonSortPartitionerWithRows(), "000001111");
++        new HoodieTableConfig(), new NonSortPartitionerWithRows(), "000001111");
+     StructType resultSchema = result.schema();
+ 
+     assertEquals(result.count(), 10);
+@@ -204,7 +205,10 @@ public void testBulkInsertHelperNoMetaFields() {
+   public void testBulkInsertPreCombine(boolean enablePreCombine) {
+     HoodieWriteConfig config = getConfigBuilder(schemaStr).withProps(getPropsAllSet("_row_key"))
+             .combineInput(enablePreCombine, enablePreCombine)
+-            .withPreCombineField("ts").build();
++            .build();
++    config.setValue(HoodieTableConfig.ORDERING_FIELDS, "ts");
++    HoodieTableConfig tableConfig = new HoodieTableConfig();
++    tableConfig.setValue(HoodieTableConfig.ORDERING_FIELDS, "ts");
+     List<Row> inserts = DataSourceTestUtils.generateRandomRows(10);
+     Dataset<Row> toUpdateDataset = sqlContext.createDataFrame(inserts.subList(0, 5), structType);
+     List<Row> updates = DataSourceTestUtils.updateRowsWithUpdatedTs(toUpdateDataset);
+@@ -213,7 +217,7 @@ public void testBulkInsertPreCombine(boolean enablePreCombine) {
+     rows.addAll(updates);
+     Dataset<Row> dataset = sqlContext.createDataFrame(rows, structType);
+     Dataset<Row> result = HoodieDatasetBulkInsertHelper.prepareForBulkInsert(dataset, config,
+-        new NonSortPartitionerWithRows(), "000001111");
++        tableConfig, new NonSortPartitionerWithRows(), "000001111");
+     StructType resultSchema = result.schema();
+ 
+     assertEquals(result.count(), enablePreCombine ? 10 : 15);
+@@ -317,7 +321,7 @@ public void testNoPropsSet() {
+     Dataset<Row> dataset = sqlContext.createDataFrame(rows, structType);
+     try {
+       Dataset<Row> preparedDF = HoodieDatasetBulkInsertHelper.prepareForBulkInsert(dataset, config,
+-          new NonSortPartitionerWithRows(), "000001111");
++          new HoodieTableConfig(), new NonSortPartitionerWithRows(), "000001111");
+       preparedDF.count();
+       fail("Should have thrown exception");
+     } catch (Exception e) {
+@@ -329,7 +333,7 @@ public void testNoPropsSet() {
+     dataset = sqlContext.createDataFrame(rows, structType);
+     try {
+       Dataset<Row> preparedDF = HoodieDatasetBulkInsertHelper.prepareForBulkInsert(dataset, config,
+-          new NonSortPartitionerWithRows(), "000001111");
++          new HoodieTableConfig(), new NonSortPartitionerWithRows(), "000001111");
+       preparedDF.count();
+       fail("Should have thrown exception");
+     } catch (Exception e) {
+@@ -341,7 +345,7 @@ public void testNoPropsSet() {
+     dataset = sqlContext.createDataFrame(rows, structType);
+     try {
+       Dataset<Row> preparedDF = HoodieDatasetBulkInsertHelper.prepareForBulkInsert(dataset, config,
+-          new NonSortPartitionerWithRows(), "000001111");
++          new HoodieTableConfig(), new NonSortPartitionerWithRows(), "000001111");
+       preparedDF.count();
+       fail("Should have thrown exception");
+     } catch (Exception e) {
+@@ -357,7 +361,10 @@ private ExpressionEncoder getEncoder(StructType schema) {
+   public void testBulkInsertParallelismParam() {
+     HoodieWriteConfig config = getConfigBuilder(schemaStr).withProps(getPropsAllSet("_row_key"))
+         .combineInput(true, true)
+-        .withPreCombineField("ts").build();
++        .build();
++    config.setValue(HoodieTableConfig.ORDERING_FIELDS, "ts");
++    HoodieTableConfig tableConfig = new HoodieTableConfig();
++    tableConfig.setValue(HoodieTableConfig.ORDERING_FIELDS, "ts");
+     int checkParallelism = 7;
+     config.setValue("hoodie.bulkinsert.shuffle.parallelism", String.valueOf(checkParallelism));
+     StageCheckBulkParallelismListener stageCheckBulkParallelismListener =
+@@ -368,7 +375,7 @@ public void testBulkInsertParallelismParam() {
+     assertNotEquals(checkParallelism, HoodieUnsafeUtils.getNumPartitions(dataset));
+     assertNotEquals(checkParallelism, sqlContext.sparkContext().defaultParallelism());
+     Dataset<Row> result = HoodieDatasetBulkInsertHelper.prepareForBulkInsert(dataset, config,
+-        new NonSortPartitionerWithRows(), "000001111");
++        tableConfig, new NonSortPartitionerWithRows(), "000001111");
+     // trigger job
+     result.count();
+     assertEquals(checkParallelism, stageCheckBulkParallelismListener.getParallelism());
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieIndex.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieIndex.java
+index c0fc5846f4b25..4b343e33051cf 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieIndex.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieIndex.java
+@@ -182,9 +182,9 @@ private Properties getPropsForKeyGen(IndexType indexType, boolean populateMetaFi
+       properties.put(HoodieTableConfig.RECORDKEY_FIELDS.key(), "_row_key");
+       properties.put("hoodie.datasource.write.keygenerator.class", RawTripTestPayloadKeyGenerator.class.getName());
+       properties.put("hoodie.datasource.write.partitionpath.field", "time");
+-      properties.put("hoodie.datasource.write.precombine.field", "number");
++      properties.put(HoodieTableConfig.ORDERING_FIELDS.key(), "number");
+       properties.put(HoodieTableConfig.PARTITION_FIELDS.key(), "time");
+-      properties.put(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "number");
++      properties.put(HoodieTableConfig.ORDERING_FIELDS.key(), "number");
+     }
+     return properties;
+   }
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
+index 0ed059fe20fb8..f8f67c14f80dc 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
+@@ -270,7 +270,7 @@ public void testRepeatedRollbackOfCompaction() throws Exception {
+   @ValueSource(booleans = {true, false})
+   public void testSimpleInsertUpdateAndDelete(boolean populateMetaFields) throws Exception {
+     Properties properties = populateMetaFields ? new Properties() : getPropertiesForKeyGen();
+-    properties.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "timestamp");
++    properties.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     properties.setProperty(HoodieTableConfig.BASE_FILE_FORMAT.key(), HoodieTableConfig.BASE_FILE_FORMAT.defaultValue().toString());
+     HoodieTableMetaClient metaClient = getHoodieMetaClient(HoodieTableType.MERGE_ON_READ, properties);
+ 
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestSparkNonBlockingConcurrencyControl.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestSparkNonBlockingConcurrencyControl.java
+index 855c6510f97d0..035e33480be84 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestSparkNonBlockingConcurrencyControl.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestSparkNonBlockingConcurrencyControl.java
+@@ -617,7 +617,7 @@ private HoodieWriteConfig createHoodieWriteConfig(boolean fullUpdate) {
+     props.put(ENABLE_SCHEMA_CONFLICT_RESOLUTION.key(), "false");
+     String basePath = basePath();
+     return HoodieWriteConfig.newBuilder()
+-        .withProps(Collections.singletonMap(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "ts"))
++        .withProps(Collections.singletonMap(HoodieTableConfig.ORDERING_FIELDS.key(), "ts"))
+         .forTable("test")
+         .withPath(basePath)
+         .withSchema(jsonSchema)
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/resources/upgrade-downgrade-fixtures/scala-templates/generate-fixture.scala b/hudi-spark-datasource/hudi-spark/src/test/resources/upgrade-downgrade-fixtures/scala-templates/generate-fixture.scala
+index fbefed9e05dfc..46f4eb43ced42 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/resources/upgrade-downgrade-fixtures/scala-templates/generate-fixture.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/resources/upgrade-downgrade-fixtures/scala-templates/generate-fixture.scala
+@@ -16,6 +16,7 @@
+  */
+ 
+ import org.apache.spark.sql.SaveMode
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.DataSourceWriteOptions._
+ import spark.implicits._
+ 
+@@ -35,7 +36,7 @@ val df = testData.toDF("id", "name", "ts", "partition")
+ 
+ // Write initial batch (creates base files)
+ df.write.format("hudi").
+-  option(PRECOMBINE_FIELD.key, "ts").
++  option(HoodieTableConfig.ORDERING_FIELDS.key, "ts").
+   option(RECORDKEY_FIELD.key, "id").
+   option(PARTITIONPATH_FIELD.key, "partition").
+   option("hoodie.table.name", tableName).
+@@ -61,7 +62,7 @@ val updateData = Seq(
+ val updateDf = updateData.toDF("id", "name", "ts", "partition")
+ 
+ updateDf.write.format("hudi").
+-  option(PRECOMBINE_FIELD.key, "ts").
++  option(HoodieTableConfig.ORDERING_FIELDS.key, "ts").
+   option(RECORDKEY_FIELD.key, "id").
+   option(PARTITIONPATH_FIELD.key, "partition").
+   option("hoodie.table.name", tableName).
+@@ -86,7 +87,7 @@ val insertData = Seq(
+ val insertDf = insertData.toDF("id", "name", "ts", "partition")
+ 
+ insertDf.write.format("hudi").
+-  option(PRECOMBINE_FIELD.key, "ts").
++  option(HoodieTableConfig.ORDERING_FIELDS.key, "ts").
+   option(RECORDKEY_FIELD.key, "id").
+   option(PARTITIONPATH_FIELD.key, "partition").
+   option("hoodie.table.name", tableName).
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroSchemaResolutionSupport.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroSchemaResolutionSupport.scala
+index 2929534ffa745..7b8f9b737e0f1 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroSchemaResolutionSupport.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroSchemaResolutionSupport.scala
+@@ -20,6 +20,7 @@ package org.apache.hudi
+ 
+ import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieReaderConfig}
+ import org.apache.hudi.common.model.HoodieTableType
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.config.HoodieWriteConfig
+ import org.apache.hudi.exception.SchemaCompatibilityException
+ import org.apache.hudi.testutils.HoodieClientTestBase
+@@ -45,7 +46,7 @@ class TestAvroSchemaResolutionSupport extends HoodieClientTestBase with ScalaAss
+     "hoodie.insert.shuffle.parallelism" -> "1",
+     "hoodie.upsert.shuffle.parallelism" -> "1",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "id",
++    HoodieTableConfig.ORDERING_FIELDS.key() -> "id",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "name",
+     DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> "org.apache.hudi.keygen.SimpleKeyGenerator",
+     HoodieMetadataConfig.ENABLE.key -> "false"
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestGenericRecordAndRowConsistency.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestGenericRecordAndRowConsistency.scala
+index 54ccfd0fd4b19..f7e132e23636f 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestGenericRecordAndRowConsistency.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestGenericRecordAndRowConsistency.scala
+@@ -17,6 +17,7 @@
+  */
+ package org.apache.hudi
+ 
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.config.HoodieWriteConfig
+ import org.apache.hudi.testutils.HoodieSparkClientTestBase
+ 
+@@ -35,7 +36,7 @@ class TestGenericRecordAndRowConsistency extends HoodieSparkClientTestBase {
+     "hoodie.upsert.shuffle.parallelism" -> "1",
+     DataSourceWriteOptions.TABLE_TYPE.key -> "COPY_ON_WRITE",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "str,eventTime",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "typeId",
++    HoodieTableConfig.ORDERING_FIELDS.key() -> "typeId",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "typeId",
+     DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> "org.apache.hudi.keygen.ComplexKeyGenerator",
+     DataSourceWriteOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key -> "true"
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+index 1071cdd8438a7..7fc9b07185d87 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+@@ -76,7 +76,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
+     "hoodie.upsert.shuffle.parallelism" -> "4",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key() -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   )
+ 
+@@ -207,7 +207,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition_path",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "timestamp",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.OPERATION.key -> DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL
+     )
+@@ -353,7 +353,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
+     val writerOpts: Map[String, String] = commonOpts ++ Map(
+       DataSourceWriteOptions.OPERATION.key -> DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
+       RECORDKEY_FIELD.key -> "id",
+-      PRECOMBINE_FIELD.key -> "version",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "version",
+       PARTITIONPATH_FIELD.key -> "dt,hh",
+       HoodieMetadataConfig.ENABLE.key -> useMetadataTable.toString
+     )
+@@ -496,7 +496,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
+     val writerOpts: Map[String, String] = commonOpts ++ Map(
+       DataSourceWriteOptions.OPERATION.key -> DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
+       RECORDKEY_FIELD.key -> "id",
+-      PRECOMBINE_FIELD.key -> "version",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "version",
+       PARTITIONPATH_FIELD.key -> partitionNames.mkString(","),
+       HoodieMetadataConfig.ENABLE.key -> useMetadataTable.toString
+     )
+@@ -551,7 +551,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
+       val writerOpts: Map[String, String] = commonOpts ++ Map(
+         DataSourceWriteOptions.OPERATION.key -> DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
+         RECORDKEY_FIELD.key -> "id",
+-        PRECOMBINE_FIELD.key -> "version",
++        HoodieTableConfig.ORDERING_FIELDS.key() -> "version",
+         PARTITIONPATH_FIELD.key -> "dt,hh"
+       )
+ 
+@@ -613,7 +613,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
+       HoodieMetadataConfig.ENABLE.key -> enableMetadataTable.toString,
+       RECORDKEY_FIELD.key -> "id",
+       PARTITIONPATH_FIELD.key -> "region_code,dt",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "price"
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "price"
+     )
+ 
+     val readerOpts: Map[String, String] = queryOpts ++ Map(
+@@ -734,7 +734,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
+       .options(commonOpts)
+       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+       .option(RECORDKEY_FIELD.key, "id")
+-      .option(PRECOMBINE_FIELD.key, "id")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key, "id")
+       .option(PARTITIONPATH_FIELD.key, partitionBy)
+       .option(HoodieMetadataConfig.ENABLE.key(), useMetaFileList)
+       .mode(SaveMode.Overwrite)
+@@ -765,7 +765,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       RECORDKEY_FIELD.key -> "id",
+-      PRECOMBINE_FIELD.key -> "id",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "id",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"
+     ) ++ writeMetadataOpts
+ 
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
+index 78ca3d149ed45..fe0f16971cda0 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
+@@ -307,7 +307,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+     option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key(), "city").
+     option(HoodieWriteConfig.TBL_NAME.key(), hoodieFooTableName).
+     option("hoodie.datasource.write.recordkey.field", "uuid").
+-    option("hoodie.datasource.write.precombine.field", "rider").
++    option(HoodieTableConfig.ORDERING_FIELDS.key(), "rider").
+     option("hoodie.datasource.write.operation", "bulk_insert").
+     option("hoodie.datasource.write.hive_style_partitioning", "true").
+     option("hoodie.populate.meta.fields", "false").
+@@ -405,7 +405,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+     val recordsSeq = convertRowListToSeq(records)
+     val df = spark.createDataFrame(sc.parallelize(recordsSeq), structType)
+     // write to Hudi
+-    HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, fooTableModifier - DataSourceWriteOptions.PRECOMBINE_FIELD.key, df)
++    HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, fooTableModifier - HoodieTableConfig.ORDERING_FIELDS.key, df)
+ 
+     // collect all partition paths to issue read of parquet files
+     val partitions = Seq(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH,
+@@ -614,7 +614,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+       .setBaseFileFormat(fooTableParams.getOrElse(HoodieWriteConfig.BASE_FILE_FORMAT.key,
+         HoodieTableConfig.BASE_FILE_FORMAT.defaultValue().name))
+       .setArchiveLogFolder(HoodieTableConfig.TIMELINE_HISTORY_PATH.defaultValue())
+-      .setPreCombineFields(fooTableParams.getOrElse(DataSourceWriteOptions.PRECOMBINE_FIELD.key, null))
++      .setOrderingFields(fooTableParams.getOrElse(HoodieTableConfig.ORDERING_FIELDS.key, null))
+       .setPartitionFields(fooTableParams(DataSourceWriteOptions.PARTITIONPATH_FIELD.key))
+       .setKeyGeneratorClassProp(fooTableParams.getOrElse(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key,
+         DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.defaultValue()))
+@@ -763,7 +763,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+     List(DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL, DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL).foreach { tableType =>
+       val baseBootStrapPath = tempBootStrapPath.toAbsolutePath.toString
+       val options = Map(DataSourceWriteOptions.TABLE_TYPE.key -> tableType,
+-        DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "col3",
++        HoodieTableConfig.ORDERING_FIELDS.key -> "col3",
+         DataSourceWriteOptions.RECORDKEY_FIELD.key -> "keyid",
+         DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "",
+         DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> "org.apache.hudi.keygen.NonpartitionedKeyGenerator",
+@@ -963,7 +963,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+   @EnumSource(value = classOf[HoodieTableType])
+   def testNonPartitionTableWithMetatableSupport(tableType: HoodieTableType): Unit = {
+     val options = Map(DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name,
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "col3",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "col3",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "keyid",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "",
+       DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> "org.apache.hudi.keygen.NonpartitionedKeyGenerator",
+@@ -1048,7 +1048,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+   def testUpsertWithCombineBeforeUpsertDisabled(tableType: HoodieTableType): Unit = {
+     val options = Map(
+       DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name,
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "col3",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "col3",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "keyid",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "",
+       DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> "org.apache.hudi.keygen.NonpartitionedKeyGenerator",
+@@ -1079,7 +1079,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+     val df = Seq((1, "a1", 10, 1000L, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "dt"
+     )
+ 
+@@ -1154,7 +1154,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+     val df = Seq((1, "a1", 10, 1000, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts"
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts"
+     )
+ 
+     // case 1: When commit C1 specifies a key generator and commit C2 does not specify key generator
+@@ -1182,7 +1182,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+     val df = Seq((1, "a1", 10, 1000, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "dt"
+     )
+ 
+@@ -1214,7 +1214,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+     val df = Seq((1, "a1", 10, 1000, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "dt"
+     )
+ 
+@@ -1246,7 +1246,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+     val df = Seq((1, "a1", 10, 1000, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "dt"
+     )
+ 
+@@ -1301,7 +1301,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+     val df = Seq((1, "a1", 10, 1000, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       HoodieIndexConfig.BUCKET_INDEX_ENGINE_TYPE.key -> "CONSISTENT_HASHING",
+       HoodieIndexConfig.INDEX_TYPE.key -> "BUCKET"
+     )
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriterWithTestFormat.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriterWithTestFormat.scala
+index 312fc6ec24140..e047d0cefe7b0 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriterWithTestFormat.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriterWithTestFormat.scala
+@@ -274,7 +274,7 @@ class TestHoodieSparkSqlWriterWithTestFormat extends HoodieSparkWriterTestBase {
+     val recordsSeq = convertRowListToSeq(records)
+     val df = spark.createDataFrame(sc.parallelize(recordsSeq), structType)
+     // write to Hudi
+-    HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, fooTableModifier - DataSourceWriteOptions.PRECOMBINE_FIELD.key, df)
++    HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, fooTableModifier - HoodieTableConfig.ORDERING_FIELDS.key, df)
+ 
+     // collect all partition paths to issue read of parquet files
+     val partitions = Seq(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH,
+@@ -485,7 +485,7 @@ class TestHoodieSparkSqlWriterWithTestFormat extends HoodieSparkWriterTestBase {
+       .setBaseFileFormat(fooTableParams.getOrElse(HoodieWriteConfig.BASE_FILE_FORMAT.key,
+         HoodieTableConfig.BASE_FILE_FORMAT.defaultValue().name))
+       .setArchiveLogFolder(HoodieTableConfig.TIMELINE_HISTORY_PATH.defaultValue())
+-      .setPreCombineFields(fooTableParams.getOrElse(DataSourceWriteOptions.PRECOMBINE_FIELD.key, null))
++      .setOrderingFields(fooTableParams.getOrElse(HoodieTableConfig.ORDERING_FIELDS.key, null))
+       .setPartitionFields(fooTableParams(DataSourceWriteOptions.PARTITIONPATH_FIELD.key))
+       .setKeyGeneratorClassProp(fooTableParams.getOrElse(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key,
+         DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.defaultValue()))
+@@ -505,7 +505,7 @@ class TestHoodieSparkSqlWriterWithTestFormat extends HoodieSparkWriterTestBase {
+     val df = Seq((1, "a1", 10, 1000, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       HoodieTableConfig.TABLE_FORMAT.key -> "test-format"
+     )
+ 
+@@ -534,7 +534,7 @@ class TestHoodieSparkSqlWriterWithTestFormat extends HoodieSparkWriterTestBase {
+     val df = Seq((1, "a1", 10, 1000, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "dt",
+       HoodieTableConfig.TABLE_FORMAT.key -> "test-format"
+     )
+@@ -567,7 +567,7 @@ class TestHoodieSparkSqlWriterWithTestFormat extends HoodieSparkWriterTestBase {
+     val df = Seq((1, "a1", 10, 1000, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "dt",
+       HoodieTableConfig.TABLE_FORMAT.key -> "test-format"
+     )
+@@ -600,7 +600,7 @@ class TestHoodieSparkSqlWriterWithTestFormat extends HoodieSparkWriterTestBase {
+     val df = Seq((1, "a1", 10, 1000, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "dt",
+       HoodieTableConfig.TABLE_FORMAT.key -> "test-format"
+     )
+@@ -658,7 +658,7 @@ class TestHoodieSparkSqlWriterWithTestFormat extends HoodieSparkWriterTestBase {
+     val df = Seq((1, "a1", 10, 1000, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       HoodieIndexConfig.BUCKET_INDEX_ENGINE_TYPE.key -> "CONSISTENT_HASHING",
+       HoodieIndexConfig.INDEX_TYPE.key -> "BUCKET",
+       HoodieTableConfig.TABLE_FORMAT.key -> "test-format"
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestInsertDedupPolicy.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestInsertDedupPolicy.scala
+index 62b02815e4901..376b38d6812da 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestInsertDedupPolicy.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestInsertDedupPolicy.scala
+@@ -21,6 +21,7 @@ package org.apache.hudi
+ 
+ import org.apache.hudi.DataSourceWriteOptions._
+ import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieReaderConfig}
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.config.{HoodieCompactionConfig, HoodieWriteConfig}
+ import org.apache.hudi.exception.HoodieUpsertException
+ import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+@@ -70,7 +71,7 @@ class TestInsertDedupPolicy extends SparkClientFunctionalTestHarness {
+     val inserts = spark.createDataFrame(firstInsertData).toDF(columns: _*)
+     inserts.write.format("hudi").
+       option(RECORDKEY_FIELD.key, "key").
+-      option(PRECOMBINE_FIELD.key, "ts").
++      option(HoodieTableConfig.ORDERING_FIELDS.key, "ts").
+       option(TABLE_TYPE.key, tableType).
+       option(DataSourceWriteOptions.TABLE_NAME.key, "test_table").
+       option(HoodieCompactionConfig.INLINE_COMPACT.key, "false").
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestParquetReaderCompatibility.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestParquetReaderCompatibility.scala
+index f9cf1a398d5e8..780e80b9e217f 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestParquetReaderCompatibility.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestParquetReaderCompatibility.scala
+@@ -23,7 +23,7 @@ import org.apache.hudi.TestParquetReaderCompatibility.NullabilityEnum.{NotNullab
+ import org.apache.hudi.client.common.HoodieSparkEngineContext
+ import org.apache.hudi.common.config.HoodieMetadataConfig
+ import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
+-import org.apache.hudi.common.table.ParquetTableSchemaResolver
++import org.apache.hudi.common.table.{HoodieTableConfig, ParquetTableSchemaResolver}
+ import org.apache.hudi.common.testutils.HoodieTestUtils
+ import org.apache.hudi.common.util.ConfigUtils.DEFAULT_HUDI_CONFIG_FOR_READER
+ import org.apache.hudi.config.HoodieWriteConfig
+@@ -202,7 +202,7 @@ class TestParquetReaderCompatibility extends HoodieSparkWriterTestBase {
+     val path = tempBasePath + "_avro_list_update"
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "key",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+       HoodieWriteConfig.TBL_NAME.key -> hoodieFooTableName,
+       "path" -> path
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
+index abcb98014f78a..d0de175ac5a8c 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
+@@ -239,7 +239,7 @@ class TestHoodieFileGroupReaderOnSpark extends TestHoodieFileGroupReaderBase[Int
+     val inserts = spark.createDataFrame(data).toDF(columns: _*)
+     inserts.write.format("hudi").
+       option(RECORDKEY_FIELD.key(), "key").
+-      option(PRECOMBINE_FIELD.key(), "ts").
++      option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts").
+       option(TABLE_TYPE.key(), tableType).
+       option(DataSourceWriteOptions.TABLE_NAME.key(), "test_table").
+       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestSpark35RecordPositionMetadataColumn.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestSpark35RecordPositionMetadataColumn.scala
+index fd06f0382e1e2..cbf37e0c6281c 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestSpark35RecordPositionMetadataColumn.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestSpark35RecordPositionMetadataColumn.scala
+@@ -23,6 +23,7 @@ import org.apache.hudi.{DataSourceWriteOptions, HoodieSparkUtils, SparkFileForma
+ import org.apache.hudi.SparkAdapterSupport.sparkAdapter
+ import org.apache.hudi.common.config.{HoodieReaderConfig, HoodieStorageConfig}
+ import org.apache.hudi.common.model.HoodieTableType
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.testutils.HoodieTestTable
+ import org.apache.hudi.common.util
+ import org.apache.hudi.config.HoodieWriteConfig
+@@ -56,7 +57,7 @@ class TestSpark35RecordPositionMetadataColumn extends SparkClientFunctionalTestH
+     // Create the file with record positions.
+     userToCountryDF.write.format("hudi")
+       .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "userid")
+-      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+       .option(HoodieWriteConfig.TBL_NAME.key, "user_to_country")
+       .option(HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key, SPARK_MERGER)
+       .option(HoodieWriteConfig.WRITE_RECORD_POSITIONS.key, "true")
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/CommonOptionUtils.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/CommonOptionUtils.scala
+index f88fb4ba2efb2..8510a2028ca21 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/CommonOptionUtils.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/CommonOptionUtils.scala
+@@ -35,7 +35,7 @@ object CommonOptionUtils {
+     HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.key() -> "true",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key -> "1"
+   )
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/HoodieStatsIndexTestBase.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/HoodieStatsIndexTestBase.scala
+index bf790e216ac05..d3b4122db2174 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/HoodieStatsIndexTestBase.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/HoodieStatsIndexTestBase.scala
+@@ -23,7 +23,7 @@ import org.apache.hudi.client.SparkRDDWriteClient
+ import org.apache.hudi.client.common.HoodieSparkEngineContext
+ import org.apache.hudi.common.config.TypedProperties
+ import org.apache.hudi.common.model.{ActionType, HoodieCommitMetadata, WriteOperationType}
+-import org.apache.hudi.common.table.HoodieTableMetaClient
++import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+ import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieInstantTimeGenerator, MetadataConversionUtils}
+ import org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR
+ import org.apache.hudi.config.HoodieWriteConfig
+@@ -53,7 +53,7 @@ class HoodieStatsIndexTestBase extends HoodieSparkClientTestBase {
+     "hoodie.upsert.shuffle.parallelism" -> "4",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     RECORDKEY_FIELD.key -> "_row_key",
+-    PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.MARKERS_TIMELINE_SERVER_BASED_BATCH_INTERVAL_MS.key -> "10"
+   )
+ 
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
+index 3fd94ad5cb3a4..95b30bbe6f20a 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
+@@ -59,7 +59,7 @@ class RecordLevelIndexTestBase extends HoodieStatsIndexTestBase {
+     RECORDKEY_FIELD.key -> "uuid",
+     SECONDARYKEY_COLUMN_NAME.key -> "city",
+     PARTITIONPATH_FIELD.key -> "state",
+-    PRECOMBINE_FIELD.key -> "ts",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+     HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"
+   ) ++ metadataOpts
+ 
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBasicSchemaEvolution.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBasicSchemaEvolution.scala
+index 5a0ade3dc0bc3..ced770865878a 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBasicSchemaEvolution.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBasicSchemaEvolution.scala
+@@ -54,7 +54,7 @@ class TestBasicSchemaEvolution extends HoodieSparkClientTestBase with ScalaAsser
+     HoodieWriteConfig.RECORD_MERGE_MODE.key() -> RecordMergeMode.COMMIT_TIME_ORDERING.name(),
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     HoodieMetadataConfig.ENABLE_METADATA_INDEX_PARTITION_STATS.key -> "true"
+   )
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBloomFiltersIndexSupport.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBloomFiltersIndexSupport.scala
+index fefc9f603ccf3..902071a411582 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBloomFiltersIndexSupport.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBloomFiltersIndexSupport.scala
+@@ -64,7 +64,7 @@ class TestBloomFiltersIndexSupport extends HoodieSparkClientTestBase {
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     RECORDKEY_FIELD.key -> "_row_key",
+     PARTITIONPATH_FIELD.key -> "partition",
+-    PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"
+   ) ++ metadataOpts
+   var mergedDfList: List[DataFrame] = List.empty
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+index 9c5d34d0960e0..70cba8e79d655 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+@@ -191,7 +191,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key() -> "timestamp,rider",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "timestamp,rider",
+       DataSourceWriteOptions.RECORD_MERGE_MODE.key() -> RecordMergeMode.EVENT_TIME_ORDERING.name(),
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+     )
+@@ -443,7 +443,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
+ 
+   @ParameterizedTest
+   @CsvSource(Array("hoodie.datasource.write.recordkey.field,begin_lat", "hoodie.datasource.write.partitionpath.field,end_lon",
+-    "hoodie.datasource.write.keygenerator.class,org.apache.hudi.keygen.NonpartitionedKeyGenerator", "hoodie.datasource.write.precombine.field,fare"))
++    "hoodie.datasource.write.keygenerator.class,org.apache.hudi.keygen.NonpartitionedKeyGenerator", "hoodie.datasource.write.precombine.fields,fare"))
+   def testAlteringRecordKeyConfig(configKey: String, configValue: String) {
+     val recordType = HoodieRecordType.AVRO
+     val (writeOpts, readOpts) = getWriterReaderOpts(recordType, Map(
+@@ -451,7 +451,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       "hoodie.bulkinsert.shuffle.parallelism" -> "2",
+       "hoodie.delete.shuffle.parallelism" -> "1",
+-      "hoodie.datasource.write.precombine.field" -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "timestamp",
+       HoodieMetadataConfig.ENABLE.key -> "false" // this is testing table configs and write configs. disabling metadata to save on test run time.
+     ))
+ 
+@@ -1535,7 +1535,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
+       .option("hoodie.bulkinsert.shuffle.parallelism", "2")
+       .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "id")
+       .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "data_date")
+-      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+       .option(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key, "org.apache.hudi.keygen.TimestampBasedKeyGenerator")
+       .option(TIMESTAMP_TYPE_FIELD.key, "DATE_STRING")
+       .option(TIMESTAMP_INPUT_DATE_FORMAT.key, "yyyy-MM-dd")
+@@ -1663,7 +1663,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
+       .options(writeOpts)
+       .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "uuid")
+       .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "partitionpath")
+-      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+       .option(HoodieWriteConfig.TBL_NAME.key, "hoodie_test")
+       .option(HoodieMetricsConfig.TURN_METRICS_ON.key(), "true")
+@@ -1792,7 +1792,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
+       DataSourceWriteOptions.TABLE_TYPE.key() -> "COPY_ON_WRITE",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key() -> "id",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key() -> "partition",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key() -> "precombine",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "precombine",
+       DataSourceWriteOptions.HIVE_STYLE_PARTITIONING.key() -> "true"
+     )
+ 
+@@ -1804,7 +1804,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
+       DataSourceWriteOptions.TABLE_TYPE.key() -> "COPY_ON_WRITE",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key() -> "id",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key() -> "partition",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key() -> "precombine"
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "precombine"
+     )
+ 
+     df.filter(df("id") === 1).
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSourceStorage.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSourceStorage.scala
+index cd77a5f6f674f..dfbd07cabe4a4 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSourceStorage.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSourceStorage.scala
+@@ -24,6 +24,7 @@ import org.apache.hudi.client.validator.{SqlQueryEqualityPreCommitValidator, Sql
+ import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieReaderConfig}
+ import org.apache.hudi.common.config.TimestampKeyGeneratorConfig.{TIMESTAMP_INPUT_DATE_FORMAT, TIMESTAMP_OUTPUT_DATE_FORMAT, TIMESTAMP_TYPE_FIELD}
+ import org.apache.hudi.common.model.WriteOperationType
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator
+ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+@@ -59,7 +60,7 @@ class TestCOWDataSourceStorage extends SparkClientFunctionalTestHarness {
+     "hoodie.delete.shuffle.parallelism" -> "1",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     DataSourceWriteOptions.HIVE_STYLE_PARTITIONING.key -> "false"
+   )
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+index 21dedc23d8636..1840c0307e9e0 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+@@ -87,7 +87,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+         HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+         DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+         RECORDKEY_FIELD.key -> "c1",
+-        PRECOMBINE_FIELD.key -> "c1",
++        HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+         HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+         "hoodie.compact.inline.max.delta.commits" -> "10",
+         HoodieWriteConfig.WRITE_TABLE_VERSION.key() -> testCase.tableVersion.toString
+@@ -212,7 +212,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       HoodieWriteConfig.WRITE_TABLE_VERSION.key() -> testCase.tableVersion.toString
+     ) ++ metadataOpts
+@@ -272,7 +272,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key -> partitionCol,
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key -> "5",
+@@ -389,7 +389,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key() -> partitionCol,
+       "hoodie.write.markers.type" -> "DIRECT",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+@@ -520,7 +520,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key() -> partitionCol,
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key() -> "5",
+@@ -577,7 +577,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key() -> partitionCol,
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key() -> "1",
+@@ -643,7 +643,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key() -> partitionCol,
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key() -> "1",
+@@ -712,7 +712,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name(),
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       HoodieWriteConfig.WRITE_TABLE_VERSION.key() -> tableVersion.toString
+     ) ++ metadataOpts
+@@ -763,7 +763,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key() -> "c8",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       HoodieCommonConfig.RECONCILE_SCHEMA.key -> "true",
+@@ -860,7 +860,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       HoodieCommonConfig.RECONCILE_SCHEMA.key -> "true",
+       HoodieWriteConfig.WRITE_TABLE_VERSION.key() -> tableVersion.toString
+@@ -975,7 +975,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       HoodieWriteConfig.WRITE_TABLE_VERSION.key() -> tableVersion.toString
+     ) ++ metadataOpts
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
+index f05c008361004..5c18aced12884 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
+@@ -67,7 +67,7 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
+       DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL
+@@ -91,7 +91,7 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
+       DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL
+@@ -328,7 +328,7 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
+       DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL,
+@@ -364,7 +364,7 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
+       DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL,
+@@ -404,7 +404,7 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
+       DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL,
+@@ -431,7 +431,7 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
+       DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL,
+@@ -466,7 +466,7 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
+       DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL,
+@@ -511,7 +511,7 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> tableName,
+       DataSourceWriteOptions.TABLE_TYPE.key -> "mor",
+       RECORDKEY_FIELD.key -> "id",
+-      PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
+       HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key() -> "20",
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
+index 7d6bbdbb6b7fb..7fe676065af87 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
+@@ -23,6 +23,7 @@ import org.apache.hudi.client.bootstrap.selector.{FullRecordBootstrapModeSelecto
+ import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieStorageConfig}
+ import org.apache.hudi.common.model.HoodieRecord
+ import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.table.timeline.{HoodieInstantTimeGenerator, HoodieTimeline}
+ import org.apache.hudi.config.{HoodieBootstrapConfig, HoodieClusteringConfig, HoodieCompactionConfig, HoodieWriteConfig}
+ import org.apache.hudi.functional.TestDataSourceForBootstrap.{dropMetaCols, sort}
+@@ -57,7 +58,7 @@ class TestDataSourceForBootstrap {
+     HoodieBootstrapConfig.PARALLELISM_VALUE.key -> "4",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "false"
+   )
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestEmptyCommit.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestEmptyCommit.scala
+index c9e1c970f98c4..e85e12e632646 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestEmptyCommit.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestEmptyCommit.scala
+@@ -18,6 +18,7 @@
+ package org.apache.hudi.functional
+ 
+ import org.apache.hudi.{DataSourceWriteOptions, HoodieDataSourceHelpers}
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.config.HoodieWriteConfig
+ import org.apache.hudi.testutils.HoodieSparkClientTestBase
+ 
+@@ -34,7 +35,7 @@ class TestEmptyCommit extends HoodieSparkClientTestBase {
+     "hoodie.upsert.shuffle.parallelism" -> "4",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   )
+ 
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieActiveTimeline.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieActiveTimeline.scala
+index 0e581fdbfbf1a..cf1a402079038 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieActiveTimeline.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieActiveTimeline.scala
+@@ -20,7 +20,7 @@ package org.apache.hudi.functional
+ import org.apache.hudi.{DataSourceWriteOptions, HoodieDataSourceHelpers}
+ import org.apache.hudi.client.WriteClientTestUtils
+ import org.apache.hudi.common.model.HoodieFileFormat
+-import org.apache.hudi.common.table.HoodieTableMetaClient
++import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+ import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
+ import org.apache.hudi.common.testutils.HoodieTestUtils
+ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+@@ -46,7 +46,7 @@ class TestHoodieActiveTimeline extends HoodieSparkClientTestBase {
+     "hoodie.upsert.shuffle.parallelism" -> "4",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   )
+ 
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieMultipleBaseFileFormat.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieMultipleBaseFileFormat.scala
+index bf34735786508..1dab17c13d4cc 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieMultipleBaseFileFormat.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieMultipleBaseFileFormat.scala
+@@ -50,7 +50,7 @@ class TestHoodieMultipleBaseFileFormat extends HoodieSparkClientTestBase with Sp
+     HoodieTableConfig.MULTIPLE_BASE_FILE_FORMATS_ENABLE.key -> "true",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   )
+   val sparkOpts = Map(
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadByStateTransitionTime.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadByStateTransitionTime.scala
+index 703138f0c7c15..498c5d3c6c214 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadByStateTransitionTime.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadByStateTransitionTime.scala
+@@ -20,6 +20,7 @@ package org.apache.hudi.functional
+ import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions}
+ import org.apache.hudi.common.config.HoodieMetadataConfig
+ import org.apache.hudi.common.model.HoodieTableType
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling.USE_TRANSITION_TIME
+ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+ import org.apache.hudi.config.HoodieWriteConfig
+@@ -41,7 +42,7 @@ class TestIncrementalReadByStateTransitionTime extends HoodieSparkClientTestBase
+     "hoodie.upsert.shuffle.parallelism" -> "4",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key -> "1"
+   )
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadWithFullTableScan.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadWithFullTableScan.scala
+index 985fd1f8de03b..615dd88257297 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadWithFullTableScan.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadWithFullTableScan.scala
+@@ -20,6 +20,7 @@ package org.apache.hudi.functional
+ import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions}
+ import org.apache.hudi.common.config.HoodieMetadataConfig
+ import org.apache.hudi.common.model.HoodieTableType
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieInstantTimeGenerator, InstantComparison}
+ import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator.instantTimeMinusMillis
+ import org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps
+@@ -70,7 +71,7 @@ class TestIncrementalReadWithFullTableScan extends HoodieSparkClientTestBase {
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key -> "1"
+     )
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLayoutOptimization.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLayoutOptimization.scala
+index 20db00f7d1bdd..00fc5a4dc82c2 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLayoutOptimization.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLayoutOptimization.scala
+@@ -21,6 +21,7 @@ package org.apache.hudi.functional
+ import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions}
+ import org.apache.hudi.HoodieFileIndex.DataSkippingFailureMode
+ import org.apache.hudi.common.config.HoodieMetadataConfig
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
+ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+ import org.apache.hudi.config.{HoodieClusteringConfig, HoodieWriteConfig}
+@@ -62,7 +63,7 @@ class TestLayoutOptimization extends HoodieSparkClientTestBase {
+     "hoodie.bulkinsert.shuffle.parallelism" -> "4",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key() -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key() -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key() -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key() -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   ) ++ metadataOpts
+ 
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
+index 9176369a4d67a..5e8ca57664c62 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
+@@ -69,7 +69,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
+     "hoodie.upsert.shuffle.parallelism" -> "4",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   )
+   val sparkOpts = Map(
+@@ -142,11 +142,11 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
+     var (writeOpts, _) = getWriterReaderOpts(writeType)
+     readOpts = readOpts ++ Map(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> logType)
+     writeOpts = writeOpts ++ Map(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> logType)
+-    readOpts = readOpts - DataSourceWriteOptions.PRECOMBINE_FIELD.key
++    readOpts = readOpts - HoodieTableConfig.ORDERING_FIELDS.key
+     if (!hasPreCombineField) {
+-      writeOpts = writeOpts - DataSourceWriteOptions.PRECOMBINE_FIELD.key
++      writeOpts = writeOpts - HoodieTableConfig.ORDERING_FIELDS.key
+     } else {
+-      writeOpts = writeOpts ++ Map(DataSourceWriteOptions.PRECOMBINE_FIELD.key ->
++      writeOpts = writeOpts ++ Map(HoodieTableConfig.ORDERING_FIELDS.key ->
+         (if (isNullOrEmpty(precombineField)) "" else precombineField))
+     }
+     if (!isNullOrEmpty(recordMergeMode)) {
+@@ -206,14 +206,14 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
+         Map(HoodieTableConfig.VERSION.key -> HoodieTableVersion.SIX.versionCode().toString)
+       } ++
+       (if (hasPreCombineField && !isNullOrEmpty(precombineField)) {
+-        Map(HoodieTableConfig.PRECOMBINE_FIELDS.key -> precombineField)
++        Map(HoodieTableConfig.ORDERING_FIELDS.key -> precombineField)
+       } else {
+         Map()
+       })).asJava
+     val nonExistentConfigs: java.util.List[String] = (if (hasPreCombineField) {
+       Seq[String]()
+     } else {
+-      Seq(HoodieTableConfig.PRECOMBINE_FIELDS.key)
++      Seq(HoodieTableConfig.ORDERING_FIELDS.key)
+     }).asJava
+     HoodieTestUtils.validateTableConfig(storage, basePath, expectedConfigs, nonExistentConfigs)
+     val commit1CompletionTime = if (
+@@ -773,7 +773,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
+       .option(PAYLOAD_CLASS_NAME.key, classOf[DefaultHoodieRecordPayload].getCanonicalName)
+       .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL)
+       .option(RECORDKEY_FIELD.key, "id")
+-      .option(PRECOMBINE_FIELD.key, "version")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key, "version")
+       .option(PARTITIONPATH_FIELD.key, "")
+       .mode(SaveMode.Append)
+       .save(basePath)
+@@ -1144,7 +1144,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.OPERATION.key() -> DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
+       DataSourceWriteOptions.TABLE_TYPE.key()-> DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL,
+@@ -1186,7 +1186,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.OPERATION.key() -> DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
+       DataSourceWriteOptions.TABLE_TYPE.key() -> DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL,
+@@ -1330,7 +1330,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
+     val options = Map[String, String](
+       DataSourceWriteOptions.TABLE_TYPE.key -> HoodieTableType.MERGE_ON_READ.name,
+       DataSourceWriteOptions.OPERATION.key -> UPSERT_OPERATION_OPT_VAL,
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> precombineField,
++      HoodieTableConfig.ORDERING_FIELDS.key -> precombineField,
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> recordKeyField,
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "",
+       DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> "org.apache.hudi.keygen.NonpartitionedKeyGenerator",
+@@ -1428,7 +1428,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
+     val options = Map[String, String](
+       DataSourceWriteOptions.TABLE_TYPE.key -> HoodieTableType.MERGE_ON_READ.name,
+       DataSourceWriteOptions.OPERATION.key -> UPSERT_OPERATION_OPT_VAL,
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> precombineField,
++      HoodieTableConfig.ORDERING_FIELDS.key -> precombineField,
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> recordKeyField,
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "",
+       DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> "org.apache.hudi.keygen.NonpartitionedKeyGenerator",
+@@ -1741,7 +1741,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key() -> "timestamp,rider",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "timestamp,rider",
+       DataSourceWriteOptions.RECORD_MERGE_MODE.key() -> RecordMergeMode.EVENT_TIME_ORDERING.name(),
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+     )
+@@ -1934,7 +1934,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
+     Map(
+       // Don't override table name - let fixture table configuration take precedence
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",         // Fixture uses 'id' as record key
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",        // Fixture uses 'ts' as precombine field
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",        // Fixture uses 'ts' as precombine field
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition", // Fixture uses 'partition' as partition field
+       "hoodie.upsert.shuffle.parallelism" -> "2",
+       "hoodie.insert.shuffle.parallelism" -> "2"
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSourceStorage.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSourceStorage.scala
+index 487ec0f1418cf..2a8163dd3b6f4 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSourceStorage.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSourceStorage.scala
+@@ -69,7 +69,7 @@ class TestMORDataSourceStorage extends SparkClientFunctionalTestHarness {
+       "hoodie.delete.shuffle.parallelism" -> "1",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition_path",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       HoodieWriteConfig.MARKERS_TIMELINE_SERVER_BASED_BATCH_INTERVAL_MS.key -> "10"
+     )
+@@ -79,7 +79,7 @@ class TestMORDataSourceStorage extends SparkClientFunctionalTestHarness {
+     var options: Map[String, String] = commonOpts +
+       (HoodieMetadataConfig.ENABLE.key -> String.valueOf(isMetadataEnabled))
+     if (!StringUtils.isNullOrEmpty(preCombineField)) {
+-      options += (DataSourceWriteOptions.PRECOMBINE_FIELD.key() -> preCombineField)
++      options += (HoodieTableConfig.ORDERING_FIELDS.key() -> preCombineField)
+     }
+     if (useFileGroupReader) {
+       options += (HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key() -> String.valueOf(useFileGroupReader))
+@@ -155,7 +155,7 @@ class TestMORDataSourceStorage extends SparkClientFunctionalTestHarness {
+       HoodieWriteConfig.WRITE_RECORD_POSITIONS.key -> "true",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition_path",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+     )
+ 
+@@ -207,7 +207,7 @@ class TestMORDataSourceStorage extends SparkClientFunctionalTestHarness {
+       HoodieWriteConfig.WRITE_RECORD_POSITIONS.key -> writeRecordPosition.toString,
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+       DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> classOf[NonpartitionedKeyGenerator].getName,
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       HoodieIndexConfig.INDEX_TYPE.key -> (if (enableNBCC) BUCKET.name else SIMPLE.name),
+       HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key() -> classOf[InProcessLockProvider].getName,
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSourceWithBucketIndex.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSourceWithBucketIndex.scala
+index e88cc35b36ce3..718a12518f65a 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSourceWithBucketIndex.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSourceWithBucketIndex.scala
+@@ -18,6 +18,7 @@
+ package org.apache.hudi.functional
+ 
+ import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieDataSourceHelpers}
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator
+ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+ import org.apache.hudi.config.{HoodieIndexConfig, HoodieLayoutConfig, HoodieWriteConfig}
+@@ -45,7 +46,7 @@ class TestMORDataSourceWithBucketIndex extends HoodieSparkClientTestBase {
+     "hoodie.bulkinsert.shuffle.parallelism" -> "2",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     HoodieIndexConfig.INDEX_TYPE.key -> IndexType.BUCKET.name,
+     HoodieIndexConfig.BUCKET_INDEX_NUM_BUCKETS.key -> "8",
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataRecordIndex.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataRecordIndex.scala
+index e1ece6d88ecb2..3e386e7f029a9 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataRecordIndex.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataRecordIndex.scala
+@@ -56,7 +56,7 @@ class TestMetadataRecordIndex extends HoodieSparkClientTestBase {
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     RECORDKEY_FIELD.key -> "_row_key",
+     PARTITIONPATH_FIELD.key -> "partition",
+-    PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"
+   ) ++ metadataOpts
+   var mergedDfList: List[DataFrame] = List.empty
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
+index 59f24a0ad173b..5bbcbe0ce0791 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
+@@ -23,7 +23,7 @@ import org.apache.hudi.avro.HoodieAvroUtils
+ import org.apache.hudi.client.common.HoodieSparkEngineContext
+ import org.apache.hudi.common.config.HoodieMetadataConfig
+ import org.apache.hudi.common.model.HoodieColumnRangeMetadata
+-import org.apache.hudi.common.table.HoodieTableMetaClient
++import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+ import org.apache.hudi.common.table.timeline.HoodieTimeline
+ import org.apache.hudi.common.table.view.FileSystemViewManager
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator
+@@ -62,7 +62,7 @@ class TestMetadataTableWithSparkDataSource extends SparkClientFunctionalTestHarn
+     "hoodie.bulkinsert.shuffle.parallelism" -> "2",
+     "hoodie.delete.shuffle.parallelism" -> "1",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   )
+ 
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetricsReporter.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetricsReporter.scala
+index 5f6b86662af34..a41fe883b8466 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetricsReporter.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetricsReporter.scala
+@@ -20,6 +20,7 @@ package org.apache.hudi.functional
+ import org.apache.hudi.{DataSourceWriteOptions, SparkDatasetMixin}
+ import org.apache.hudi.HoodieConversionUtils.toJavaOption
+ import org.apache.hudi.common.config.HoodieMetadataConfig
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+ import org.apache.hudi.common.util.Option
+ import org.apache.hudi.config.HoodieWriteConfig
+@@ -48,7 +49,7 @@ class TestMetricsReporter extends HoodieSparkClientTestBase with SparkDatasetMix
+     "hoodie.upsert.shuffle.parallelism" -> "4",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   )
+ 
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestParquetColumnProjection.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestParquetColumnProjection.scala
+index 3be899b43e4ac..8784e254ea5d0 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestParquetColumnProjection.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestParquetColumnProjection.scala
+@@ -50,7 +50,7 @@ class TestParquetColumnProjection extends SparkClientFunctionalTestHarness with
+     "hoodie.bulkinsert.shuffle.parallelism" -> "2",
+     "hoodie.delete.shuffle.parallelism" -> "1",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     HoodieMetadataConfig.ENABLE.key -> "true"
+     // NOTE: It's critical that we use non-partitioned table, since the way we track amount of bytes read
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartialUpdateAvroPayload.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartialUpdateAvroPayload.scala
+index 98ff000262239..ec5dd8dabf03d 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartialUpdateAvroPayload.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartialUpdateAvroPayload.scala
+@@ -23,6 +23,7 @@ import org.apache.hudi.HoodieConversionUtils.toJavaOption
+ import org.apache.hudi.QuickstartUtils.{convertToStringList, getQuickstartWriteConfigs}
+ import org.apache.hudi.common.config.{HoodieReaderConfig, RecordMergeMode}
+ import org.apache.hudi.common.model.HoodieTableType
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.util.Option
+ import org.apache.hudi.config.HoodieWriteConfig
+ import org.apache.hudi.testutils.HoodieClientTestBase
+@@ -85,7 +86,7 @@ class TestPartialUpdateAvroPayload extends HoodieClientTestBase {
+       .option(DataSourceWriteOptions.TABLE_TYPE.key(), hoodieTableType.name())
+       .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "uuid")
+       .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "partitionpath")
+-      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+       .option(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key, "org.apache.hudi.common.model.PartialUpdateAvroPayload")
+       .option(HoodieWriteConfig.RECORD_MERGE_MODE.key(), RecordMergeMode.CUSTOM.name())
+@@ -118,7 +119,7 @@ class TestPartialUpdateAvroPayload extends HoodieClientTestBase {
+       .option(DataSourceWriteOptions.TABLE_TYPE.key(), hoodieTableType.name())
+       .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "uuid")
+       .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "partitionpath")
+-      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
+       .option(HoodieWriteConfig.TBL_NAME.key, "hoodie_test")
+       .option(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key, "org.apache.hudi.common.model.PartialUpdateAvroPayload")
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndexWithSql.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndexWithSql.scala
+index d58b5d81e8c2e..dd23cdd13e5fa 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndexWithSql.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndexWithSql.scala
+@@ -146,7 +146,7 @@ class TestPartitionStatsIndexWithSql extends HoodieSparkSqlTestBase {
+         val properties = metaClient.getTableConfig.getProps.asScala.toMap
+         assertResult(true)(properties.contains(HoodieTableConfig.CREATE_SCHEMA.key))
+         assertResult("dt")(properties(HoodieTableConfig.PARTITION_FIELDS.key))
+-        assertResult("ts")(properties(HoodieTableConfig.PRECOMBINE_FIELDS.key))
++        assertResult("ts")(properties(HoodieTableConfig.ORDERING_FIELDS.key))
+         assertResult(tableName)(metaClient.getTableConfig.getTableName)
+         // Validate partition_stats index exists
+         assertTrue(metaClient.getTableConfig.getMetadataPartitions.contains(PARTITION_STATS.getPartitionPath))
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsPruning.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsPruning.scala
+index 26f9aa71ab311..c961b5ff93cd6 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsPruning.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsPruning.scala
+@@ -58,7 +58,7 @@ class TestPartitionStatsPruning extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key() -> "c8",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"
+     ) ++ metadataOpts
+@@ -87,7 +87,7 @@ class TestPartitionStatsPruning extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key() -> "c8",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       "hoodie.compact.inline.max.delta.commits" -> "10"
+@@ -195,7 +195,7 @@ class TestPartitionStatsPruning extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key -> partitionCol,
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key -> "3"
+@@ -306,7 +306,7 @@ class TestPartitionStatsPruning extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key() -> partitionCol,
+       "hoodie.write.markers.type" -> "DIRECT",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionedRecordLevelIndex.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionedRecordLevelIndex.scala
+index d3a02ab4debbc..a9ec4d984ad64 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionedRecordLevelIndex.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionedRecordLevelIndex.scala
+@@ -27,7 +27,7 @@ import org.apache.hudi.common.config.{HoodieMetadataConfig, TypedProperties}
+ import org.apache.hudi.common.data.HoodieListData
+ import org.apache.hudi.common.fs.FSUtils
+ import org.apache.hudi.common.model.{HoodieRecordGlobalLocation, HoodieTableType}
+-import org.apache.hudi.common.table.TableSchemaResolver
++import org.apache.hudi.common.table.{HoodieTableConfig, TableSchemaResolver}
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator
+ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+ import org.apache.hudi.common.util.{Option => HOption}
+@@ -69,7 +69,7 @@ class TestPartitionedRecordLevelIndex extends RecordLevelIndexTestBase {
+       DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name(),
+       RECORDKEY_FIELD.key -> "_row_key",
+       PARTITIONPATH_FIELD.key -> "data_partition_path",
+-      PRECOMBINE_FIELD.key -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+       HoodieMetadataConfig.RECORD_INDEX_ENABLE_PROP.key()-> "false",
+       HoodieMetadataConfig.PARTITIONED_RECORD_INDEX_ENABLE_PROP.key() -> "true",
+       HoodieMetadataConfig.STREAMING_WRITE_ENABLED.key() -> streamingWriteEnabled.toString,
+@@ -342,7 +342,7 @@ class TestPartitionedRecordLevelIndex extends RecordLevelIndexTestBase {
+       DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name(),
+       RECORDKEY_FIELD.key -> "_row_key",
+       PARTITIONPATH_FIELD.key -> "data_partition_path",
+-      PRECOMBINE_FIELD.key -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+       HoodieMetadataConfig.RECORD_INDEX_ENABLE_PROP.key()-> "false",
+       HoodieMetadataConfig.SECONDARY_INDEX_ENABLE_PROP.key() -> "false",
+       HoodieMetadataConfig.STREAMING_WRITE_ENABLED.key() -> streamingWriteEnabled.toString,
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
+index 647ee6868df5c..27be7429af2c2 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
+@@ -52,7 +52,7 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
+     val inserts = spark.createDataFrame(data).toDF(columns: _*)
+     inserts.write.format("hudi").
+       option(RECORDKEY_FIELD.key(), "key").
+-      option(PRECOMBINE_FIELD.key(), "ts").
++      option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts").
+       option(TABLE_TYPE.key(), tableType).
+       option(DataSourceWriteOptions.TABLE_NAME.key(), "test_table").
+       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
+index f412b696174cf..a1af34331cdb3 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
+@@ -27,7 +27,7 @@ import org.apache.hudi.client.transaction.SimpleConcurrentFileWritesConflictReso
+ import org.apache.hudi.client.transaction.lock.InProcessLockProvider
+ import org.apache.hudi.common.config.{HoodieMetadataConfig, RecordMergeMode, TypedProperties}
+ import org.apache.hudi.common.model._
+-import org.apache.hudi.common.table.HoodieTableMetaClient
++import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+ import org.apache.hudi.common.table.timeline.HoodieInstant
+ import org.apache.hudi.common.table.view.HoodieTableFileSystemView
+ import org.apache.hudi.common.testutils.HoodieTestUtils
+@@ -76,7 +76,7 @@ class TestSecondaryIndexPruning extends SparkClientFunctionalTestHarness {
+     RECORDKEY_FIELD.key -> "record_key_col",
+     PARTITIONPATH_FIELD.key -> "partition_key_col",
+     HIVE_STYLE_PARTITIONING.key -> "true",
+-    PRECOMBINE_FIELD.key -> "ts",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+     HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key() -> "org.apache.hudi.common.model.OverwriteWithLatestAvroPayload",
+     DataSourceWriteOptions.RECORD_MERGE_MODE.key() -> RecordMergeMode.COMMIT_TIME_ORDERING.name()
+   ) ++ metadataOpts
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSevenToEightUpgrade.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSevenToEightUpgrade.scala
+index 92d920f90e094..231c4b303e967 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSevenToEightUpgrade.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSevenToEightUpgrade.scala
+@@ -107,7 +107,7 @@ class TestSevenToEightUpgrade extends RecordLevelIndexTestBase {
+       assertEquals(RecordMergeMode.COMMIT_TIME_ORDERING.name, metaClient.getTableConfig.getRecordMergeMode.name)
+       assertEquals(HoodieRecordMerger.COMMIT_TIME_BASED_MERGE_STRATEGY_UUID, metaClient.getTableConfig.getRecordMergeStrategyId)
+     } else {
+-      if (metaClient.getTableConfig.getPreCombineFieldsStr.isPresent && StringUtils.isNullOrEmpty(metaClient.getTableConfig.getPreCombineFieldsStr.get())) {
++      if (metaClient.getTableConfig.getOrderingFieldsStr.isPresent && StringUtils.isNullOrEmpty(metaClient.getTableConfig.getOrderingFieldsStr.get())) {
+         assertEquals(classOf[OverwriteWithLatestAvroPayload].getName, metaClient.getTableConfig.getPayloadClass)
+         assertEquals(RecordMergeMode.COMMIT_TIME_ORDERING.name, metaClient.getTableConfig.getRecordMergeMode.name)
+         assertEquals(HoodieRecordMerger.COMMIT_TIME_BASED_MERGE_STRATEGY_UUID, metaClient.getTableConfig.getRecordMergeStrategyId)
+@@ -133,7 +133,7 @@ class TestSevenToEightUpgrade extends RecordLevelIndexTestBase {
+     val hudiOptions = Map[String, String](
+       "hoodie.table.name" -> tableName,
+       RECORDKEY_FIELD.key -> "id",
+-      PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       TABLE_TYPE.key -> HoodieTableType.MERGE_ON_READ.name(),
+       OPERATION.key -> UPSERT_OPERATION_OPT_VAL,
+       KEYGENERATOR_CLASS_NAME.key -> classOf[NonpartitionedKeyGenerator].getName,
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkDataSource.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkDataSource.scala
+index d891ed7c302b2..4dcbede1ca716 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkDataSource.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkDataSource.scala
+@@ -23,6 +23,7 @@ import org.apache.hudi.{AvroConversionUtils, DataSourceReadOptions, DataSourceWr
+ import org.apache.hudi.common.config.{HoodieMetadataConfig, RecordMergeMode}
+ import org.apache.hudi.common.model.{HoodieRecord, HoodieTableType}
+ import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator
+ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+ import org.apache.hudi.config.{HoodieCompactionConfig, HoodieIndexConfig, HoodieWriteConfig}
+@@ -55,7 +56,7 @@ class TestSparkDataSource extends SparkClientFunctionalTestHarness {
+     "hoodie.bulkinsert.shuffle.parallelism" -> s"$parallelism",
+     "hoodie.delete.shuffle.parallelism" -> s"$parallelism",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   )
+ 
+@@ -312,7 +313,7 @@ class TestSparkDataSource extends SparkClientFunctionalTestHarness {
+     var (writeOpts, readOpts) = getWriterReaderOpts(HoodieRecordType.AVRO)
+     writeOpts = writeOpts ++ Map("hoodie.write.table.version" -> tableVersion.toString,
+       "hoodie.datasource.write.table.type" -> tableType.name(),
+-      "hoodie.datasource.write.precombine.field" -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "ts",
+       "hoodie.write.record.merge.mode" -> mergeMode.name(),
+       "hoodie.index.type" -> indexType.name(),
+       "hoodie.metadata.record.index.enable" -> "true",
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkDataSourceDAGExecution.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkDataSourceDAGExecution.scala
+index 0255b22c77e92..2410dd8df505f 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkDataSourceDAGExecution.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkDataSourceDAGExecution.scala
+@@ -56,7 +56,7 @@ class TestSparkDataSourceDAGExecution extends HoodieSparkClientTestBase with Sca
+     HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.key() -> "true",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     HoodieMetadataConfig.ENABLE.key -> "false"
+   )
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlWithCustomKeyGenerator.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlWithCustomKeyGenerator.scala
+index 712b66c84cbc1..5672d4e95f11d 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlWithCustomKeyGenerator.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlWithCustomKeyGenerator.scala
+@@ -625,7 +625,7 @@ class TestSparkSqlWithCustomKeyGenerator extends HoodieSparkSqlTestBase {
+       .option("hoodie.datasource.write.keygenerator.class", keyGenClassName)
+       .option("hoodie.datasource.write.partitionpath.field", writePartitionFields)
+       .option("hoodie.datasource.write.recordkey.field", "id")
+-      .option("hoodie.datasource.write.precombine.field", "name")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key(), "name")
+       .option("hoodie.table.name", tableName)
+       .option("hoodie.insert.shuffle.parallelism", "1")
+       .option("hoodie.upsert.shuffle.parallelism", "1")
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamSourceReadByStateTransitionTime.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamSourceReadByStateTransitionTime.scala
+index d61963f365b80..e364f046dc21a 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamSourceReadByStateTransitionTime.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamSourceReadByStateTransitionTime.scala
+@@ -23,7 +23,7 @@ import org.apache.hudi.client.{SparkRDDWriteClient, WriteClientTestUtils}
+ import org.apache.hudi.client.common.HoodieSparkEngineContext
+ import org.apache.hudi.common.engine.EngineType
+ import org.apache.hudi.common.model.{HoodieFailedWritesCleaningPolicy, HoodieRecord, HoodieTableType}
+-import org.apache.hudi.common.table.HoodieTableMetaClient
++import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator
+ import org.apache.hudi.common.testutils.HoodieTestTable.makeNewCommitTime
+ import org.apache.hudi.config.{HoodieCleanConfig, HoodieWriteConfig}
+@@ -39,7 +39,7 @@ class TestStreamSourceReadByStateTransitionTime extends StreamTest  {
+ 
+   protected val commonOptions: Map[String, String] = Map(
+     RECORDKEY_FIELD.key -> "id",
+-    PRECOMBINE_FIELD.key -> "ts",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+     INSERT_PARALLELISM_VALUE.key -> "4",
+     UPSERT_PARALLELISM_VALUE.key -> "4",
+     DELETE_PARALLELISM_VALUE.key -> "4",
+@@ -64,7 +64,7 @@ class TestStreamSourceReadByStateTransitionTime extends StreamTest  {
+         HoodieTableMetaClient.newTableBuilder()
+           .setTableType(tableType)
+           .setTableName(s"test_stream_${tableType.name()}")
+-          .setPreCombineFields("timestamp")
++          .setOrderingFields("timestamp")
+           .setPartitionFields("partition_path")
+           .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
+ 
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
+index 5915f93f1a0d2..45d112b0ed3e5 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
+@@ -22,7 +22,7 @@ import org.apache.hudi.DataSourceReadOptions.{START_OFFSET, STREAMING_READ_TABLE
+ import org.apache.hudi.DataSourceWriteOptions.{PRECOMBINE_FIELD, RECORDKEY_FIELD}
+ import org.apache.hudi.common.model.HoodieTableType
+ import org.apache.hudi.common.model.HoodieTableType.{COPY_ON_WRITE, MERGE_ON_READ}
+-import org.apache.hudi.common.table.{HoodieTableMetaClient, HoodieTableVersion}
++import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, HoodieTableVersion}
+ import org.apache.hudi.common.table.timeline.HoodieTimeline
+ import org.apache.hudi.config.{HoodieClusteringConfig, HoodieCompactionConfig}
+ import org.apache.hudi.config.HoodieWriteConfig.{DELETE_PARALLELISM_VALUE, INSERT_PARALLELISM_VALUE, TBL_NAME, UPSERT_PARALLELISM_VALUE, WRITE_TABLE_VERSION}
+@@ -38,7 +38,7 @@ class TestStreamingSource extends StreamTest {
+   import testImplicits._
+   protected val commonOptions: Map[String, String] = Map(
+     RECORDKEY_FIELD.key -> "id",
+-    PRECOMBINE_FIELD.key -> "ts",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+     INSERT_PARALLELISM_VALUE.key -> "4",
+     UPSERT_PARALLELISM_VALUE.key -> "4",
+     DELETE_PARALLELISM_VALUE.key -> "4"
+@@ -61,7 +61,7 @@ class TestStreamingSource extends StreamTest {
+         .setTableType(COPY_ON_WRITE)
+         .setTableName(getTableName(tablePath))
+         .setRecordKeyFields("id")
+-        .setPreCombineFields("ts")
++        .setOrderingFields("ts")
+         .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
+ 
+       addData(tablePath, Seq(("1", "a1", "10", "000")))
+@@ -112,7 +112,7 @@ class TestStreamingSource extends StreamTest {
+         .setTableType(MERGE_ON_READ)
+         .setTableName(getTableName(tablePath))
+         .setRecordKeyFields("id")
+-        .setPreCombineFields("ts")
++        .setOrderingFields("ts")
+         .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
+ 
+       addData(tablePath, Seq(("1", "a1", "10", "000")))
+@@ -157,7 +157,7 @@ class TestStreamingSource extends StreamTest {
+         .setTableType(COPY_ON_WRITE)
+         .setTableName(getTableName(tablePath))
+         .setRecordKeyFields("id")
+-        .setPreCombineFields("ts")
++        .setOrderingFields("ts")
+         .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
+ 
+       addData(tablePath, Seq(("1", "a1", "10", "000")))
+@@ -188,7 +188,7 @@ class TestStreamingSource extends StreamTest {
+         .setTableType(COPY_ON_WRITE)
+         .setTableName(getTableName(tablePath))
+         .setRecordKeyFields("id")
+-        .setPreCombineFields("ts")
++        .setOrderingFields("ts")
+         .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
+ 
+       addData(tablePath, Seq(("1", "a1", "10", "000")))
+@@ -220,7 +220,7 @@ class TestStreamingSource extends StreamTest {
+         .setTableType(MERGE_ON_READ)
+         .setTableName(getTableName(tablePath))
+         .setRecordKeyFields("id")
+-        .setPreCombineFields("ts")
++        .setOrderingFields("ts")
+         .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
+ 
+       addData(tablePath, Seq(("1", "a1", "10", "000")))
+@@ -262,7 +262,7 @@ class TestStreamingSource extends StreamTest {
+           .setTableType(MERGE_ON_READ)
+           .setTableName(getTableName(tablePath))
+           .setRecordKeyFields("id")
+-          .setPreCombineFields("ts")
++          .setOrderingFields("ts")
+           .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
+ 
+         addData(tablePath, Seq(("1", "a1", "10", "000")))
+@@ -305,7 +305,7 @@ class TestStreamingSource extends StreamTest {
+         .setTableName(getTableName(tablePath))
+         .setTableVersion(writeTableVersion)
+         .setRecordKeyFields("id")
+-        .setPreCombineFields("ts")
++        .setOrderingFields("ts")
+         .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
+ 
+       // Add initial data
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala
+index 56b77919bd224..1025e43b9bdfb 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala
+@@ -23,7 +23,7 @@ import org.apache.hudi.HoodieStreamingSink.SINK_CHECKPOINT_KEY
+ import org.apache.hudi.client.transaction.lock.InProcessLockProvider
+ import org.apache.hudi.common.config.HoodieStorageConfig
+ import org.apache.hudi.common.model.{FileSlice, HoodieTableType, WriteConcurrencyMode}
+-import org.apache.hudi.common.table.HoodieTableMetaClient
++import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+ import org.apache.hudi.common.table.timeline.HoodieTimeline
+ import org.apache.hudi.common.testutils.{HoodieTestDataGenerator, HoodieTestTable, HoodieTestUtils}
+ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+@@ -60,7 +60,7 @@ class TestStructuredStreaming extends HoodieSparkClientTestBase {
+     "hoodie.upsert.shuffle.parallelism" -> "4",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   )
+ 
+@@ -526,7 +526,7 @@ class TestStructuredStreaming extends HoodieSparkClientTestBase {
+       DataSourceWriteOptions.TABLE_TYPE.key() -> tableType,
+       DataSourceWriteOptions.RECORD_MERGE_MODE.key() -> mergeMode,
+       HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key() -> "parquet",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "weight")
++      HoodieTableConfig.ORDERING_FIELDS.key -> "weight")
+     if (mergeMode == "CUSTOM") {
+       opts = opts ++ Map(DataSourceWriteOptions.RECORD_MERGE_STRATEGY_ID.key() -> HoodieSparkDeleteRecordMerger.DELETE_MERGER_STRATEGY,
+         DataSourceWriteOptions.RECORD_MERGE_IMPL_CLASSES.key() -> classOf[HoodieSparkDeleteRecordMerger].getName)
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestTimeTravelQuery.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestTimeTravelQuery.scala
+index 7f95db48d8bd2..93c80f9479206 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestTimeTravelQuery.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestTimeTravelQuery.scala
+@@ -21,7 +21,7 @@ import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, ScalaAsse
+ import org.apache.hudi.common.config.HoodieMetadataConfig
+ import org.apache.hudi.common.model.{HoodieCleaningPolicy, HoodieTableType}
+ import org.apache.hudi.common.model.HoodieTableType.{COPY_ON_WRITE, MERGE_ON_READ}
+-import org.apache.hudi.common.table.TableSchemaResolver
++import org.apache.hudi.common.table.{HoodieTableConfig, TableSchemaResolver}
+ import org.apache.hudi.common.table.timeline.TimelineUtils
+ import org.apache.hudi.common.testutils.HoodieTestTable
+ import org.apache.hudi.config.{HoodieArchivalConfig, HoodieCleanConfig, HoodieCompactionConfig, HoodieWriteConfig}
+@@ -46,7 +46,7 @@ class TestTimeTravelQuery extends HoodieSparkClientTestBase with ScalaAssertionS
+     "hoodie.bulkinsert.shuffle.parallelism" -> "2",
+     "hoodie.delete.shuffle.parallelism" -> "1",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "version",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "version",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   )
+ 
+@@ -177,7 +177,7 @@ class TestTimeTravelQuery extends HoodieSparkClientTestBase with ScalaAssertionS
+     val opts = commonOpts ++ Map(
+       DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name,
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "version",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "version",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "dt"
+     )
+ 
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/HoodieCDCTestBase.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/HoodieCDCTestBase.scala
+index 6f13c9257bd3e..0694f582f9037 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/HoodieCDCTestBase.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/HoodieCDCTestBase.scala
+@@ -54,7 +54,7 @@ abstract class HoodieCDCTestBase extends HoodieSparkClientTestBase {
+     "hoodie.bulkinsert.shuffle.parallelism" -> "2",
+     "hoodie.delete.shuffle.parallelism" -> "1",
+     RECORDKEY_FIELD.key -> "_row_key",
+-    PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key -> "1",
+     HoodieCleanConfig.AUTO_CLEAN.key -> "false",
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCDataFrameSuite.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCDataFrameSuite.scala
+index 1416470fec40d..ae09b9a96ff5b 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCDataFrameSuite.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCDataFrameSuite.scala
+@@ -643,7 +643,7 @@ class TestCDCDataFrameSuite extends HoodieCDCTestBase {
+     val options = Map(
+       "hoodie.table.name" -> "test",
+       "hoodie.datasource.write.recordkey.field" -> "id",
+-      "hoodie.datasource.write.precombine.field" -> "replicadmstimestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "replicadmstimestamp",
+       "hoodie.datasource.write.keygenerator.class" -> "org.apache.hudi.keygen.NonpartitionedKeyGenerator",
+       "hoodie.datasource.write.partitionpath.field" -> "",
+       "hoodie.datasource.write.payload.class" -> "org.apache.hudi.common.model.AWSDmsAvroPayload",
+@@ -702,7 +702,7 @@ class TestCDCDataFrameSuite extends HoodieCDCTestBase {
+       "hoodie.bulkinsert.shuffle.parallelism" -> "2",
+       "hoodie.delete.shuffle.parallelism" -> "1",
+       "hoodie.datasource.write.recordkey.field" -> "_row_key",
+-      "hoodie.datasource.write.precombine.field" -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "timestamp",
+       "hoodie.table.name" -> ("hoodie_test" + loggingMode.name()),
+       "hoodie.clean.automatic" -> "true",
+       "hoodie.clean.commits.retained" -> "1"
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCStreamingSuite.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCStreamingSuite.scala
+index 4ba1eb76b739e..d39ba79c9f0db 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCStreamingSuite.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCStreamingSuite.scala
+@@ -70,7 +70,7 @@ class TestCDCStreamingSuite extends HoodieCDCTestBase {
+       .option(HoodieTableConfig.CDC_ENABLED.key, "true")
+       .option(HoodieTableConfig.CDC_SUPPLEMENTAL_LOGGING_MODE.key, loggingMode.name())
+       .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "userid")
+-      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+       .option(HoodieWriteConfig.TBL_NAME.key, "user_to_country")
+       .save(userToCountryTblPath)
+ 
+@@ -82,7 +82,7 @@ class TestCDCStreamingSuite extends HoodieCDCTestBase {
+     countryToPopulationDF.write.format("hudi")
+       .options(commonOptions)
+       .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "country")
+-      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+       .option(HoodieWriteConfig.TBL_NAME.key, "country_to_population")
+       .save(countryToPopulationTblPath)
+ 
+@@ -98,7 +98,7 @@ class TestCDCStreamingSuite extends HoodieCDCTestBase {
+           .options(commonOptions)
+           .option(HoodieTableConfig.CDC_ENABLED.key, "true")
+           .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "userid")
+-          .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(HoodieWriteConfig.TBL_NAME.key, "user_to_country")
+           .mode(SaveMode.Append)
+           .save(userToCountryTblPath)
+@@ -147,7 +147,7 @@ class TestCDCStreamingSuite extends HoodieCDCTestBase {
+           .write.format("hudi")
+           .options(commonOptions)
+           .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "country")
+-          .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(HoodieWriteConfig.TBL_NAME.key, "country_to_population")
+           .mode(SaveMode.Append)
+           .save(countryToPopulationTblPath)
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieOptionConfig.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieOptionConfig.scala
+index daadfb6a37679..e6d1e9282bf63 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieOptionConfig.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieOptionConfig.scala
+@@ -59,7 +59,7 @@ class TestHoodieOptionConfig extends SparkClientFunctionalTestHarness {
+ 
+     assertTrue(tableConfigs.size == 5)
+     assertTrue(tableConfigs(HoodieTableConfig.RECORDKEY_FIELDS.key) == "id,addr")
+-    assertTrue(tableConfigs(HoodieTableConfig.PRECOMBINE_FIELDS.key) == "timestamp")
++    assertTrue(tableConfigs(HoodieTableConfig.ORDERING_FIELDS.key) == "timestamp")
+     assertTrue(tableConfigs(HoodieTableConfig.TYPE.key) == "MERGE_ON_READ")
+     assertTrue(tableConfigs("hoodie.index.type") == "INMEMORY")
+     assertTrue(tableConfigs("hoodie.compact.inline") == "true")
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTableDropPartition.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTableDropPartition.scala
+index 57d79f8c13825..c8aafefb46614 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTableDropPartition.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTableDropPartition.scala
+@@ -20,6 +20,7 @@ package org.apache.spark.sql.hudi.ddl
+ import org.apache.hudi.{DataSourceWriteOptions, HoodieCLIUtils}
+ import org.apache.hudi.avro.model.{HoodieCleanMetadata, HoodieCleanPartitionMetadata}
+ import org.apache.hudi.common.model.{HoodieCleaningPolicy, HoodieCommitMetadata}
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.table.timeline.HoodieInstant
+ import org.apache.hudi.common.util.{Option => HOption, PartitionPathEncodeUtils, StringUtils}
+ import org.apache.hudi.config.{HoodieCleanConfig, HoodieWriteConfig}
+@@ -121,7 +122,7 @@ class TestAlterTableDropPartition extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+           .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL)
+           .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "id")
+-          .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "dt")
+           .option(DataSourceWriteOptions.URL_ENCODE_PARTITIONING.key(), urlencode)
+           .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")
+@@ -140,7 +141,7 @@ class TestAlterTableDropPartition extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+           .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL)
+           .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "id")
+-          .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "dt")
+           .option(DataSourceWriteOptions.URL_ENCODE_PARTITIONING.key(), urlencode)
+           .option(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key, classOf[SimpleKeyGenerator].getName)
+@@ -199,7 +200,7 @@ class TestAlterTableDropPartition extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+           .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL)
+           .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "id")
+-          .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "dt")
+           .option(DataSourceWriteOptions.URL_ENCODE_PARTITIONING.key(), urlencode)
+           .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")
+@@ -305,7 +306,7 @@ class TestAlterTableDropPartition extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+           .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL)
+           .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "id")
+-          .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "year,month,day")
+           .option(DataSourceWriteOptions.HIVE_STYLE_PARTITIONING.key, hiveStyle)
+           .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")
+@@ -329,7 +330,7 @@ class TestAlterTableDropPartition extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+           .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL)
+           .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "id")
+-          .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "year,month,day")
+           .option(DataSourceWriteOptions.HIVE_STYLE_PARTITIONING.key, hiveStyle)
+           .option(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key, classOf[ComplexKeyGenerator].getName)
+@@ -385,7 +386,7 @@ class TestAlterTableDropPartition extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+           .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL)
+           .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "id")
+-          .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "year,month,day")
+           .option(DataSourceWriteOptions.HIVE_STYLE_PARTITIONING.key, hiveStyle)
+           .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")
+@@ -409,7 +410,7 @@ class TestAlterTableDropPartition extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+           .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL)
+           .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "id")
+-          .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "year,month,day")
+           .option(DataSourceWriteOptions.HIVE_STYLE_PARTITIONING.key, hiveStyle)
+           .option(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key, classOf[ComplexKeyGenerator].getName)
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+index 6c9d57e8c175b..a0c24c5bfc386 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+@@ -139,7 +139,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
+     assertResult(true)(tableConfig.contains(HoodieTableConfig.CREATE_SCHEMA.key))
+     assertResult("dt")(tableConfig(HoodieTableConfig.PARTITION_FIELDS.key))
+     assertResult("id")(tableConfig(HoodieTableConfig.RECORDKEY_FIELDS.key))
+-    assertResult("ts")(tableConfig(HoodieTableConfig.PRECOMBINE_FIELDS.key))
++    assertResult("ts")(tableConfig(HoodieTableConfig.ORDERING_FIELDS.key))
+     assertResult(KeyGeneratorType.SIMPLE.name())(tableConfig(HoodieTableConfig.KEY_GENERATOR_TYPE.key))
+     assertResult("default")(tableConfig(HoodieTableConfig.DATABASE_NAME.key()))
+     assertResult(tableName)(tableConfig(HoodieTableConfig.NAME.key()))
+@@ -877,7 +877,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, s"original_$tableName")
+           .option(TABLE_TYPE.key, COW_TABLE_TYPE_OPT_VAL)
+           .option(RECORDKEY_FIELD.key, "id")
+-          .option(PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(PARTITIONPATH_FIELD.key, "dt")
+           .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")
+           .option(HoodieWriteConfig.UPSERT_PARALLELISM_VALUE.key, "1")
+@@ -907,7 +907,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
+         val properties = metaClient.getTableConfig.getProps.asScala.toMap
+         assertResult(true)(properties.contains(HoodieTableConfig.CREATE_SCHEMA.key))
+         assertResult("dt")(properties(HoodieTableConfig.PARTITION_FIELDS.key))
+-        assertResult("ts")(properties(HoodieTableConfig.PRECOMBINE_FIELDS.key))
++        assertResult("ts")(properties(HoodieTableConfig.ORDERING_FIELDS.key))
+         assertResult("hudi_database")(metaClient.getTableConfig.getDatabaseName)
+         assertResult(s"original_$tableName")(metaClient.getTableConfig.getTableName)
+ 
+@@ -956,7 +956,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+           .option(TABLE_TYPE.key, MOR_TABLE_TYPE_OPT_VAL)
+           .option(RECORDKEY_FIELD.key, "id")
+-          .option(PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(PARTITIONPATH_FIELD.key, "day,hh")
+           .option(URL_ENCODE_PARTITIONING.key, "true")
+           .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")
+@@ -978,7 +978,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
+         val properties = metaClient.getTableConfig.getProps.asScala.toMap
+         assertResult(true)(properties.contains(HoodieTableConfig.CREATE_SCHEMA.key))
+         assertResult("day,hh")(properties(HoodieTableConfig.PARTITION_FIELDS.key))
+-        assertResult("ts")(properties(HoodieTableConfig.PRECOMBINE_FIELDS.key))
++        assertResult("ts")(properties(HoodieTableConfig.ORDERING_FIELDS.key))
+ 
+         val escapedPathPart = escapePathName(day)
+ 
+@@ -1025,7 +1025,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
+         .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+         .option(TABLE_TYPE.key, COW_TABLE_TYPE_OPT_VAL)
+         .option(RECORDKEY_FIELD.key, "id")
+-        .option(PRECOMBINE_FIELD.key, "ts")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+         .option(PARTITIONPATH_FIELD.key, "")
+         .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")
+         .option(HoodieWriteConfig.UPSERT_PARALLELISM_VALUE.key, "1")
+@@ -1045,7 +1045,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
+       val metaClient = createMetaClient(spark, tmp.getCanonicalPath)
+       val properties = metaClient.getTableConfig.getProps.asScala.toMap
+       assertResult(true)(properties.contains(HoodieTableConfig.CREATE_SCHEMA.key))
+-      assertResult("ts")(properties(HoodieTableConfig.PRECOMBINE_FIELDS.key))
++      assertResult("ts")(properties(HoodieTableConfig.ORDERING_FIELDS.key))
+ 
+       // Test insert into
+       spark.sql(s"insert into $tableName values(2, 'a2', 10, 1000)")
+@@ -1448,13 +1448,13 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
+              | tblproperties (
+              |  hoodie.table.recordkey.fields ='id',
+              |  hoodie.table.type = '$tableType',
+-             |  hoodie.table.precombine.field = 'ts'
++             |  hoodie.table.ordering.fields = 'ts'
+              | )
+        """.stripMargin)
+         val hoodieCatalogTable = HoodieCatalogTable(spark, TableIdentifier(tableName))
+         assertResult(Array("id"))(hoodieCatalogTable.primaryKeys)
+         assertResult(tableType)(hoodieCatalogTable.tableTypeName)
+-        assertResult(java.util.Collections.singletonList[String]("ts"))(hoodieCatalogTable.preCombineKeys)
++        assertResult(java.util.Collections.singletonList[String]("ts"))(hoodieCatalogTable.orderingFields)
+       }
+     }
+   }
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestRepairTable.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestRepairTable.scala
+index ebbdc1a6a1c00..3b60c2cef6d4e 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestRepairTable.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestRepairTable.scala
+@@ -20,6 +20,7 @@
+ package org.apache.spark.sql.hudi.ddl
+ 
+ import org.apache.hudi.DataSourceWriteOptions.{PARTITIONPATH_FIELD, PRECOMBINE_FIELD, RECORDKEY_FIELD}
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.table.HoodieTableConfig.HIVE_STYLE_PARTITIONING_ENABLE
+ import org.apache.hudi.config.HoodieWriteConfig.TBL_NAME
+ 
+@@ -85,7 +86,7 @@ class TestRepairTable extends HoodieSparkSqlTestBase {
+           .toDF("id", "name", "ts", "dt", "hh")
+         df.write.format("hudi")
+           .option(RECORDKEY_FIELD.key, "id")
+-          .option(PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(PARTITIONPATH_FIELD.key, "dt,hh")
+           .option(HIVE_STYLE_PARTITIONING_ENABLE.key, hiveStylePartitionEnable)
+           .mode(SaveMode.Append)
+@@ -111,7 +112,7 @@ class TestRepairTable extends HoodieSparkSqlTestBase {
+         df.write.format("hudi")
+           .option(TBL_NAME.key(), tableName)
+           .option(RECORDKEY_FIELD.key, "id")
+-          .option(PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(PARTITIONPATH_FIELD.key, "dt,hh")
+           .option(HIVE_STYLE_PARTITIONING_ENABLE.key, hiveStylePartitionEnable)
+           .mode(SaveMode.Append)
+@@ -162,7 +163,7 @@ class TestRepairTable extends HoodieSparkSqlTestBase {
+         df1.write.format("hudi")
+           .option(TBL_NAME.key(), tableName)
+           .option(RECORDKEY_FIELD.key, "id")
+-          .option(PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(PARTITIONPATH_FIELD.key, "dt")
+           .option(HIVE_STYLE_PARTITIONING_ENABLE.key, hiveStylePartitionEnable)
+           .mode(SaveMode.Append)
+@@ -177,7 +178,7 @@ class TestRepairTable extends HoodieSparkSqlTestBase {
+         df2.write.format("hudi")
+           .option(TBL_NAME.key(), tableName)
+           .option(RECORDKEY_FIELD.key, "id")
+-          .option(PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(PARTITIONPATH_FIELD.key, "dt")
+           .option(HIVE_STYLE_PARTITIONING_ENABLE.key, hiveStylePartitionEnable)
+           .mode(SaveMode.Overwrite)
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestSpark3DDL.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestSpark3DDL.scala
+index df3382b356dec..5585d49603ca5 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestSpark3DDL.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestSpark3DDL.scala
+@@ -21,7 +21,7 @@ import org.apache.hudi.{DataSourceWriteOptions, DefaultSparkRecordMerger, Quicks
+ import org.apache.hudi.common.config.{HoodieReaderConfig, HoodieStorageConfig}
+ import org.apache.hudi.common.model.{HoodieRecord, HoodieTableType}
+ import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
+-import org.apache.hudi.common.table.TableSchemaResolver
++import org.apache.hudi.common.table.{HoodieTableConfig, TableSchemaResolver}
+ import org.apache.hudi.common.table.timeline.HoodieInstant
+ import org.apache.hudi.common.testutils.{HoodieTestDataGenerator, RawTripTestPayload}
+ import org.apache.hudi.config.HoodieWriteConfig
+@@ -205,7 +205,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
+         val df = spark.createDataFrame(rowRdd, structType)
+         df.write.format("hudi")
+           .option("hoodie.datasource.write.recordkey.field", "id")
+-          .option("hoodie.datasource.write.precombine.field", "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts")
+           .option("hoodie.datasource.write.partitionpath.field", "partition")
+           .option("hoodie.table.name", tableName)
+           .option("hoodie.datasource.write.table.type", tableType.name())
+@@ -224,7 +224,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
+         val df2 = spark.createDataFrame(rowRdd2, structType)
+         df2.write.format("hudi")
+           .option("hoodie.datasource.write.recordkey.field", "id")
+-          .option("hoodie.datasource.write.precombine.field", "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts")
+           .option("hoodie.datasource.write.partitionpath.field", "partition")
+           .option("hoodie.table.name", tableName)
+           .option("hoodie.datasource.write.table.type", tableType.name())
+@@ -250,7 +250,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
+         val df3 = spark.createDataFrame(rowRdd3, structType3)
+         df3.write.format("hudi")
+           .option("hoodie.datasource.write.recordkey.field", "id")
+-          .option("hoodie.datasource.write.precombine.field", "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts")
+           .option("hoodie.datasource.write.partitionpath.field", "partition")
+           .option("hoodie.table.name", tableName)
+           .option("hoodie.datasource.write.table.type", tableType.name())
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestTruncateTable.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestTruncateTable.scala
+index 3d290d589e249..247161d2f50b1 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestTruncateTable.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestTruncateTable.scala
+@@ -20,6 +20,7 @@
+ package org.apache.spark.sql.hudi.ddl
+ 
+ import org.apache.hudi.DataSourceWriteOptions._
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.config.HoodieWriteConfig
+ 
+ import org.apache.spark.sql.SaveMode
+@@ -73,7 +74,7 @@ class TestTruncateTable extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+           .option(TABLE_TYPE.key, MOR_TABLE_TYPE_OPT_VAL)
+           .option(RECORDKEY_FIELD.key, "id")
+-          .option(PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(PARTITIONPATH_FIELD.key, "dt")
+           .option(URL_ENCODE_PARTITIONING.key(), urlencode)
+           .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")
+@@ -114,7 +115,7 @@ class TestTruncateTable extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+           .option(TABLE_TYPE.key, COW_TABLE_TYPE_OPT_VAL)
+           .option(RECORDKEY_FIELD.key, "id")
+-          .option(PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(PARTITIONPATH_FIELD.key, "year,month,day")
+           .option(HIVE_STYLE_PARTITIONING.key, hiveStyle)
+           .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/insert/TestInsertTable.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/insert/TestInsertTable.scala
+index da6a44ef4865e..9001995712c68 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/insert/TestInsertTable.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/insert/TestInsertTable.scala
+@@ -1168,7 +1168,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
+             .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+             .option(TABLE_TYPE.key, COW_TABLE_TYPE_OPT_VAL)
+             .option(RECORDKEY_FIELD.key, "id")
+-            .option(PRECOMBINE_FIELD.key, "ts")
++            .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+             .option(HoodieWriteConfig.BULKINSERT_PARALLELISM_VALUE.key, "1")
+             // test specific settings
+             .option(OPERATION.key, WriteOperationType.BULK_INSERT.value)
+@@ -1492,7 +1492,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
+         .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+         .option(TABLE_TYPE.key, MOR_TABLE_TYPE_OPT_VAL)
+         .option(RECORDKEY_FIELD.key, "id")
+-        .option(PRECOMBINE_FIELD.key, "ts")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+         .option(PARTITIONPATH_FIELD.key, "day,hh")
+         .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")
+         .option(HoodieWriteConfig.UPSERT_PARALLELISM_VALUE.key, "1")
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestDeleteTable.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestDeleteTable.scala
+index 0e7223b35fbdd..06f0a77e93f38 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestDeleteTable.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestDeleteTable.scala
+@@ -20,6 +20,7 @@
+ package org.apache.spark.sql.hudi.dml.others
+ 
+ import org.apache.hudi.DataSourceWriteOptions._
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.config.HoodieWriteConfig
+ 
+ import org.apache.spark.sql.SaveMode
+@@ -337,7 +338,7 @@ class TestDeleteTable extends HoodieSparkSqlTestBase {
+             .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+             .option(TABLE_TYPE.key, MOR_TABLE_TYPE_OPT_VAL)
+             .option(RECORDKEY_FIELD.key, "id")
+-            .option(PRECOMBINE_FIELD.key, "ts")
++            .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+             .option(PARTITIONPATH_FIELD.key, "dt")
+             .option(URL_ENCODE_PARTITIONING.key(), urlencode)
+             .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeCommitTimeOrdering.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeCommitTimeOrdering.scala
+index 2b359d483ba0f..60c2626e3ab77 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeCommitTimeOrdering.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeCommitTimeOrdering.scala
+@@ -75,12 +75,12 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
+         HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key -> COMMIT_TIME_BASED_MERGE_STRATEGY_UUID)
+     }
+     val nonExistentConfigs = if (tableVersion.toInt == 6) {
+-      Seq(HoodieTableConfig.RECORD_MERGE_MODE.key, HoodieTableConfig.PRECOMBINE_FIELDS.key)
++      Seq(HoodieTableConfig.RECORD_MERGE_MODE.key, HoodieTableConfig.ORDERING_FIELDS.key)
+     } else {
+       if (setRecordMergeConfigs) {
+         Seq()
+       } else {
+-        Seq(HoodieTableConfig.PRECOMBINE_FIELDS.key)
++        Seq(HoodieTableConfig.ORDERING_FIELDS.key)
+       }
+     }
+ 
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeEventTimeOrdering.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeEventTimeOrdering.scala
+index 572eaa82744b4..d9d3282dc316c 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeEventTimeOrdering.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeEventTimeOrdering.scala
+@@ -71,12 +71,12 @@ class TestMergeModeEventTimeOrdering extends HoodieSparkSqlTestBase {
+       Map(
+         HoodieTableConfig.VERSION.key -> "6",
+         HoodieTableConfig.PAYLOAD_CLASS_NAME.key -> classOf[DefaultHoodieRecordPayload].getName,
+-        HoodieTableConfig.PRECOMBINE_FIELDS.key -> "ts"
++        HoodieTableConfig.ORDERING_FIELDS.key -> "ts"
+       )
+     } else {
+       Map(
+         HoodieTableConfig.VERSION.key -> String.valueOf(HoodieTableVersion.current().versionCode()),
+-        HoodieTableConfig.PRECOMBINE_FIELDS.key -> "ts",
++        HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+         HoodieTableConfig.RECORD_MERGE_MODE.key -> EVENT_TIME_ORDERING.name(),
+         HoodieTableConfig.PAYLOAD_CLASS_NAME.key -> classOf[DefaultHoodieRecordPayload].getName,
+         HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key -> EVENT_TIME_BASED_MERGE_STRATEGY_UUID)
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestExpressionIndex.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestExpressionIndex.scala
+index 230895caf4fb7..2d8361a77ba67 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestExpressionIndex.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestExpressionIndex.scala
+@@ -29,7 +29,7 @@ import org.apache.hudi.client.utils.SparkMetadataWriterUtils
+ import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieStorageConfig, TypedProperties}
+ import org.apache.hudi.common.fs.FSUtils
+ import org.apache.hudi.common.model.{FileSlice, HoodieIndexDefinition}
+-import org.apache.hudi.common.table.{HoodieTableMetaClient, HoodieTableVersion}
++import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, HoodieTableVersion}
+ import org.apache.hudi.common.table.view.{FileSystemViewManager, HoodieTableFileSystemView}
+ import org.apache.hudi.common.testutils.HoodieTestUtils
+ import org.apache.hudi.common.util.Option
+@@ -1984,7 +1984,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
+         "hoodie.upsert.shuffle.parallelism" -> "4",
+         HoodieWriteConfig.TBL_NAME.key -> tableName,
+         RECORDKEY_FIELD.key -> "c1",
+-        PRECOMBINE_FIELD.key -> "c1",
++        HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+         PARTITIONPATH_FIELD.key() -> "c8",
+         "hoodie.metadata.index.column.stats.enable" -> "false"
+       )
+@@ -2070,7 +2070,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
+         HoodieWriteConfig.TBL_NAME.key -> tableName,
+         TABLE_TYPE.key -> "MERGE_ON_READ",
+         RECORDKEY_FIELD.key -> "c1",
+-        PRECOMBINE_FIELD.key -> "c1",
++        HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+         PARTITIONPATH_FIELD.key() -> "c8",
+         // setting IndexType to be INMEMORY to simulate Global Index nature
+         HoodieIndexConfig.INDEX_TYPE.key -> HoodieIndex.IndexType.INMEMORY.name(),
+@@ -2142,7 +2142,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "testGetExpressionIndexRecordsUsingBloomFilter",
+       TABLE_TYPE.key -> "MERGE_ON_READ",
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key() -> "c8",
+       // setting IndexType to be INMEMORY to simulate Global Index nature
+       HoodieIndexConfig.INDEX_TYPE.key -> HoodieIndex.IndexType.INMEMORY.name()
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/testHoodieBackedTableMetadataIndexLookup.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestHoodieBackedTableMetadataIndexLookup.scala
+similarity index 99%
+rename from hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/testHoodieBackedTableMetadataIndexLookup.scala
+rename to hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestHoodieBackedTableMetadataIndexLookup.scala
+index 88a2c13436ed1..6371fb7925ad9 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/testHoodieBackedTableMetadataIndexLookup.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestHoodieBackedTableMetadataIndexLookup.scala
+@@ -24,7 +24,7 @@ import org.apache.hudi.client.common.HoodieSparkEngineContext
+ import org.apache.hudi.common.data.{HoodieListData, HoodiePairData}
+ import org.apache.hudi.common.engine.EngineType
+ import org.apache.hudi.common.model.HoodieRecordLocation
+-import org.apache.hudi.common.table.HoodieTableMetaClient
++import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator
+ import org.apache.hudi.common.util.HoodieDataUtils
+ import org.apache.hudi.config.HoodieWriteConfig
+@@ -179,7 +179,7 @@ abstract class HoodieBackedTableMetadataIndexLookupTestBase extends HoodieSparkS
+       "hoodie.insert.shuffle.parallelism" -> "4",
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       HoodieWriteConfig.TBL_NAME.key -> tableName,
+       DataSourceWriteOptions.OPERATION.key -> DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL
+     )
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestSecondaryIndex.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestSecondaryIndex.scala
+index aedd18e0ead34..232fa431f5ee2 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestSecondaryIndex.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestSecondaryIndex.scala
+@@ -23,7 +23,7 @@ import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieSpa
+ import org.apache.hudi.DataSourceWriteOptions._
+ import org.apache.hudi.common.config.{HoodieMetadataConfig, RecordMergeMode}
+ import org.apache.hudi.common.model.WriteOperationType
+-import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
++import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, TableSchemaResolver}
+ import org.apache.hudi.common.testutils.{HoodieTestDataGenerator, HoodieTestUtils}
+ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+ import org.apache.hudi.config.{HoodieClusteringConfig, HoodieCompactionConfig, HoodieWriteConfig}
+@@ -53,7 +53,7 @@ class TestSecondaryIndex extends HoodieSparkSqlTestBase {
+     "hoodie.upsert.shuffle.parallelism" -> "4",
+     RECORDKEY_FIELD.key -> "_row_key",
+     PARTITIONPATH_FIELD.key -> "partition_path",
+-    PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieClusteringConfig.INLINE_CLUSTERING.key -> "true",
+     HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key -> "4",
+     HoodieCompactionConfig.INLINE_COMPACT.key() -> "true",
+@@ -1174,7 +1174,7 @@ class TestSecondaryIndex extends HoodieSparkSqlTestBase {
+           .option("hoodie.table.name", tableName)
+           .option("hoodie.datasource.write.table.type", "COPY_ON_WRITE")
+           .option("hoodie.datasource.write.recordkey.field", "id")
+-          .option("hoodie.datasource.write.precombine.field", "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts")
+           .option("hoodie.datasource.write.operation", "upsert")
+           .option("hoodie.schema.on.read.enable", "true")
+           .mode("append")
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestBootstrapProcedure.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestBootstrapProcedure.scala
+index 6f81377b22aeb..78dae86cdf3f1 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestBootstrapProcedure.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestBootstrapProcedure.scala
+@@ -246,7 +246,7 @@ class TestBootstrapProcedure extends HoodieSparkProcedureTestBase {
+       }
+ 
+       spark.sql("set hoodie.bootstrap.parallelism = 20")
+-      spark.sql("set hoodie.datasource.write.precombine.field=timestamp")
++      spark.sql("set hoodie.datasource.write.precombine.fields=timestamp")
+       spark.sql("set hoodie.metadata.index.column.stats.enable = false")
+ 
+       checkAnswer(
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRepairsProcedure.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRepairsProcedure.scala
+index a5e9e56fb81d0..d36b41ae48f1d 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRepairsProcedure.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRepairsProcedure.scala
+@@ -149,7 +149,7 @@ class TestRepairsProcedure extends HoodieSparkProcedureTestBase {
+           |[hoodie.table.initial.version,$tableVersion,$tableVersion]
+           |[hoodie.table.keygenerator.type,NON_PARTITION,null]
+           |[hoodie.table.name,,]
+-          |[hoodie.table.precombine.field,ts,null]
++          |[hoodie.table.ordering.fields,ts,null]
+           |[hoodie.table.recordkey.fields,id,null]
+           |[hoodie.table.type,COPY_ON_WRITE,COPY_ON_WRITE]
+           |[hoodie.table.version,,]
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestTTLProcedure.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestTTLProcedure.scala
+index 0c4fb7a29b884..39a6deb6f59f8 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestTTLProcedure.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestTTLProcedure.scala
+@@ -31,7 +31,7 @@ import org.apache.hudi.config.HoodieWriteConfig
+ 
+ import org.apache.spark.api.java.JavaSparkContext
+ 
+-import java.util.Properties
++import java.util.{Collections, Properties}
+ 
+ import scala.collection.JavaConverters._
+ 
+@@ -114,7 +114,6 @@ class TestTTLProcedure extends HoodieSparkProcedureTestBase with SparkDatasetMix
+       .newBuilder
+       .withPath(basePath)
+       .withSchema(TRIP_EXAMPLE_SCHEMA)
+-      .withPreCombineField("_row_key")
+       .forTable(tableName)
+-
++      .withProps(Collections.singletonMap(HoodieTableConfig.ORDERING_FIELDS.key(), "_row_key"))
+ }
+diff --git a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/processor/maxwell/MaxwellJsonKafkaSourcePostProcessor.java b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/processor/maxwell/MaxwellJsonKafkaSourcePostProcessor.java
+index 50fd71c949f85..73ff2fc9ce25e 100644
+--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/processor/maxwell/MaxwellJsonKafkaSourcePostProcessor.java
++++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/processor/maxwell/MaxwellJsonKafkaSourcePostProcessor.java
+@@ -20,9 +20,9 @@
+ 
+ import org.apache.hudi.common.config.TypedProperties;
+ import org.apache.hudi.common.model.HoodieRecord;
++import org.apache.hudi.common.util.ConfigUtils;
+ import org.apache.hudi.common.util.DateTimeUtils;
+ import org.apache.hudi.common.util.Option;
+-import org.apache.hudi.config.HoodieWriteConfig;
+ import org.apache.hudi.utilities.config.JsonKafkaPostProcessorConfig;
+ import org.apache.hudi.utilities.exception.HoodieSourcePostProcessException;
+ import org.apache.hudi.utilities.sources.processor.JsonKafkaSourcePostProcessor;
+@@ -124,7 +124,7 @@ private String processDelete(JsonNode inputJson, ObjectNode result) {
+ 
+     // we can update the `update_time`(delete time) only when it is in timestamp format.
+     if (!preCombineFieldType.equals(NON_TIMESTAMP)) {
+-      String preCombineField = this.props.getString(HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key(), null);
++      String preCombineField = ConfigUtils.getOrderingFieldsStrDuringWrite(props);
+ 
+       // ts from maxwell
+       long ts = inputJson.get(TS).longValue();
+diff --git a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BootstrapExecutor.java b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BootstrapExecutor.java
+index a5ea67823f5b0..cd0948ed4703d 100644
+--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BootstrapExecutor.java
++++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BootstrapExecutor.java
+@@ -59,7 +59,6 @@
+ import static org.apache.hudi.common.table.HoodieTableConfig.POPULATE_META_FIELDS;
+ import static org.apache.hudi.common.table.HoodieTableConfig.TIMELINE_HISTORY_PATH;
+ import static org.apache.hudi.common.table.HoodieTableConfig.TIMELINE_TIMEZONE;
+-import static org.apache.hudi.config.HoodieWriteConfig.PRECOMBINE_FIELD_NAME;
+ import static org.apache.hudi.config.HoodieWriteConfig.WRITE_TABLE_VERSION;
+ import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_BUCKET_SYNC;
+ import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_BUCKET_SYNC_SPEC;
+@@ -207,7 +206,7 @@ private void initializeTable() throws IOException {
+         .setTableType(cfg.tableType)
+         .setTableName(cfg.targetTableName)
+         .setRecordKeyFields(props.getString(RECORDKEY_FIELD_NAME.key()))
+-        .setPreCombineFields(props.getString(PRECOMBINE_FIELD_NAME.key(), null))
++        .setOrderingFields(ConfigUtils.getOrderingFieldsStrDuringWrite(props))
+         .setTableVersion(ConfigUtils.getIntWithAltKeys(props, WRITE_TABLE_VERSION))
+         .setTableFormat(props.getString(HoodieTableConfig.TABLE_FORMAT.key(), HoodieTableConfig.TABLE_FORMAT.defaultValue()))
+         .setPopulateMetaFields(props.getBoolean(
+diff --git a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
+index 02b189e382f4d..f3693a9dae384 100644
+--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
++++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
+@@ -272,8 +272,8 @@ public static class Config implements Serializable {
+             + "JsonKafkaSource, AvroKafkaSource, HiveIncrPullSource}")
+     public String sourceClassName = JsonDFSSource.class.getName();
+ 
+-    @Parameter(names = {"--source-ordering-field"}, description = "Comma separated list of fields within source record to decide how"
+-        + " to break ties between records with same key in input data.")
++    @Parameter(names = {"--source-ordering-fields", "--source-ordering-field"}, description = "Comma separated list of fields within source record to decide how"
++        + " to break ties between records with same key in input data. --source-ordering-field is deprecated, please use --source-ordering-fields instead")
+     public String sourceOrderingFields = null;
+ 
+     @Parameter(names = {"--payload-class"}, description = "Deprecated. "
+diff --git a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+index a8d5c2a0907a0..894b7c70b0be1 100644
+--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
++++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+@@ -444,7 +444,7 @@ HoodieTableMetaClient initializeEmptyTable(HoodieTableMetaClient.TableBuilder ta
+         .setPopulateMetaFields(props.getBoolean(HoodieTableConfig.POPULATE_META_FIELDS.key(),
+             HoodieTableConfig.POPULATE_META_FIELDS.defaultValue()))
+         .setKeyGeneratorClassProp(keyGenClassName)
+-        .setPreCombineFields(cfg.sourceOrderingFields)
++        .setOrderingFields(cfg.sourceOrderingFields)
+         .setPartitionMetafileUseBaseFormat(props.getBoolean(HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.key(),
+             HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.defaultValue()))
+         .setCDCEnabled(props.getBoolean(HoodieTableConfig.CDC_ENABLED.key(),
+diff --git a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
+index 4d88ef28bd070..b305469f44227 100644
+--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
++++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
+@@ -34,6 +34,7 @@
+ import org.apache.hudi.common.model.HoodieLogFile;
+ import org.apache.hudi.common.model.HoodieRecord;
+ import org.apache.hudi.common.model.WriteOperationType;
++import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.common.table.HoodieTableMetaClient;
+ import org.apache.hudi.common.table.log.HoodieLogFormat;
+ import org.apache.hudi.common.table.log.block.HoodieAvroDataBlock;
+@@ -191,7 +192,7 @@ public void testMetadataTableValidation(String viewStorageTypeForFSListing, Stri
+     writeOptions.put(DataSourceWriteOptions.TABLE_NAME().key(), "test_table");
+     writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), "MERGE_ON_READ");
+     writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+-    writeOptions.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++    writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     writeOptions.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition_path");
+ 
+     Dataset<Row> inserts = makeInsertDf("000", 5).cache();
+@@ -250,7 +251,7 @@ void missingLogFileFailsValidation() throws Exception {
+     writeOptions.put("hoodie.table.name", "test_table");
+     writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), "MERGE_ON_READ");
+     writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+-    writeOptions.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++    writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     writeOptions.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition_path");
+ 
+     Dataset<Row> inserts = makeInsertDf("000", 5).cache();
+@@ -314,7 +315,7 @@ public void testSecondaryIndexValidation() throws Exception {
+               + "hoodie.metadata.record.index.enable = 'true', "
+               + "hoodie.datasource.write.recordkey.field = 'record_key_col', "
+               + "hoodie.enable.data.skipping = 'true', "
+-              + "hoodie.datasource.write.precombine.field = 'ts', "
++              + "hoodie.datasource.write.precombine.fields = 'ts', "
+               + "hoodie.datasource.write.payload.class = 'org.apache.hudi.common.model.OverwriteWithLatestAvroPayload'"
+               + ") "
+               + "partitioned by(partition_key_col) "
+@@ -365,7 +366,7 @@ public void testGetFSSecondaryKeyToRecordKeys() throws Exception {
+               + "hoodie.metadata.record.index.enable = 'true', "
+               + "hoodie.datasource.write.recordkey.field = 'record_key_col', "
+               + "hoodie.enable.data.skipping = 'true', "
+-              + "hoodie.datasource.write.precombine.field = 'ts'"
++              + "hoodie.datasource.write.precombine.fields = 'ts'"
+               + ") "
+               + "partitioned by(partition_key_col) "
+               + "location '" + basePath + "'");
+@@ -417,7 +418,7 @@ public void testColumnStatsValidation(String tableType) {
+     writeOptions.put("hoodie.table.name", "test_table");
+     writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), tableType);
+     writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+-    writeOptions.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++    writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     writeOptions.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition_path");
+     writeOptions.put(HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key(), "true");
+ 
+@@ -449,7 +450,7 @@ public void testPartitionStatsValidation(String tableType) throws Exception {
+       writeOptions.put("hoodie.table.name", "test_table");
+       writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), tableType);
+       writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+-      writeOptions.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++      writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+       writeOptions.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition_path");
+       writeOptions.put(HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key(), "true");
+ 
+@@ -517,7 +518,7 @@ public void testAdditionalPartitionsinMDT(boolean testFailureCase) throws IOExce
+     writeOptions.put(DataSourceWriteOptions.TABLE_NAME().key(), "test_table");
+     writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), "MERGE_ON_READ");
+     writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+-    writeOptions.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++    writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     writeOptions.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition_path");
+ 
+     // constructor of HoodieMetadataValidator instantiates HoodieTableMetaClient. hence creating an actual table. but rest of tests is mocked.
+@@ -598,7 +599,7 @@ public void testAdditionalFilesInMetadata(Integer lastNFileSlices, boolean ignor
+       writeOptions.put(DataSourceWriteOptions.TABLE_NAME().key(), "test_table");
+       writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), "MERGE_ON_READ");
+       writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+-      writeOptions.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++      writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+       writeOptions.put(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "2");
+ 
+       Dataset<Row> inserts = makeInsertDf("000", 10).cache();
+@@ -721,7 +722,7 @@ public void testAdditionalPartitionsinMdtEndToEnd(boolean ignoreFailed) throws E
+       writeOptions.put("hoodie.table.name", "test_table");
+       writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), "MERGE_ON_READ");
+       writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+-      writeOptions.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++      writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+       writeOptions.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(),"partition_path");
+       writeOptions.put(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "2");
+ 
+@@ -1178,7 +1179,7 @@ public void testRecordIndexMismatch(boolean ignoreFailed) throws IOException {
+     writeOptions.put("hoodie.table.name", "test_table");
+     writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), "COPY_ON_WRITE");
+     writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+-    writeOptions.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++    writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     writeOptions.put(DataSourceWriteOptions.OPERATION().key(),"bulk_insert");
+     writeOptions.put(HoodieMetadataConfig.RECORD_INDEX_ENABLE_PROP.key(), "true");
+ 
+@@ -1275,7 +1276,7 @@ public void testRliValidationFalsePositiveCase() throws Exception {
+       writeOptions.put(DataSourceWriteOptions.TABLE_NAME().key(), "test_table");
+       writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), "MERGE_ON_READ");
+       writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+-      writeOptions.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++      writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+       writeOptions.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition_path");
+ 
+       Dataset<Row> inserts = makeInsertDf("000", 5).cache();
+@@ -1401,7 +1402,7 @@ void testLogDetailMaxLength() {
+     writeOptions.put("hoodie.table.name", "test_table");
+     writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), "MERGE_ON_READ");
+     writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+-    writeOptions.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++    writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     writeOptions.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition_path");
+ 
+     // Create a large dataset to generate long validation messages
+diff --git a/packaging/bundle-validation/utilities/hoodieapp.properties b/packaging/bundle-validation/utilities/hoodieapp.properties
+index 6d2382fc89045..2718c52c364b6 100644
+--- a/packaging/bundle-validation/utilities/hoodieapp.properties
++++ b/packaging/bundle-validation/utilities/hoodieapp.properties
+@@ -16,7 +16,7 @@
+ 
+ hoodie.datasource.write.recordkey.field=key
+ hoodie.datasource.write.partitionpath.field=date
+-hoodie.datasource.write.precombine.field=ts
++hoodie.datasource.write.precombine.fields=ts
+ hoodie.metadata.enable=true
+ hoodie.deltastreamer.source.dfs.root=file:///opt/bundle-validation/data/stocks/data
+ hoodie.deltastreamer.schemaprovider.target.schema.file=file:///opt/bundle-validation/data/stocks/schema.avsc

--- a/pr_13718_files/0001.diff
+++ b/pr_13718_files/0001.diff
@@ -1,0 +1,32 @@
+diff --git a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+index 84c0e20a475c1..4701bbb7b487a 100644
+--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
++++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+@@ -170,9 +170,11 @@ public class HoodieWriteConfig extends HoodieConfig {
+       .withDocumentation("Determine what level of persistence is used to cache write RDDs. "
+           + "Refer to org.apache.spark.storage.StorageLevel for different values");
+ 
++  @Deprecated
+   public static final ConfigProperty<String> PRECOMBINE_FIELD_NAME = ConfigProperty
+       .key("hoodie.datasource.write.precombine.field")
+       .noDefaultValue()
++      .withAlternatives("hoodie.datasource.write.precombine.field")
+       .withDocumentation("Comma separated list of fields used in preCombining before actual write. When two records have the same key value, "
+           + "we will pick the one with the largest value for the precombine field, determined by Object.compareTo(..). "
+           + "For multiple fields if first key comparison is same, second key comparison is made and so on. This config is used for combining records "
+@@ -1408,6 +1410,7 @@ public HoodieTableType getTableType() {
+         HoodieTableConfig.TYPE, HoodieTableConfig.TYPE.defaultValue().name()).toUpperCase());
+   }
+ 
++  @Deprecated
+   public List<String> getPreCombineFields() {
+     return Option.ofNullable(getString(PRECOMBINE_FIELD_NAME))
+         .map(preCombine -> Arrays.asList(preCombine.split(",")))
+@@ -3018,6 +3021,7 @@ public Builder forTable(String tableName) {
+       return this;
+     }
+ 
++    @Deprecated
+     public Builder withPreCombineField(String preCombineField) {
+       writeConfig.setValue(PRECOMBINE_FIELD_NAME, preCombineField);
+       return this;

--- a/pr_13718_files/0002.diff
+++ b/pr_13718_files/0002.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
+index aa2e36184259b..278dd1928ae97 100644
+--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
++++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/SevenToEightUpgradeHandler.java
+@@ -168,7 +168,7 @@ static void upgradePartitionFields(HoodieWriteConfig config, HoodieTableConfig t
+ 
+   static void upgradeMergeMode(HoodieTableConfig tableConfig, Map<ConfigProperty, String> tablePropsToAdd) {
+     String payloadClass = tableConfig.getPayloadClass();
+-    String preCombineFields = tableConfig.getPreCombineFieldsStr().orElse(null);
++    String preCombineFields = tableConfig.getOrderingFieldsStr().orElse(null);
+     if (isCustomPayloadClass(payloadClass)) {
+       // This contains a special case: HoodieMetadataPayload.
+       tablePropsToAdd.put(

--- a/pr_13718_files/0003.diff
+++ b/pr_13718_files/0003.diff
@@ -1,0 +1,22 @@
+diff --git a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestSevenToEightUpgradeHandler.java b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestSevenToEightUpgradeHandler.java
+index a8c2103e46d31..66d03811b76fc 100644
+--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestSevenToEightUpgradeHandler.java
++++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/upgrade/TestSevenToEightUpgradeHandler.java
+@@ -97,7 +97,7 @@ void testPropertyUpgrade() {
+     // Mock record merge mode configuration for merging behavior
+     when(tableConfig.contains(isA(ConfigProperty.class))).thenAnswer(i -> i.getArguments()[0].equals(PAYLOAD_CLASS_NAME));
+     when(tableConfig.getPayloadClass()).thenReturn(OverwriteWithLatestAvroPayload.class.getName());
+-    when(tableConfig.getPreCombineFieldsStr()).thenReturn(Option.empty());
++    when(tableConfig.getOrderingFieldsStr()).thenReturn(Option.empty());
+     SevenToEightUpgradeHandler.upgradeMergeMode(tableConfig, tablePropsToAdd);
+     assertTrue(tablePropsToAdd.containsKey(RECORD_MERGE_MODE));
+     assertNotNull(tablePropsToAdd.get(RECORD_MERGE_MODE));
+@@ -140,7 +140,7 @@ void testUpgradeMergeMode(String payloadClass, String preCombineField, String ex
+     Map<ConfigProperty, String> tablePropsToAdd = new HashMap<>();
+ 
+     when(tableConfig.getPayloadClass()).thenReturn(payloadClass);
+-    when(tableConfig.getPreCombineFieldsStr()).thenReturn(Option.ofNullable(preCombineField));
++    when(tableConfig.getOrderingFieldsStr()).thenReturn(Option.ofNullable(preCombineField));
+ 
+     SevenToEightUpgradeHandler.upgradeMergeMode(tableConfig, tablePropsToAdd);
+ 

--- a/pr_13718_files/0004.diff
+++ b/pr_13718_files/0004.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/common/table/read/HoodieFileGroupReaderOnJavaTestBase.java b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/common/table/read/HoodieFileGroupReaderOnJavaTestBase.java
+index 4043f9c9153ab..c4e3adeff01f8 100644
+--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/common/table/read/HoodieFileGroupReaderOnJavaTestBase.java
++++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/common/table/read/HoodieFileGroupReaderOnJavaTestBase.java
+@@ -28,6 +28,7 @@
+ import org.apache.hudi.common.model.HoodieRecordPayload;
+ import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.common.table.HoodieTableMetaClient;
++import org.apache.hudi.common.util.ConfigUtils;
+ import org.apache.hudi.common.util.Option;
+ import org.apache.hudi.config.HoodieWriteConfig;
+ import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+@@ -89,7 +90,7 @@ public void commitToTable(List<HoodieRecord> recordList, String operation, boole
+             .setKeyGeneratorType(KeyGeneratorType.SIMPLE.name())
+             .setRecordKeyFields(writeConfigs.get(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key()))
+             .setPartitionFields(writeConfigs.get(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key()))
+-            .setPreCombineFields(writeConfigs.get("hoodie.datasource.write.precombine.field"))
++            .setOrderingFields(ConfigUtils.getOrderingFieldsStrDuringWrite(writeConfigs))
+             .setBaseFileFormat(writeConfigs.get(HoodieTableConfig.BASE_FILE_FORMAT.key()))
+             .set(initConfigs);
+         if (writeConfigs.containsKey("hoodie.datasource.write.payload.class")) {

--- a/pr_13718_files/0005.diff
+++ b/pr_13718_files/0005.diff
@@ -1,0 +1,37 @@
+diff --git a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieDatasetBulkInsertHelper.scala b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieDatasetBulkInsertHelper.scala
+index e2f6cba93bde5..3b89a27962d9e 100644
+--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieDatasetBulkInsertHelper.scala
++++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieDatasetBulkInsertHelper.scala
+@@ -25,6 +25,7 @@ import org.apache.hudi.common.config.TypedProperties
+ import org.apache.hudi.common.data.HoodieData
+ import org.apache.hudi.common.engine.TaskContextSupplier
+ import org.apache.hudi.common.model.HoodieRecord
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.util.{OrderingValues, ReflectionUtils}
+ import org.apache.hudi.config.HoodieWriteConfig
+ import org.apache.hudi.data.HoodieJavaRDD
+@@ -36,7 +37,6 @@ import org.apache.hudi.keygen.{AutoRecordGenWrapperKeyGenerator, BuiltinKeyGener
+ import org.apache.hudi.table.action.commit.{BucketBulkInsertDataInternalWriterHelper, BulkInsertDataInternalWriterHelper, ConsistentBucketBulkInsertDataInternalWriterHelper, ParallelismHelper}
+ import org.apache.hudi.table.{BulkInsertPartitioner, HoodieTable}
+ import org.apache.hudi.util.JFunction.toJavaSerializableFunctionUnchecked
+-
+ import org.apache.spark.TaskContext
+ import org.apache.spark.internal.Logging
+ import org.apache.spark.rdd.RDD
+@@ -68,6 +68,7 @@ object HoodieDatasetBulkInsertHelper
+    */
+   def prepareForBulkInsert(df: DataFrame,
+                            config: HoodieWriteConfig,
++                           tableConfig: HoodieTableConfig,
+                            partitioner: BulkInsertPartitioner[Dataset[Row]],
+                            instantTime: String): Dataset[Row] = {
+     val populateMetaFields = config.populateMetaFields()
+@@ -121,7 +122,7 @@ object HoodieDatasetBulkInsertHelper
+       }
+ 
+       val dedupedRdd = if (config.shouldCombineBeforeInsert) {
+-        dedupeRows(prependedRdd, updatedSchema, config.getPreCombineFields.asScala.toList, SparkHoodieIndexFactory.isGlobalIndex(config), targetParallelism)
++        dedupeRows(prependedRdd, updatedSchema, tableConfig.getOrderingFields.asScala.toList, SparkHoodieIndexFactory.isGlobalIndex(config), targetParallelism)
+       } else {
+         prependedRdd
+       }

--- a/pr_13718_files/0006.diff
+++ b/pr_13718_files/0006.diff
@@ -1,0 +1,20 @@
+diff --git a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
+index 120b7cef9fdf1..28e34c04ca693 100644
+--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
++++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/HoodieReaderContext.java
+@@ -274,13 +274,13 @@ private void initRecordMerger(TypedProperties properties, boolean isIngestion) {
+     // If the provided payload class differs from the table's payload class, we need to infer the correct merging behavior.
+     if (isIngestion && providedPayloadClass.map(className -> !className.equals(tableConfig.getPayloadClass())).orElse(false)) {
+       Triple<RecordMergeMode, String, String> triple = HoodieTableConfig.inferCorrectMergingBehavior(null, providedPayloadClass.get(), null,
+-          tableConfig.getPreCombineFieldsStr().orElse(null), tableVersion);
++          tableConfig.getOrderingFieldsStr().orElse(null), tableVersion);
+       recordMergeMode = triple.getLeft();
+       mergeStrategyId = triple.getRight();
+     } else if (!tableVersion.greaterThanOrEquals(HoodieTableVersion.EIGHT)) {
+       Triple<RecordMergeMode, String, String> triple = HoodieTableConfig.inferCorrectMergingBehavior(
+           recordMergeMode, tableConfig.getPayloadClass(),
+-          mergeStrategyId, tableConfig.getPreCombineFieldsStr().orElse(null), tableVersion);
++          mergeStrategyId, tableConfig.getOrderingFieldsStr().orElse(null), tableVersion);
+       recordMergeMode = triple.getLeft();
+       mergeStrategyId = triple.getRight();
+     }

--- a/pr_13718_files/0007.diff
+++ b/pr_13718_files/0007.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordMerger.java b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordMerger.java
+index d26147f856ae5..4bdd5613ff851 100644
+--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordMerger.java
++++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordMerger.java
+@@ -172,7 +172,7 @@ default String[] getMandatoryFieldsForMerging(Schema dataSchema, HoodieTableConf
+       }
+     }
+ 
+-    List<String> preCombineFields = cfg.getPreCombineFields();
++    List<String> preCombineFields = cfg.getOrderingFields();
+     requiredFields.addAll(preCombineFields);
+     return requiredFields.toArray(new String[0]);
+   }

--- a/pr_13718_files/0008.diff
+++ b/pr_13718_files/0008.diff
@@ -1,0 +1,59 @@
+diff --git a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+index 450f7df7eb3d6..3e7e20ca8c892 100644
+--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
++++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+@@ -156,10 +156,16 @@ public class HoodieTableConfig extends HoodieConfig {
+           + " to identify what upgrade/downgrade paths happened on the table. This is only configured "
+           + "when the table is initially setup.");
+ 
+-  // TODO: is this this called precombine in 1.0. ..
+-  public static final ConfigProperty<String> PRECOMBINE_FIELDS = ConfigProperty
+-      .key("hoodie.table.precombine.field")
++  /**
++   * @deprecated Use {@link #ORDERING_FIELDS} instead
++   */
++  @Deprecated
++  public static final String PRECOMBINE_FIELD = "hoodie.table.precombine.field";
++
++  public static final ConfigProperty<String> ORDERING_FIELDS = ConfigProperty
++      .key("hoodie.table.ordering.fields")
+       .noDefaultValue()
++      .withAlternatives(PRECOMBINE_FIELD)
+       .withDocumentation("Comma separated fields used in preCombining before actual write. By default, when two records have the same key value, "
+           + "the largest value for the precombine field determined by Object.compareTo(..), is picked. If there are multiple fields configured, "
+           + "comparison is made on the first field. If the first field values are same, comparison is made on the second field and so on.");
+@@ -924,14 +930,14 @@ static RecordMergeMode inferRecordMergeModeFromMergeStrategyId(String recordMerg
+     }
+   }
+ 
+-  public List<String> getPreCombineFields() {
+-    return getPreCombineFieldsStr()
++  public List<String> getOrderingFields() {
++    return getOrderingFieldsStr()
+         .map(preCombine -> Arrays.stream(preCombine.split(",")).filter(StringUtils::nonEmpty).collect(Collectors.toList()))
+         .orElse(Collections.emptyList());
+   }
+ 
+-  public Option<String> getPreCombineFieldsStr() {
+-    return Option.ofNullable(getString(PRECOMBINE_FIELDS));
++  public Option<String> getOrderingFieldsStr() {
++    return Option.ofNullable(getString(ORDERING_FIELDS));
+   }
+ 
+   public Option<String[]> getRecordKeyFields() {
+@@ -1237,11 +1243,13 @@ public Map<String, String> propsMap() {
+    */
+   @Deprecated
+   public static final String HOODIE_TABLE_VERSION_PROP_NAME = VERSION.key();
++
+   /**
+-   * @deprecated Use {@link #PRECOMBINE_FIELDS} and its methods.
++   * @deprecated Use {@link #ORDERING_FIELDS} and its methods.
+    */
+   @Deprecated
+-  public static final String HOODIE_TABLE_PRECOMBINE_FIELD = PRECOMBINE_FIELDS.key();
++  public static final String HOODIE_TABLE_PRECOMBINE_FIELD = PRECOMBINE_FIELD;
++
+   /**
+    * @deprecated Use {@link #BASE_FILE_FORMAT} and its methods.
+    */

--- a/pr_13718_files/0009.diff
+++ b/pr_13718_files/0009.diff
@@ -1,0 +1,60 @@
+diff --git a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+index 1b15c401103e7..e71f335c6172e 100644
+--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
++++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableMetaClient.java
+@@ -1069,7 +1069,7 @@ public static class TableBuilder {
+     private String timelinePath;
+     private String timelineHistoryPath;
+     private String baseFileFormat;
+-    private String preCombineFields;
++    private String orderingFields;
+     private String partitionFields;
+     private Boolean cdcEnabled;
+     private String cdcSupplementalLoggingMode;
+@@ -1191,11 +1191,11 @@ public TableBuilder setBaseFileFormat(String baseFileFormat) {
+     }
+ 
+     /**
+-     * Sets preCombine fields as a comma separated string in the table
+-     * @param preCombineFieldsAsString - Comma separated preCombine fields which need to be set for the table
++     * Sets ordering fields as a comma separated string in the table
++     * @param orderingFieldsAsString - Comma separated ordering fields which need to be set for the table
+      */
+-    public TableBuilder setPreCombineFields(String preCombineFieldsAsString) {
+-      this.preCombineFields = preCombineFieldsAsString;
++    public TableBuilder setOrderingFields(String orderingFieldsAsString) {
++      this.orderingFields = orderingFieldsAsString;
+       return this;
+     }
+ 
+@@ -1398,8 +1398,8 @@ public TableBuilder fromProperties(Properties properties) {
+         setBootstrapIndexEnable(hoodieConfig.getBoolean(HoodieTableConfig.BOOTSTRAP_INDEX_ENABLE));
+       }
+ 
+-      if (hoodieConfig.contains(HoodieTableConfig.PRECOMBINE_FIELDS)) {
+-        setPreCombineFields(hoodieConfig.getString(HoodieTableConfig.PRECOMBINE_FIELDS));
++      if (hoodieConfig.contains(HoodieTableConfig.ORDERING_FIELDS)) {
++        setOrderingFields(hoodieConfig.getString(HoodieTableConfig.ORDERING_FIELDS));
+       }
+       if (hoodieConfig.contains(HoodieTableConfig.PARTITION_FIELDS)) {
+         setPartitionFields(
+@@ -1482,7 +1482,7 @@ public Properties build() {
+ 
+       Triple<RecordMergeMode, String, String> mergeConfigs =
+           HoodieTableConfig.inferCorrectMergingBehavior(
+-              recordMergeMode, payloadClassName, recordMergerStrategyId, preCombineFields,
++              recordMergeMode, payloadClassName, recordMergerStrategyId, orderingFields,
+               tableVersion);
+       tableConfig.setValue(RECORD_MERGE_MODE, mergeConfigs.getLeft().name());
+       tableConfig.setValue(PAYLOAD_CLASS_NAME.key(), mergeConfigs.getMiddle());
+@@ -1531,8 +1531,8 @@ public Properties build() {
+         tableConfig.setValue(HoodieTableConfig.BOOTSTRAP_BASE_PATH, bootstrapBasePath);
+       }
+ 
+-      if (StringUtils.nonEmpty(preCombineFields)) {
+-        tableConfig.setValue(HoodieTableConfig.PRECOMBINE_FIELDS, preCombineFields);
++      if (StringUtils.nonEmpty(orderingFields)) {
++        tableConfig.setValue(HoodieTableConfig.ORDERING_FIELDS, orderingFields);
+       }
+ 
+       if (null != partitionFields) {

--- a/pr_13718_files/0010.diff
+++ b/pr_13718_files/0010.diff
@@ -1,0 +1,31 @@
+diff --git a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordScanner.java b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordScanner.java
+index 4266dd79d6bf8..97d0f41cca60d 100644
+--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordScanner.java
++++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/AbstractHoodieLogRecordScanner.java
+@@ -104,8 +104,6 @@ public abstract class AbstractHoodieLogRecordScanner {
+   private final Option<String> partitionPathFieldOpt;
+   // Partition name override
+   private final Option<String> partitionNameOverrideOpt;
+-  // Pre-combining field
+-  protected final String preCombineFields;
+   // Stateless component for merging records
+   protected final HoodieRecordMerger recordMerger;
+   private final TypedProperties payloadProps;
+@@ -175,13 +173,12 @@ protected AbstractHoodieLogRecordScanner(HoodieStorage storage, String basePath,
+     // load class from the payload fully qualified class name
+     HoodieTableConfig tableConfig = this.hoodieTableMetaClient.getTableConfig();
+     this.payloadClassFQN = tableConfig.getPayloadClass();
+-    this.preCombineFields = tableConfig.getPreCombineFieldsStr().orElse(null);
++    String orderingFieldsStr = tableConfig.getOrderingFieldsStr().orElse(null);
+     // Log scanner merge log with precombine
+     TypedProperties props = new TypedProperties();
+-    if (preCombineFields != null) {
+-      props.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, preCombineFields);
+-      props.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), preCombineFields);
+-      props.setProperty("hoodie.datasource.write.precombine.field", preCombineFields);
++    if (orderingFieldsStr != null) {
++      props.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, orderingFieldsStr);
++      props.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), orderingFieldsStr);
+     }
+     this.tableVersion = tableConfig.getTableVersion();
+     this.payloadProps = props;

--- a/pr_13718_files/0011.diff
+++ b/pr_13718_files/0011.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java b/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
+index 831a86ad3e9aa..a7d413c5477c5 100644
+--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
++++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/BaseHoodieLogRecordReader.java
+@@ -151,7 +151,7 @@ protected BaseHoodieLogRecordReader(HoodieReaderContext<T> readerContext, Hoodie
+     // load class from the payload fully qualified class name
+     HoodieTableConfig tableConfig = this.hoodieTableMetaClient.getTableConfig();
+     this.payloadClassFQN = tableConfig.getPayloadClass();
+-    this.preCombineFields = tableConfig.getPreCombineFieldsStr().orElse(null);
++    this.preCombineFields = tableConfig.getOrderingFieldsStr().orElse(null);
+     // Log scanner merge log with precombine
+     TypedProperties props = new TypedProperties();
+     if (this.preCombineFields != null) {

--- a/pr_13718_files/0012.diff
+++ b/pr_13718_files/0012.diff
@@ -1,0 +1,22 @@
+diff --git a/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupReaderSchemaHandler.java b/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupReaderSchemaHandler.java
+index a05fa38b29657..acd81697d8a11 100644
+--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupReaderSchemaHandler.java
++++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/FileGroupReaderSchemaHandler.java
+@@ -191,7 +191,7 @@ private static String[] getMandatoryFieldsForMerging(HoodieTableConfig cfg,
+         cfg.getRecordMergeMode(),
+         cfg.getPayloadClass(),
+         cfg.getRecordMergeStrategyId(),
+-        cfg.getPreCombineFieldsStr().orElse(null),
++        cfg.getOrderingFieldsStr().orElse(null),
+         cfg.getTableVersion());
+ 
+     if (mergingConfigs.getLeft() == RecordMergeMode.CUSTOM) {
+@@ -216,7 +216,7 @@ private static String[] getMandatoryFieldsForMerging(HoodieTableConfig cfg,
+     }
+     // Add precombine field for event time ordering merge mode.
+     if (mergingConfigs.getLeft() == RecordMergeMode.EVENT_TIME_ORDERING) {
+-      List<String> preCombineFields = cfg.getPreCombineFields();
++      List<String> preCombineFields = cfg.getOrderingFields();
+       requiredFields.addAll(preCombineFields);
+     }
+     // Add `HOODIE_IS_DELETED_FIELD` field if exists.

--- a/pr_13718_files/0013.diff
+++ b/pr_13718_files/0013.diff
@@ -1,0 +1,103 @@
+diff --git a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+index 937748677b450..271b735bb7ebe 100644
+--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
++++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ConfigUtils.java
+@@ -82,15 +82,48 @@ public class ConfigUtils {
+    */
+   @Nullable
+   public static String[] getOrderingFields(Properties properties) {
++    String orderField = getOrderingFieldsStr(properties);
++    return orderField == null ? null : orderField.split(",");
++  }
++
++  /**
++   * Get ordering fields as comma separated string.
++   */
++  @Nullable
++  public static String getOrderingFieldsStr(Properties properties) {
++    String orderField = getOrderingFieldsStrDuringWrite(properties);
++    if (orderField == null && properties.containsKey(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY)) {
++      orderField = properties.getProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY);
++    }
++    return orderField;
++  }
++
++  /**
++   * Get ordering fields as comma separated string.
++   */
++  @Nullable
++  public static String getOrderingFieldsStrDuringWrite(Properties properties) {
+     String orderField = null;
+-    if (properties.containsKey("hoodie.datasource.write.precombine.field")) {
++    if (containsConfigProperty(properties, HoodieTableConfig.ORDERING_FIELDS)) {
++      orderField = getStringWithAltKeys(properties, HoodieTableConfig.ORDERING_FIELDS);
++    } else if (properties.containsKey("hoodie.datasource.write.precombine.field")) {
+       orderField = properties.getProperty("hoodie.datasource.write.precombine.field");
+-    } else if (properties.containsKey(HoodieTableConfig.PRECOMBINE_FIELDS.key())) {
+-      orderField = properties.getProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key());
+-    } else if (properties.containsKey(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY)) {
+-      orderField = properties.getProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY);
+     }
+-    return orderField == null ? null : orderField.split(",");
++    return orderField;
++  }
++
++  /**
++   * Get ordering fields as comma separated string.
++   */
++  @Nullable
++  public static String getOrderingFieldsStrDuringWrite(Map<String, String> properties) {
++    String orderField = null;
++    if (containsConfigProperty(properties, HoodieTableConfig.ORDERING_FIELDS)) {
++      orderField = getStringWithAltKeys(properties, HoodieTableConfig.ORDERING_FIELDS);
++    } else if (properties.containsKey("hoodie.datasource.write.precombine.field")) {
++      orderField = properties.get("hoodie.datasource.write.precombine.field");
++    }
++    return orderField;
+   }
+ 
+   /**
+@@ -101,8 +134,7 @@ public static String[] getOrderingFields(Properties properties) {
+   public static TypedProperties supplementOrderingFields(TypedProperties props, List<String> orderingFields) {
+     String orderingFieldsAsString = String.join(",", orderingFields);
+     props.putIfAbsent(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, orderingFieldsAsString);
+-    props.putIfAbsent(HoodieTableConfig.PRECOMBINE_FIELDS.key(), orderingFieldsAsString);
+-    props.putIfAbsent("hoodie.datasource.write.precombine.field", orderingFieldsAsString);
++    props.putIfAbsent(HoodieTableConfig.ORDERING_FIELDS.key(), orderingFieldsAsString);
+     return props;
+   }
+ 
+@@ -253,11 +285,11 @@ public static Option<String> stripPrefix(String prop, ConfigProperty<String> pre
+    * Whether the properties contain a config. If any of the key or alternative keys of the
+    * {@link ConfigProperty} exists in the properties, this method returns {@code true}.
+    *
+-   * @param props          Configs in {@link TypedProperties}
++   * @param props          Configs in {@link Properties}
+    * @param configProperty Config to look up.
+    * @return {@code true} if exists; {@code false} otherwise.
+    */
+-  public static boolean containsConfigProperty(TypedProperties props,
++  public static boolean containsConfigProperty(Properties props,
+                                                ConfigProperty<?> configProperty) {
+     if (!props.containsKey(configProperty.key())) {
+       for (String alternative : configProperty.getAlternatives()) {
+@@ -278,7 +310,7 @@ public static boolean containsConfigProperty(TypedProperties props,
+    * @param configProperty Config to look up.
+    * @return {@code true} if exists; {@code false} otherwise.
+    */
+-  public static boolean containsConfigProperty(Map<String, Object> props,
++  public static boolean containsConfigProperty(Map<String, ?> props,
+                                                ConfigProperty<?> configProperty) {
+     return containsConfigProperty(props::containsKey, configProperty);
+   }
+@@ -450,8 +482,8 @@ public static String getStringWithAltKeys(Properties props,
+    * and there is default value defined in the {@link ConfigProperty} config and is convertible to
+    * String type; {@code null} otherwise.
+    */
+-  public static String getStringWithAltKeys(Map<String, Object> props,
+-                                            ConfigProperty<?> configProperty) {
++  public static <V> String getStringWithAltKeys(Map<String, V> props,
++                                                ConfigProperty<?> configProperty) {
+     return getStringWithAltKeys(props::get, configProperty);
+   }
+ 

--- a/pr_13718_files/0014.diff
+++ b/pr_13718_files/0014.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordUtils.java b/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordUtils.java
+index dd0eccb32e301..4094adbe485b2 100644
+--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordUtils.java
++++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordUtils.java
+@@ -126,6 +126,6 @@ public static List<String> getOrderingFieldNames(RecordMergeMode mergeMode,
+                                                    HoodieTableMetaClient metaClient) {
+     return mergeMode == RecordMergeMode.COMMIT_TIME_ORDERING
+         ? Collections.emptyList()
+-        : Option.ofNullable(ConfigUtils.getOrderingFields(props)).map(Arrays::asList).orElseGet(() -> metaClient.getTableConfig().getPreCombineFields());
++        : Option.ofNullable(ConfigUtils.getOrderingFields(props)).map(Arrays::asList).orElseGet(() -> metaClient.getTableConfig().getOrderingFields());
+   }
+ }
+\ No newline at end of file

--- a/pr_13718_files/0015.diff
+++ b/pr_13718_files/0015.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+index 4bfeee6d8704f..2a6bf0cd91eee 100644
+--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
++++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+@@ -1047,7 +1047,7 @@ private static <T> ClosableIterator<BufferedRecord<T>> getLogRecords(List<String
+       readerContext.setSchemaHandler(new FileGroupReaderSchemaHandler<>(readerContext, writerSchemaOpt.get(), writerSchemaOpt.get(), Option.empty(), tableConfig, properties));
+       HoodieReadStats readStats = new HoodieReadStats();
+       KeyBasedFileGroupRecordBuffer<T> recordBuffer = new KeyBasedFileGroupRecordBuffer<>(readerContext, datasetMetaClient,
+-          readerContext.getMergeMode(), PartialUpdateMode.NONE, properties, tableConfig.getPreCombineFields(),
++          readerContext.getMergeMode(), PartialUpdateMode.NONE, properties, tableConfig.getOrderingFields(),
+           UpdateProcessor.create(readStats, readerContext, true, Option.empty()));
+ 
+       // CRITICAL: Ensure allowInflightInstants is set to true

--- a/pr_13718_files/0016.diff
+++ b/pr_13718_files/0016.diff
@@ -1,0 +1,20 @@
+diff --git a/hudi-common/src/test/java/org/apache/hudi/common/table/read/SchemaHandlerTestBase.java b/hudi-common/src/test/java/org/apache/hudi/common/table/read/SchemaHandlerTestBase.java
+index 41d63434f5d76..fe9423cdc5536 100644
+--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/SchemaHandlerTestBase.java
++++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/SchemaHandlerTestBase.java
+@@ -251,11 +251,11 @@ private static void setupMORTable(RecordMergeMode mergeMode, boolean hasPrecombi
+     when(hoodieTableConfig.populateMetaFields()).thenReturn(true);
+     when(hoodieTableConfig.getRecordMergeMode()).thenReturn(mergeMode);
+     if (hasPrecombine) {
+-      when(hoodieTableConfig.getPreCombineFieldsStr()).thenReturn(Option.of("timestamp"));
+-      when(hoodieTableConfig.getPreCombineFields()).thenReturn(Collections.singletonList("timestamp"));
++      when(hoodieTableConfig.getOrderingFieldsStr()).thenReturn(Option.of("timestamp"));
++      when(hoodieTableConfig.getOrderingFields()).thenReturn(Collections.singletonList("timestamp"));
+     } else {
+-      when(hoodieTableConfig.getPreCombineFieldsStr()).thenReturn(Option.empty());
+-      when(hoodieTableConfig.getPreCombineFields()).thenReturn(Collections.emptyList());
++      when(hoodieTableConfig.getOrderingFieldsStr()).thenReturn(Option.empty());
++      when(hoodieTableConfig.getOrderingFields()).thenReturn(Collections.emptyList());
+     }
+     if (mergeMode == CUSTOM) {
+       when(hoodieTableConfig.getRecordMergeStrategyId()).thenReturn("asdf");

--- a/pr_13718_files/0017.diff
+++ b/pr_13718_files/0017.diff
@@ -1,0 +1,15 @@
+diff --git a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestFileGroupReaderSchemaHandler.java b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestFileGroupReaderSchemaHandler.java
+index 39ff90cc05c5c..8df6c665a8f67 100644
+--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestFileGroupReaderSchemaHandler.java
++++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestFileGroupReaderSchemaHandler.java
+@@ -192,8 +192,8 @@ public void testSchemaForMandatoryFields(boolean setPrecombine,
+     HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+     when(tableConfig.getRecordMergeMode()).thenReturn(mergeMode);
+     when(tableConfig.populateMetaFields()).thenReturn(true);
+-    when(tableConfig.getPreCombineFieldsStr()).thenReturn(Option.of(setPrecombine ? preCombineField : StringUtils.EMPTY_STRING));
+-    when(tableConfig.getPreCombineFields()).thenReturn(setPrecombine ? Collections.singletonList(preCombineField) : Collections.emptyList());
++    when(tableConfig.getOrderingFieldsStr()).thenReturn(Option.of(setPrecombine ? preCombineField : StringUtils.EMPTY_STRING));
++    when(tableConfig.getOrderingFields()).thenReturn(setPrecombine ? Collections.singletonList(preCombineField) : Collections.emptyList());
+     when(tableConfig.getTableVersion()).thenReturn(tableVersion);
+     if (tableConfig.getTableVersion() == HoodieTableVersion.SIX) {
+       if (mergeMode == RecordMergeMode.EVENT_TIME_ORDERING) {

--- a/pr_13718_files/0018.diff
+++ b/pr_13718_files/0018.diff
@@ -1,0 +1,95 @@
+diff --git a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
+index df9e7c4793a5a..1bb513d6c7d24 100644
+--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
++++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
+@@ -111,7 +111,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
+   private static final List<HoodieFileFormat> DEFAULT_SUPPORTED_FILE_FORMATS = Arrays.asList(HoodieFileFormat.PARQUET, HoodieFileFormat.ORC);
+   protected static List<HoodieFileFormat> supportedFileFormats;
+   private static final String KEY_FIELD_NAME = "_row_key";
+-  private static final String PRECOMBINE_FIELD_NAME = "timestamp";
++  private static final String ORDERING_FIELD_NAME = "timestamp";
+   private static final String PARTITION_FIELD_NAME = "partition_path";
+   private static final String RIDER_FIELD_NAME = "rider";
+   @TempDir
+@@ -208,7 +208,7 @@ public void testReadFileGroupWithMultipleOrderingFields() throws Exception {
+     writeConfigs.put("hoodie.datasource.write.table.type", HoodieTableType.MERGE_ON_READ.name());
+     // Use two precombine values - combination of timestamp and rider
+     String orderingValues = "timestamp,rider";
+-    writeConfigs.put("hoodie.datasource.write.precombine.field", orderingValues);
++    writeConfigs.put(HoodieTableConfig.ORDERING_FIELDS.key(), orderingValues);
+     writeConfigs.put("hoodie.payload.ordering.field", orderingValues);
+ 
+     try (HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator(0xDEEF)) {
+@@ -628,8 +628,8 @@ protected Map<String, String> getCommonConfigs(RecordMergeMode recordMergeMode,
+     Map<String, String> configMapping = new HashMap<>();
+     configMapping.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), KEY_FIELD_NAME);
+     configMapping.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), PARTITION_FIELD_NAME);
+-    configMapping.put("hoodie.datasource.write.precombine.field", PRECOMBINE_FIELD_NAME);
+-    configMapping.put("hoodie.payload.ordering.field", PRECOMBINE_FIELD_NAME);
++    configMapping.put(HoodieTableConfig.ORDERING_FIELDS.key(), ORDERING_FIELD_NAME);
++    configMapping.put("hoodie.payload.ordering.field", ORDERING_FIELD_NAME);
+     configMapping.put(HoodieTableConfig.HOODIE_TABLE_NAME_KEY, "hoodie_test");
+     configMapping.put("hoodie.insert.shuffle.parallelism", "4");
+     configMapping.put("hoodie.upsert.shuffle.parallelism", "4");
+@@ -713,7 +713,7 @@ private static List<HoodieRecord> getExpectedHoodieRecordsWithOrderingValue(List
+     return expectedHoodieRecords.stream().map(rec -> {
+       RawTripTestPayload oldPayload = (RawTripTestPayload) rec.getData();
+       try {
+-        List<String> orderingFields = metaClient.getTableConfig().getPreCombineFields();
++        List<String> orderingFields = metaClient.getTableConfig().getOrderingFields();
+         HoodieAvroRecord avroRecord = ((HoodieAvroRecord) rec);
+         Comparable orderingValue = OrderingValues.create(orderingFields, field -> (Comparable) avroRecord.getColumnValueAsJava(avroSchema, field, new TypedProperties()));
+         RawTripTestPayload newPayload = new RawTripTestPayload(Option.ofNullable(oldPayload.getJsonData()), oldPayload.getRowKey(), oldPayload.getPartitionPath(), null, false, orderingValue);
+@@ -739,20 +739,20 @@ private void validateOutputFromFileGroupReaderWithExistingRecords(StorageConfigu
+     boolean sortOutput = !containsBaseFile;
+     List<HoodieTestDataGenerator.RecordIdentifier> actualRecordList = convertEngineRecords(
+         readRecordsFromFileGroup(storageConf, tablePath, metaClient, fileSlices, avroSchema, recordMergeMode, false, sortOutput),
+-        avroSchema, readerContext, metaClient.getTableConfig().getPreCombineFields());
++        avroSchema, readerContext, metaClient.getTableConfig().getOrderingFields());
+     // validate size is equivalent to ensure no duplicates are returned
+     assertEquals(expectedRecords.size(), actualRecordList.size());
+     assertEquals(new HashSet<>(expectedRecords), new HashSet<>(actualRecordList));
+     // validate records can be read from file group as HoodieRecords
+     actualRecordList = convertHoodieRecords(
+         readHoodieRecordsFromFileGroup(storageConf, tablePath, metaClient, fileSlices, avroSchema, recordMergeMode),
+-        avroSchema, readerContext, metaClient.getTableConfig().getPreCombineFields());
++        avroSchema, readerContext, metaClient.getTableConfig().getOrderingFields());
+     assertEquals(expectedRecords.size(), actualRecordList.size());
+     assertEquals(new HashSet<>(expectedRecords), new HashSet<>(actualRecordList));
+     // validate unmerged records
+     actualRecordList = convertEngineRecords(
+         readRecordsFromFileGroup(storageConf, tablePath, metaClient, fileSlices, avroSchema, recordMergeMode, true, false),
+-        avroSchema, readerContext, metaClient.getTableConfig().getPreCombineFields());
++        avroSchema, readerContext, metaClient.getTableConfig().getOrderingFields());
+     assertEquals(expectedUnmergedRecords.size(), actualRecordList.size());
+     assertEquals(new HashSet<>(expectedUnmergedRecords), new HashSet<>(actualRecordList));
+   }
+@@ -888,8 +888,8 @@ private List<HoodieRecord<T>> readHoodieRecordsFromFileGroup(StorageConfiguratio
+ 
+   private TypedProperties buildProperties(HoodieTableMetaClient metaClient, RecordMergeMode recordMergeMode) {
+     TypedProperties props = new TypedProperties();
+-    props.setProperty("hoodie.datasource.write.precombine.field", metaClient.getTableConfig().getPreCombineFieldsStr().orElse(""));
+-    props.setProperty("hoodie.payload.ordering.field", metaClient.getTableConfig().getPreCombineFieldsStr().orElse(""));
++    props.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), metaClient.getTableConfig().getOrderingFieldsStr().orElse(""));
++    props.setProperty("hoodie.payload.ordering.field", metaClient.getTableConfig().getOrderingFieldsStr().orElse(""));
+     props.setProperty(RECORD_MERGE_MODE.key(), recordMergeMode.name());
+     if (recordMergeMode.equals(RecordMergeMode.CUSTOM)) {
+       props.setProperty(RECORD_MERGE_STRATEGY_ID.key(), PAYLOAD_BASED_MERGE_STRATEGY_UUID);
+@@ -949,14 +949,14 @@ private List<HoodieTestDataGenerator.RecordIdentifier> convertEngineRecords(List
+   }
+ 
+   private List<HoodieTestDataGenerator.RecordIdentifier> convertHoodieRecords(List<HoodieRecord<T>> records, Schema schema, HoodieReaderContext<T> readerContext,
+-                                                                              List<String> preCombineFields) {
++                                                                              List<String> orderingFields) {
+     TypedProperties props = new TypedProperties();
+-    props.setProperty("hoodie.datasource.write.precombine.field", String.join(",", preCombineFields));
++    props.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), String.join(",", orderingFields));
+     return records.stream()
+         .map(record -> new HoodieTestDataGenerator.RecordIdentifier(
+             record.getRecordKey(),
+             removeHiveStylePartition(record.getPartitionPath()),
+-            record.getOrderingValue(schema, props, preCombineFields.toArray(new String[0])).toString(),
++            record.getOrderingValue(schema, props, orderingFields.toArray(new String[0])).toString(),
+             readerContext.getRecordContext().getValue(record.getData(), schema, RIDER_FIELD_NAME).toString()))
+         .collect(Collectors.toList());
+   }

--- a/pr_13718_files/0019.diff
+++ b/pr_13718_files/0019.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestFileGroupRecordBufferLoader.java b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestFileGroupRecordBufferLoader.java
+index 3289614165afd..c8dae1e6dfe68 100644
+--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestFileGroupRecordBufferLoader.java
++++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestFileGroupRecordBufferLoader.java
+@@ -63,7 +63,7 @@ public void testDefaultFileGroupBufferRecordLoader(String fileGroupRecordBufferT
+     HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+     when(tableConfig.getRecordMergeMode()).thenReturn(RecordMergeMode.COMMIT_TIME_ORDERING);
+     when(tableConfig.getTableVersion()).thenReturn(HoodieTableVersion.NINE);
+-    when(tableConfig.getPreCombineFieldsStr()).thenReturn(Option.empty());
++    when(tableConfig.getOrderingFieldsStr()).thenReturn(Option.empty());
+     when(tableConfig.getRecordKeyFields()).thenReturn(Option.of(new String[] {"record_key"}));
+     StorageConfiguration<?> storageConfiguration = mock(StorageConfiguration.class);
+     HoodieReaderContext<IndexedRecord> readerContext = new HoodieAvroReaderContext(storageConfiguration, tableConfig, Option.empty(), Option.empty());

--- a/pr_13718_files/0020.diff
+++ b/pr_13718_files/0020.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestKeyBasedFileGroupRecordBuffer.java b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestKeyBasedFileGroupRecordBuffer.java
+index 50eaeb454df2a..d1d0b6e92290d 100644
+--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestKeyBasedFileGroupRecordBuffer.java
++++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestKeyBasedFileGroupRecordBuffer.java
+@@ -140,7 +140,7 @@ void readWithEventTimeOrderingAndDeleteBlock() throws IOException {
+   void readWithEventTimeOrderingWithRecords() throws IOException {
+     HoodieReadStats readStats = new HoodieReadStats();
+     TypedProperties properties = new TypedProperties();
+-    properties.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "ts");
++    properties.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), "ts");
+     properties.setProperty(DELETE_KEY, "counter");
+     properties.setProperty(DELETE_MARKER, "3");
+     HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);

--- a/pr_13718_files/0021.diff
+++ b/pr_13718_files/0021.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestSortedKeyBasedFileGroupRecordBuffer.java b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestSortedKeyBasedFileGroupRecordBuffer.java
+index 0cbf8c2017e51..065560e8b0fdc 100644
+--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestSortedKeyBasedFileGroupRecordBuffer.java
++++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestSortedKeyBasedFileGroupRecordBuffer.java
+@@ -112,7 +112,7 @@ void readBaseFileAndLogFile() throws IOException {
+   void readWithStreamingRecordBufferLoaderAndEventTimeOrdering() throws IOException {
+     HoodieReadStats readStats = new HoodieReadStats();
+     TypedProperties properties = new TypedProperties();
+-    properties.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "ts");
++    properties.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), "ts");
+     properties.setProperty(DELETE_KEY, "counter");
+     properties.setProperty(DELETE_MARKER, "3");
+     HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);

--- a/pr_13718_files/0022.diff
+++ b/pr_13718_files/0022.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestStreamingKeyBasedFileGroupRecordBuffer.java b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestStreamingKeyBasedFileGroupRecordBuffer.java
+index baf1140cfee2e..7bb7d751255a8 100644
+--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestStreamingKeyBasedFileGroupRecordBuffer.java
++++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestStreamingKeyBasedFileGroupRecordBuffer.java
+@@ -70,7 +70,7 @@ class TestStreamingKeyBasedFileGroupRecordBuffer extends BaseTestFileGroupRecord
+   void readWithEventTimeOrdering() throws IOException {
+     HoodieReadStats readStats = new HoodieReadStats();
+     TypedProperties properties = new TypedProperties();
+-    properties.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "ts");
++    properties.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), "ts");
+     properties.setProperty(DELETE_KEY, "counter");
+     properties.setProperty(DELETE_MARKER, "3");
+     HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);

--- a/pr_13718_files/0023.diff
+++ b/pr_13718_files/0023.diff
@@ -1,0 +1,17 @@
+diff --git a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieAdaptablePayloadDataGenerator.java b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieAdaptablePayloadDataGenerator.java
+index 4d397e8bfac96..5a0106c1b340c 100644
+--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieAdaptablePayloadDataGenerator.java
++++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieAdaptablePayloadDataGenerator.java
+@@ -65,10 +65,10 @@ public static Properties getKeyGenProps(Class<?> payloadClass) {
+     Properties props = new Properties();
+     props.put("hoodie.datasource.write.recordkey.field", "id");
+     props.put("hoodie.datasource.write.partitionpath.field", "pt");
+-    props.put("hoodie.datasource.write.precombine.field", orderingField);
++    props.put(HoodieTableConfig.ORDERING_FIELDS.key(), orderingField);
+     props.put(HoodieTableConfig.RECORDKEY_FIELDS.key(), "id");
+     props.put(HoodieTableConfig.PARTITION_FIELDS.key(), "pt");
+-    props.put(HoodieTableConfig.PRECOMBINE_FIELDS.key(), orderingField);
++    props.put(HoodieTableConfig.ORDERING_FIELDS.key(), orderingField);
+     return props;
+   }
+ 

--- a/pr_13718_files/0024.diff
+++ b/pr_13718_files/0024.diff
@@ -1,0 +1,15 @@
+diff --git a/hudi-common/src/test/java/org/apache/hudi/common/testutils/PreCombineTestUtils.java b/hudi-common/src/test/java/org/apache/hudi/common/testutils/PreCombineTestUtils.java
+index 1591433dd1ddd..2b5b5429e998a 100644
+--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/PreCombineTestUtils.java
++++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/PreCombineTestUtils.java
+@@ -30,8 +30,8 @@
+ 
+ public class PreCombineTestUtils {
+   private static String[] preCombineConfigs = new String[] {
+-      HoodieTableConfig.PRECOMBINE_FIELDS.key(),
+-      "hoodie.datasource.write.precombine.field",
++      HoodieTableConfig.ORDERING_FIELDS.key(),
++      "hoodie.datasource.write.precombine.fields",
+       HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY
+   };
+ 

--- a/pr_13718_files/0025.diff
+++ b/pr_13718_files/0025.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-common/src/test/java/org/apache/hudi/common/util/TestHoodieRecordUtils.java b/hudi-common/src/test/java/org/apache/hudi/common/util/TestHoodieRecordUtils.java
+index 96a299c9e6ab4..bf1b633c29673 100644
+--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestHoodieRecordUtils.java
++++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestHoodieRecordUtils.java
+@@ -71,7 +71,7 @@ void testGetOrderingFields() {
+ 
+     // Assert table config precombine fields are returned when props are not set with event time merge mode
+     HoodieTableConfig tableConfig = new HoodieTableConfig();
+-    tableConfig.setValue(HoodieTableConfig.PRECOMBINE_FIELDS, "tbl");
++    tableConfig.setValue(HoodieTableConfig.ORDERING_FIELDS, "tbl");
+     when(metaClient.getTableConfig()).thenReturn(tableConfig);
+     assertEquals(Collections.singletonList("tbl"), HoodieRecordUtils.getOrderingFieldNames(RecordMergeMode.EVENT_TIME_ORDERING, props, metaClient));
+ 

--- a/pr_13718_files/0026.diff
+++ b/pr_13718_files/0026.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-examples/hudi-examples-k8s/src/main/java/org/apache/hudi/examples/k8s/quickstart/HudiDataStreamWriter.java b/hudi-examples/hudi-examples-k8s/src/main/java/org/apache/hudi/examples/k8s/quickstart/HudiDataStreamWriter.java
+index fc3fd5bb642fc..c71d2a9865cc7 100644
+--- a/hudi-examples/hudi-examples-k8s/src/main/java/org/apache/hudi/examples/k8s/quickstart/HudiDataStreamWriter.java
++++ b/hudi-examples/hudi-examples-k8s/src/main/java/org/apache/hudi/examples/k8s/quickstart/HudiDataStreamWriter.java
+@@ -107,7 +107,7 @@ private static Map<String, String> createHudiOptions(String basePath) {
+     options.put(FlinkOptions.PATH.key(), basePath);
+     options.put(HoodieCommonConfig.HOODIE_FS_ATOMIC_CREATION_SUPPORT.key(), "s3a");
+     options.put(FlinkOptions.TABLE_TYPE.key(), HoodieTableType.MERGE_ON_READ.name());
+-    options.put(FlinkOptions.PRECOMBINE_FIELD.key(), "ts");
++    options.put(FlinkOptions.ORDERING_FIELDS.key(), "ts");
+     options.put(FlinkOptions.RECORD_KEY_FIELD.key(), "uuid");
+     options.put(FlinkOptions.IGNORE_FAILED.key(), "true");
+     return options;

--- a/pr_13718_files/0027.diff
+++ b/pr_13718_files/0027.diff
@@ -1,0 +1,57 @@
+diff --git a/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/quickstart/HoodieSparkQuickstart.java b/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/quickstart/HoodieSparkQuickstart.java
+index 2a22334989983..fd002d4177eb4 100644
+--- a/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/quickstart/HoodieSparkQuickstart.java
++++ b/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/quickstart/HoodieSparkQuickstart.java
+@@ -21,6 +21,7 @@
+ import org.apache.hudi.QuickstartUtils;
+ import org.apache.hudi.common.model.HoodieAvroPayload;
+ import org.apache.hudi.common.model.WriteOperationType;
++import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.config.HoodieWriteConfig;
+ import org.apache.hudi.examples.common.HoodieExampleDataGenerator;
+ import org.apache.hudi.examples.common.HoodieExampleSparkUtils;
+@@ -115,7 +116,7 @@ public static Dataset<Row> insertData(SparkSession spark, JavaSparkContext jsc,
+ 
+     df.write().format("hudi")
+         .options(QuickstartUtils.getQuickstartWriteConfigs())
+-        .option(HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key(), "ts")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts")
+         .option(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "uuid")
+         .option(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partitionpath")
+         .option(TBL_NAME.key(), tableName)
+@@ -136,7 +137,7 @@ public static Dataset<Row> insertOverwriteData(SparkSession spark, JavaSparkCont
+     df.write().format("hudi")
+         .options(QuickstartUtils.getQuickstartWriteConfigs())
+         .option("hoodie.datasource.write.operation", WriteOperationType.INSERT_OVERWRITE.name())
+-        .option(HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key(), "ts")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts")
+         .option(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "uuid")
+         .option(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partitionpath")
+         .option(TBL_NAME.key(), tableName)
+@@ -183,7 +184,7 @@ public static Dataset<Row> updateData(SparkSession spark, JavaSparkContext jsc,
+     Dataset<Row> df = spark.read().json(jsc.parallelize(updates, 1));
+     df.write().format("hudi")
+         .options(QuickstartUtils.getQuickstartWriteConfigs())
+-        .option(HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key(), "ts")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts")
+         .option(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "uuid")
+         .option(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partitionpath")
+         .option(TBL_NAME.key(), tableName)
+@@ -204,7 +205,7 @@ public static Dataset<Row> delete(SparkSession spark, String tablePath, String t
+ 
+     df.write().format("hudi")
+         .options(QuickstartUtils.getQuickstartWriteConfigs())
+-        .option(HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key(), "ts")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts")
+         .option(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "uuid")
+         .option(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partitionpath")
+         .option(TBL_NAME.key(), tableName)
+@@ -221,7 +222,7 @@ public static void deleteByPartition(SparkSession spark, String tablePath, Strin
+     Dataset<Row> df = spark.emptyDataFrame();
+     df.write().format("hudi")
+         .options(QuickstartUtils.getQuickstartWriteConfigs())
+-        .option(HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key(), "ts")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts")
+         .option(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "uuid")
+         .option(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partitionpath")
+         .option(TBL_NAME.key(), tableName)

--- a/pr_13718_files/0028.diff
+++ b/pr_13718_files/0028.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/spark/HoodieSparkBootstrapExample.java b/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/spark/HoodieSparkBootstrapExample.java
+index 31f93601f9275..888817641622e 100644
+--- a/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/spark/HoodieSparkBootstrapExample.java
++++ b/hudi-examples/hudi-examples-spark/src/main/java/org/apache/hudi/examples/spark/HoodieSparkBootstrapExample.java
+@@ -61,7 +61,7 @@ public static void main(String[] args) throws Exception {
+     df.write().format("hudi").option(HoodieWriteConfig.TBL_NAME.key(), tableName)
+         .option(DataSourceWriteOptions.OPERATION().key(), DataSourceWriteOptions.BOOTSTRAP_OPERATION_OPT_VAL())
+         .option(DataSourceWriteOptions.RECORDKEY_FIELD().key(), recordKey)
+-        .option(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), preCombineField)
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), preCombineField)
+         .option(HoodieTableConfig.BASE_FILE_FORMAT.key(), HoodieFileFormat.ORC.name())
+         .option(HoodieBootstrapConfig.BASE_PATH.key(), basePath)
+         .option(HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key(), NonpartitionedKeyGenerator.class.getCanonicalName())

--- a/pr_13718_files/0029.diff
+++ b/pr_13718_files/0029.diff
@@ -1,0 +1,51 @@
+diff --git a/hudi-examples/hudi-examples-spark/src/main/scala/org/apache/hudi/examples/spark/HoodieDataSourceExample.scala b/hudi-examples/hudi-examples-spark/src/main/scala/org/apache/hudi/examples/spark/HoodieDataSourceExample.scala
+index a319bc1812288..0bfa4c2106222 100644
+--- a/hudi-examples/hudi-examples-spark/src/main/scala/org/apache/hudi/examples/spark/HoodieDataSourceExample.scala
++++ b/hudi-examples/hudi-examples-spark/src/main/scala/org/apache/hudi/examples/spark/HoodieDataSourceExample.scala
+@@ -22,9 +22,9 @@ import org.apache.hudi.DataSourceReadOptions.{END_COMMIT, QUERY_TYPE, QUERY_TYPE
+ import org.apache.hudi.DataSourceWriteOptions.{DELETE_OPERATION_OPT_VAL, DELETE_PARTITION_OPERATION_OPT_VAL, OPERATION, PARTITIONPATH_FIELD, PARTITIONS_TO_DELETE, PRECOMBINE_FIELD, RECORDKEY_FIELD}
+ import org.apache.hudi.QuickstartUtils.getQuickstartWriteConfigs
+ import org.apache.hudi.common.model.HoodieAvroPayload
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.config.HoodieWriteConfig.TBL_NAME
+ import org.apache.hudi.examples.common.{HoodieExampleDataGenerator, HoodieExampleSparkUtils}
+-
+ import org.apache.spark.sql.SaveMode.{Append, Overwrite}
+ import org.apache.spark.sql.SparkSession
+ 
+@@ -78,7 +78,7 @@ object HoodieDataSourceExample {
+     val df = spark.read.json(spark.sparkContext.parallelize(inserts, 1))
+     df.write.format("hudi").
+       options(getQuickstartWriteConfigs).
+-      option(PRECOMBINE_FIELD.key, "ts").
++      option(HoodieTableConfig.ORDERING_FIELDS.key, "ts").
+       option(RECORDKEY_FIELD.key, "uuid").
+       option(PARTITIONPATH_FIELD.key, "partitionpath").
+       option(TBL_NAME.key, tableName).
+@@ -120,7 +120,7 @@ object HoodieDataSourceExample {
+     val df = spark.read.json(spark.sparkContext.parallelize(updates, 1))
+     df.write.format("hudi").
+       options(getQuickstartWriteConfigs).
+-      option(PRECOMBINE_FIELD.key, "ts").
++      option(HoodieTableConfig.ORDERING_FIELDS.key, "ts").
+       option(RECORDKEY_FIELD.key, "uuid").
+       option(PARTITIONPATH_FIELD.key, "partitionpath").
+       option(TBL_NAME.key, tableName).
+@@ -139,7 +139,7 @@ object HoodieDataSourceExample {
+ 
+     df.write.format("hudi").
+       options(getQuickstartWriteConfigs).
+-      option(PRECOMBINE_FIELD.key, "ts").
++      option(HoodieTableConfig.ORDERING_FIELDS.key, "ts").
+       option(RECORDKEY_FIELD.key, "uuid").
+       option(PARTITIONPATH_FIELD.key, "partitionpath").
+       option(TBL_NAME.key, tableName).
+@@ -155,7 +155,7 @@ object HoodieDataSourceExample {
+     val df = spark.emptyDataFrame
+     df.write.format("hudi").
+       options(getQuickstartWriteConfigs).
+-      option(PRECOMBINE_FIELD.key, "ts").
++      option(HoodieTableConfig.ORDERING_FIELDS.key, "ts").
+       option(RECORDKEY_FIELD.key, "uuid").
+       option(PARTITIONPATH_FIELD.key, "partitionpath").
+       option(TBL_NAME.key, tableName).

--- a/pr_13718_files/0030.diff
+++ b/pr_13718_files/0030.diff
@@ -1,0 +1,30 @@
+diff --git a/hudi-examples/hudi-examples-spark/src/main/scala/org/apache/hudi/examples/spark/HoodieMorCompactionJob.scala b/hudi-examples/hudi-examples-spark/src/main/scala/org/apache/hudi/examples/spark/HoodieMorCompactionJob.scala
+index 0fbb2a007a2c1..269480a58783f 100644
+--- a/hudi-examples/hudi-examples-spark/src/main/scala/org/apache/hudi/examples/spark/HoodieMorCompactionJob.scala
++++ b/hudi-examples/hudi-examples-spark/src/main/scala/org/apache/hudi/examples/spark/HoodieMorCompactionJob.scala
+@@ -24,6 +24,7 @@ import org.apache.hudi.QuickstartUtils.getQuickstartWriteConfigs
+ import org.apache.hudi.client.SparkRDDWriteClient
+ import org.apache.hudi.client.common.HoodieSparkEngineContext
+ import org.apache.hudi.common.model.{HoodieAvroPayload, HoodieRecordPayload, HoodieTableType}
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.util.Option
+ import org.apache.hudi.config.HoodieWriteConfig.TBL_NAME
+ import org.apache.hudi.config.{HoodieCompactionConfig, HoodieWriteConfig}
+@@ -89,7 +90,7 @@ object HoodieMorCompactionJob {
+     val df = spark.read.json(spark.sparkContext.parallelize(inserts, 1))
+     df.write.format("hudi").
+       options(getQuickstartWriteConfigs).
+-      option(PRECOMBINE_FIELD.key, "ts").
++      option(HoodieTableConfig.ORDERING_FIELDS.key, "ts").
+       option(RECORDKEY_FIELD.key, "uuid").
+       option(PARTITIONPATH_FIELD.key, "partitionpath").
+       option(TBL_NAME.key, tableName).
+@@ -105,7 +106,7 @@ object HoodieMorCompactionJob {
+     val df = spark.read.json(spark.sparkContext.parallelize(updates, 1))
+     df.write.format("hudi").
+       options(getQuickstartWriteConfigs).
+-      option(PRECOMBINE_FIELD.key, "ts").
++      option(HoodieTableConfig.ORDERING_FIELDS.key, "ts").
+       option(RECORDKEY_FIELD.key, "uuid").
+       option(PARTITIONPATH_FIELD.key, "partitionpath").
+       option(TBL_NAME.key, tableName).

--- a/pr_13718_files/0031.diff
+++ b/pr_13718_files/0031.diff
@@ -1,0 +1,40 @@
+diff --git a/hudi-examples/hudi-examples-spark/src/test/python/HoodiePySparkQuickstart.py b/hudi-examples/hudi-examples-spark/src/test/python/HoodiePySparkQuickstart.py
+index 9505e3217850c..d3b7be749e6be 100644
+--- a/hudi-examples/hudi-examples-spark/src/test/python/HoodiePySparkQuickstart.py
++++ b/hudi-examples/hudi-examples-spark/src/test/python/HoodiePySparkQuickstart.py
+@@ -35,7 +35,7 @@ def __init__(self, spark: sql.SparkSession, tableName: str, basePath: str):
+             'hoodie.datasource.write.recordkey.field': 'uuid',
+             'hoodie.datasource.write.partitionpath.field': 'partitionpath',
+             'hoodie.datasource.write.operation': 'upsert',
+-            'hoodie.datasource.write.precombine.field': 'ts',
++            'hoodie.datasource.write.precombine.fields': 'ts',
+             'hoodie.upsert.shuffle.parallelism': 2,
+             'hoodie.insert.shuffle.parallelism': 2
+         }
+@@ -162,7 +162,7 @@ def softDeletes(self):
+         'hoodie.datasource.write.recordkey.field': 'uuid',
+         'hoodie.datasource.write.partitionpath.field': 'partitionpath',
+         'hoodie.datasource.write.operation': 'upsert',
+-        'hoodie.datasource.write.precombine.field': 'ts',
++        'hoodie.datasource.write.precombine.fields': 'ts',
+         'hoodie.upsert.shuffle.parallelism': 2, 
+         'hoodie.insert.shuffle.parallelism': 2
+         }
+@@ -196,7 +196,7 @@ def hardDeletes(self):
+             'hoodie.datasource.write.recordkey.field': 'uuid',
+             'hoodie.datasource.write.partitionpath.field': 'partitionpath',
+             'hoodie.datasource.write.operation': 'delete',
+-            'hoodie.datasource.write.precombine.field': 'ts',
++            'hoodie.datasource.write.precombine.fields': 'ts',
+             'hoodie.upsert.shuffle.parallelism': 2, 
+             'hoodie.insert.shuffle.parallelism': 2
+         }
+@@ -223,7 +223,7 @@ def insertOverwrite(self):
+             'hoodie.datasource.write.recordkey.field': 'uuid',
+             'hoodie.datasource.write.partitionpath.field': 'partitionpath',
+             'hoodie.datasource.write.operation': 'insert_overwrite',
+-            'hoodie.datasource.write.precombine.field': 'ts',
++            'hoodie.datasource.write.precombine.fields': 'ts',
+             'hoodie.upsert.shuffle.parallelism': 2,
+             'hoodie.insert.shuffle.parallelism': 2
+         }

--- a/pr_13718_files/0032.diff
+++ b/pr_13718_files/0032.diff
@@ -1,0 +1,24 @@
+diff --git a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+index a2a43566231cb..fa060d71fb78e 100644
+--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
++++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+@@ -110,14 +110,15 @@ private FlinkOptions() {
+       .withDescription("Type of table to write. COPY_ON_WRITE (or) MERGE_ON_READ");
+ 
+   public static final String NO_PRE_COMBINE = "no_precombine";
+-  public static final ConfigOption<String> PRECOMBINE_FIELD = ConfigOptions
+-      .key("precombine.field")
++  public static final ConfigOption<String> ORDERING_FIELDS = ConfigOptions
++      .key("ordering.fields")
+       .stringType()
+       .defaultValue("ts")
+-      .withFallbackKeys("write.precombine.field", HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key())
++      .withFallbackKeys("precombine.field", "write.precombine.field", HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key())
+       .withDescription("Comma separated list of fields used in preCombining before actual write. When two records have the same\n"
+           + "key value, we will pick the one with the largest value for the precombine field,\n"
+-          + "determined by Object.compareTo(..). For multiple fields if first key comparison is same, second key comparison is made and so on");
++          + "determined by Object.compareTo(..). For multiple fields if first key comparison is same, second key comparison is made and so on.\n"
++          + "Config precombine.field is now deprecated, please use precombine.fields instead.");
+ 
+   @AdvancedConfig
+   public static final ConfigOption<String> PAYLOAD_CLASS_NAME = ConfigOptions

--- a/pr_13718_files/0033.diff
+++ b/pr_13718_files/0033.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+index aa453fe54cdb0..375c3de809a04 100644
+--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
++++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/OptionsResolver.java
+@@ -152,12 +152,12 @@ public static boolean isDefaultHoodieRecordPayloadClazz(Configuration conf) {
+   }
+ 
+   /**
+-   * Returns the preCombine field
++   * Returns the preCombine fields as comma separated string
+    * or null if the value is set as {@link FlinkOptions#NO_PRE_COMBINE}.
+    */
+-  public static String getPreCombineField(Configuration conf) {
+-    final String preCombineField = conf.get(FlinkOptions.PRECOMBINE_FIELD);
+-    return preCombineField.equals(FlinkOptions.NO_PRE_COMBINE) ? null : preCombineField;
++  public static String getOrderingFieldsStr(Configuration conf) {
++    final String orderingFields = conf.get(FlinkOptions.ORDERING_FIELDS);
++    return orderingFields.equals(FlinkOptions.NO_PRE_COMBINE) ? null : orderingFields;
+   }
+ 
+   /**

--- a/pr_13718_files/0034.diff
+++ b/pr_13718_files/0034.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/HoodieFlinkCompactor.java b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/HoodieFlinkCompactor.java
+index b686017996547..669195e46a339 100644
+--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/HoodieFlinkCompactor.java
++++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/compact/HoodieFlinkCompactor.java
+@@ -175,7 +175,7 @@ public AsyncCompactionService(FlinkCompactionConfig cfg, Configuration conf) thr
+       // set table schema
+       CompactionUtil.setAvroSchema(conf, metaClient);
+ 
+-      CompactionUtil.setPreCombineField(conf, metaClient);
++      CompactionUtil.setOrderingFields(conf, metaClient);
+ 
+       // infer changelog mode
+       CompactionUtil.inferChangelogMode(conf, metaClient);

--- a/pr_13718_files/0035.diff
+++ b/pr_13718_files/0035.diff
@@ -1,0 +1,27 @@
+diff --git a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/streamer/FlinkStreamerConfig.java b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/streamer/FlinkStreamerConfig.java
+index fc7444e2c2415..278daacb081e3 100644
+--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/streamer/FlinkStreamerConfig.java
++++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/streamer/FlinkStreamerConfig.java
+@@ -114,9 +114,10 @@ public class FlinkStreamerConfig extends Configuration {
+       + "By default `SIMPLE`.")
+   public String keygenType = KeyGeneratorType.SIMPLE.name();
+ 
+-  @Parameter(names = {"--source-ordering-field"}, description = "Field within source record to decide how"
+-      + " to break ties between records with same key in input data. Default: 'ts' holding unix timestamp of record.")
+-  public String sourceOrderingField = "ts";
++  @Parameter(names = {"--source-ordering-fields", "--source-ordering-field"}, description = "Field within source record to decide how"
++      + " to break ties between records with same key in input data. Default: 'ts' holding unix timestamp of record. "
++      + "Option --source-ordering-field is deprecated, please use --source-ordering-fields instead.")
++  public String sourceOrderingFields = "ts";
+ 
+   @Parameter(names = {"--write-table-version"}, description = "Version of table written")
+   public Integer writeTableVersion = HoodieTableVersion.current().versionCode();
+@@ -425,7 +426,7 @@ public static org.apache.flink.configuration.Configuration toFlinkConfig(FlinkSt
+     conf.set(FlinkOptions.TABLE_TYPE, config.tableType.toUpperCase());
+     conf.set(FlinkOptions.INSERT_CLUSTER, config.insertCluster);
+     conf.set(FlinkOptions.OPERATION, config.operation.value());
+-    conf.set(FlinkOptions.PRECOMBINE_FIELD, config.sourceOrderingField);
++    conf.set(FlinkOptions.ORDERING_FIELDS, config.sourceOrderingFields);
+     conf.set(FlinkOptions.WRITE_TABLE_VERSION, config.writeTableVersion);
+     conf.set(FlinkOptions.PAYLOAD_CLASS_NAME, config.payloadClassName);
+     conf.set(FlinkOptions.RECORD_MERGER_IMPLS, config.recordMergerImpls);

--- a/pr_13718_files/0036.diff
+++ b/pr_13718_files/0036.diff
@@ -1,0 +1,17 @@
+diff --git a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
+index cd10f8edb29a8..726b6fef5ef8a 100644
+--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
++++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableFactory.java
+@@ -117,9 +117,9 @@ private void setupTableOptions(String basePath, Configuration conf) {
+               && !conf.contains(FlinkOptions.RECORD_KEY_FIELD)) {
+             conf.set(FlinkOptions.RECORD_KEY_FIELD, tableConfig.getString(HoodieTableConfig.RECORDKEY_FIELDS));
+           }
+-          if (tableConfig.contains(HoodieTableConfig.PRECOMBINE_FIELDS)
+-              && !conf.contains(FlinkOptions.PRECOMBINE_FIELD)) {
+-            conf.set(FlinkOptions.PRECOMBINE_FIELD, tableConfig.getString(HoodieTableConfig.PRECOMBINE_FIELDS));
++          if (tableConfig.contains(HoodieTableConfig.ORDERING_FIELDS)
++              && !conf.contains(FlinkOptions.ORDERING_FIELDS)) {
++            conf.set(FlinkOptions.ORDERING_FIELDS, tableConfig.getString(HoodieTableConfig.ORDERING_FIELDS));
+           }
+           if (tableConfig.contains(HoodieTableConfig.HIVE_STYLE_PARTITIONING_ENABLE)
+               && !conf.contains(FlinkOptions.HIVE_STYLE_PARTITIONING)) {

--- a/pr_13718_files/0037.diff
+++ b/pr_13718_files/0037.diff
@@ -1,0 +1,20 @@
+diff --git a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/TableOptionProperties.java b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/TableOptionProperties.java
+index de6b6bc4111f4..c7781171b9992 100644
+--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/TableOptionProperties.java
++++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/catalog/TableOptionProperties.java
+@@ -90,13 +90,13 @@ public class TableOptionProperties {
+ 
+     KEY_MAPPING.put("type", FlinkOptions.TABLE_TYPE.key());
+     KEY_MAPPING.put("primaryKey", FlinkOptions.RECORD_KEY_FIELD.key());
+-    KEY_MAPPING.put("preCombineField", FlinkOptions.PRECOMBINE_FIELD.key());
++    KEY_MAPPING.put("preCombineField", FlinkOptions.ORDERING_FIELDS.key());
+     KEY_MAPPING.put("payloadClass", FlinkOptions.PAYLOAD_CLASS_NAME.key());
+     KEY_MAPPING.put(SPARK_SOURCE_PROVIDER, CONNECTOR.key());
+     KEY_MAPPING.put(FlinkOptions.KEYGEN_CLASS_NAME.key(), FlinkOptions.KEYGEN_CLASS_NAME.key());
+     KEY_MAPPING.put(FlinkOptions.TABLE_TYPE.key(), "type");
+     KEY_MAPPING.put(FlinkOptions.RECORD_KEY_FIELD.key(), "primaryKey");
+-    KEY_MAPPING.put(FlinkOptions.PRECOMBINE_FIELD.key(), "preCombineField");
++    KEY_MAPPING.put(FlinkOptions.ORDERING_FIELDS.key(), "preCombineField");
+     KEY_MAPPING.put(FlinkOptions.PAYLOAD_CLASS_NAME.key(), "payloadClass");
+   }
+ 

--- a/pr_13718_files/0038.diff
+++ b/pr_13718_files/0038.diff
@@ -1,0 +1,19 @@
+diff --git a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/CompactionUtil.java b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/CompactionUtil.java
+index 42df2ced0cdd4..4c482835d2035 100644
+--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/CompactionUtil.java
++++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/CompactionUtil.java
+@@ -100,10 +100,10 @@ public static void setAvroSchema(HoodieWriteConfig writeConfig, HoodieTableMetaC
+    *
+    * @param conf The configuration
+    */
+-  public static void setPreCombineField(Configuration conf, HoodieTableMetaClient metaClient) {
+-    String preCombineField = metaClient.getTableConfig().getPreCombineFieldsStr().orElse(null);
+-    if (preCombineField != null) {
+-      conf.set(FlinkOptions.PRECOMBINE_FIELD, preCombineField);
++  public static void setOrderingFields(Configuration conf, HoodieTableMetaClient metaClient) {
++    String orderingFields = metaClient.getTableConfig().getOrderingFieldsStr().orElse(null);
++    if (orderingFields != null) {
++      conf.set(FlinkOptions.ORDERING_FIELDS, orderingFields);
+     }
+   }
+ 

--- a/pr_13718_files/0039.diff
+++ b/pr_13718_files/0039.diff
@@ -1,0 +1,59 @@
+diff --git a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+index 0369d0e168032..355bb19011319 100644
+--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
++++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/util/StreamerUtil.java
+@@ -175,8 +175,8 @@ public static DFSPropertiesConfiguration readConfig(org.apache.hadoop.conf.Confi
+   public static HoodiePayloadConfig getPayloadConfig(Configuration conf) {
+     return HoodiePayloadConfig.newBuilder()
+         .withPayloadClass(conf.get(FlinkOptions.PAYLOAD_CLASS_NAME))
+-        .withPayloadOrderingFields(conf.get(FlinkOptions.PRECOMBINE_FIELD))
+-        .withPayloadEventTimeField(conf.get(FlinkOptions.PRECOMBINE_FIELD))
++        .withPayloadOrderingFields(conf.get(FlinkOptions.ORDERING_FIELDS))
++        .withPayloadEventTimeField(conf.get(FlinkOptions.ORDERING_FIELDS))
+         .build();
+   }
+ 
+@@ -296,7 +296,7 @@ public static HoodieTableMetaClient initTableIfNotExists(
+           .setPayloadClassName(getPayloadClass(conf))
+           .setDatabaseName(conf.get(FlinkOptions.DATABASE_NAME))
+           .setRecordKeyFields(conf.getString(FlinkOptions.RECORD_KEY_FIELD.key(), null))
+-          .setPreCombineFields(OptionsResolver.getPreCombineField(conf))
++          .setOrderingFields(OptionsResolver.getOrderingFieldsStr(conf))
+           .setArchiveLogFolder(TIMELINE_HISTORY_PATH.defaultValue())
+           .setPartitionFields(conf.getString(FlinkOptions.PARTITION_PATH_FIELD.key(), null))
+           .setKeyGeneratorClassProp(
+@@ -404,7 +404,7 @@ public static void addFlinkCheckpointIdIntoMetaData(
+    */
+   public static Triple<RecordMergeMode, String, String> inferMergingBehavior(Configuration conf) {
+     return HoodieTableConfig.inferCorrectMergingBehavior(
+-        getMergeMode(conf), getPayloadClass(conf), getMergeStrategyId(conf), OptionsResolver.getPreCombineField(conf), HoodieTableVersion.EIGHT);
++        getMergeMode(conf), getPayloadClass(conf), getMergeStrategyId(conf), OptionsResolver.getOrderingFieldsStr(conf), HoodieTableVersion.EIGHT);
+   }
+ 
+   /**
+@@ -657,17 +657,17 @@ public static boolean isWriteCommit(HoodieTableType tableType, HoodieInstant ins
+    * Validate pre_combine key.
+    */
+   public static void checkPreCombineKey(Configuration conf, List<String> fields) {
+-    String preCombineField = conf.get(FlinkOptions.PRECOMBINE_FIELD);
+-    if (!fields.contains(preCombineField)) {
++    String orderingFields = conf.get(FlinkOptions.ORDERING_FIELDS);
++    if (!fields.contains(orderingFields)) {
+       if (OptionsResolver.isDefaultHoodieRecordPayloadClazz(conf)) {
+-        throw new HoodieValidationException("Option '" + FlinkOptions.PRECOMBINE_FIELD.key()
++        throw new HoodieValidationException("Option '" + FlinkOptions.ORDERING_FIELDS.key()
+                 + "' is required for payload class: " + DefaultHoodieRecordPayload.class.getName());
+       }
+-      if (preCombineField.equals(FlinkOptions.PRECOMBINE_FIELD.defaultValue())) {
+-        conf.set(FlinkOptions.PRECOMBINE_FIELD, FlinkOptions.NO_PRE_COMBINE);
+-      } else if (!preCombineField.equals(FlinkOptions.NO_PRE_COMBINE)) {
+-        throw new HoodieValidationException("Field " + preCombineField + " does not exist in the table schema."
+-                + "Please check '" + FlinkOptions.PRECOMBINE_FIELD.key() + "' option.");
++      if (orderingFields.equals(FlinkOptions.ORDERING_FIELDS.defaultValue())) {
++        conf.set(FlinkOptions.ORDERING_FIELDS, FlinkOptions.NO_PRE_COMBINE);
++      } else if (!orderingFields.equals(FlinkOptions.NO_PRE_COMBINE)) {
++        throw new HoodieValidationException("Field " + orderingFields + " does not exist in the table schema."
++                + "Please check '" + FlinkOptions.ORDERING_FIELDS.key() + "' option.");
+       }
+     }
+   }

--- a/pr_13718_files/0040.diff
+++ b/pr_13718_files/0040.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnRead.java b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnRead.java
+index fc7dd4a3d2da9..6deef95901700 100644
+--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnRead.java
++++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/TestWriteMergeOnRead.java
+@@ -99,7 +99,7 @@ public void testEventTimeAvroPayloadMergeRead() throws Exception {
+     conf.set(FlinkOptions.CHANGELOG_ENABLED, false);
+     conf.set(FlinkOptions.COMPACTION_DELTA_COMMITS, 2);
+     conf.set(FlinkOptions.PRE_COMBINE, true);
+-    conf.set(FlinkOptions.PRECOMBINE_FIELD, "ts");
++    conf.set(FlinkOptions.ORDERING_FIELDS, "ts");
+     conf.set(FlinkOptions.PAYLOAD_CLASS_NAME, EventTimeAvroPayload.class.getName());
+     HashMap<String, String> mergedExpected = new HashMap<>(EXPECTED1);
+     mergedExpected.put("par1", "[id1,par1,id1,Danny,22,4,par1, id2,par1,id2,Stephen,33,2,par1]");

--- a/pr_13718_files/0041.diff
+++ b/pr_13718_files/0041.diff
@@ -1,0 +1,67 @@
+diff --git a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
+index 5462ce3892ef8..0a317c5f40b66 100644
+--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
++++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/ITTestHoodieDataSource.java
+@@ -689,7 +689,7 @@ void testWriteAndReadWithProctimeSequenceWithTsColumnExisting(HoodieTableType ta
+         .option(FlinkOptions.PATH, tempFile.getAbsolutePath())
+         .option(FlinkOptions.TABLE_TYPE, tableType)
+         .option(FlinkOptions.HIVE_STYLE_PARTITIONING, hiveStylePartitioning)
+-        .option(FlinkOptions.PRECOMBINE_FIELD, FlinkOptions.NO_PRE_COMBINE)
++        .option(FlinkOptions.ORDERING_FIELDS, FlinkOptions.NO_PRE_COMBINE)
+         .end();
+     tableEnv.executeSql(hoodieTableDDL);
+ 
+@@ -1541,7 +1541,7 @@ void testWriteReadDecimals(String operation) {
+         .field("f3 decimal(38, 18)")
+         .option(FlinkOptions.PATH, tempFile.getAbsolutePath())
+         .option(FlinkOptions.OPERATION, operation)
+-        .option(FlinkOptions.PRECOMBINE_FIELD, "f1")
++        .option(FlinkOptions.ORDERING_FIELDS, "f1")
+         .pkField("f0")
+         .noPartition()
+         .end();
+@@ -2098,7 +2098,7 @@ void testBuiltinFunctionWithHMSCatalog() {
+         .pkField("f_int")
+         .partitionField("f_par")
+         .option(FlinkOptions.RECORD_KEY_FIELD, "f_int")
+-        .option(FlinkOptions.PRECOMBINE_FIELD, "f_date")
++        .option(FlinkOptions.ORDERING_FIELDS, "f_date")
+         .end();
+     tableEnv.executeSql(hoodieTableDDL);
+ 
+@@ -2126,7 +2126,7 @@ void testWriteReadWithComputedColumns() {
+         .field("f2 bigint")
+         .field("f3 as f0 + f2")
+         .option(FlinkOptions.PATH, tempFile.getAbsolutePath())
+-        .option(FlinkOptions.PRECOMBINE_FIELD, "f1")
++        .option(FlinkOptions.ORDERING_FIELDS, "f1")
+         .pkField("f0")
+         .noPartition()
+         .end();
+@@ -2154,7 +2154,7 @@ void testWriteReadWithComputedColumnsInTheMiddle() {
+         .field("f2 as f0 + f1")
+         .field("f3 varchar(10)")
+         .option(FlinkOptions.PATH, tempFile.getAbsolutePath())
+-        .option(FlinkOptions.PRECOMBINE_FIELD, "f1")
++        .option(FlinkOptions.ORDERING_FIELDS, "f1")
+         .pkField("f0")
+         .noPartition()
+         .end();
+@@ -2184,7 +2184,7 @@ void testWriteReadWithLocalTimestamp(HoodieTableType tableType) {
+         .field("f2 TIMESTAMP_LTZ(3)")
+         .field("f4 TIMESTAMP_LTZ(6)")
+         .option(FlinkOptions.PATH, tempFile.getAbsolutePath())
+-        .option(FlinkOptions.PRECOMBINE_FIELD, "f1")
++        .option(FlinkOptions.ORDERING_FIELDS, "f1")
+         .option(FlinkOptions.TABLE_TYPE, tableType)
+         .pkField("f0")
+         .noPartition()
+@@ -2215,7 +2215,7 @@ void testWriteReadWithTimestampWithoutTZ(HoodieTableType tableType, boolean read
+         .field("f2 TIMESTAMP(3)")
+         .field("f3 TIMESTAMP(6)")
+         .option(FlinkOptions.PATH, tempFile.getAbsolutePath())
+-        .option(FlinkOptions.PRECOMBINE_FIELD, "f1")
++        .option(FlinkOptions.ORDERING_FIELDS, "f1")
+         .option(FlinkOptions.TABLE_TYPE, tableType)
+         .option(FlinkOptions.WRITE_UTC_TIMEZONE, false)
+         .option(FlinkOptions.READ_UTC_TIMEZONE, readUtcTimezone)

--- a/pr_13718_files/0042.diff
+++ b/pr_13718_files/0042.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieFileGroupReaderOnFlink.java b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieFileGroupReaderOnFlink.java
+index dc66a0e6a74c0..5c169f62cb9f6 100644
+--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieFileGroupReaderOnFlink.java
++++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieFileGroupReaderOnFlink.java
+@@ -33,6 +33,7 @@
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+ import org.apache.hudi.common.testutils.HoodieTestUtils;
+ import org.apache.hudi.common.util.CollectionUtils;
++import org.apache.hudi.common.util.ConfigUtils;
+ import org.apache.hudi.common.util.Option;
+ import org.apache.hudi.common.util.OrderingValues;
+ import org.apache.hudi.common.util.collection.ClosableIterator;
+@@ -140,7 +141,7 @@ protected void readWithFileGroupReader(
+   @Override
+   public void commitToTable(List<HoodieRecord> recordList, String operation, boolean firstCommit, Map<String, String> writeConfigs, String schemaStr) {
+     writeConfigs.forEach((key, value) -> conf.setString(key, value));
+-    conf.set(FlinkOptions.PRECOMBINE_FIELD, writeConfigs.get("hoodie.datasource.write.precombine.field"));
++    conf.set(FlinkOptions.ORDERING_FIELDS, ConfigUtils.getOrderingFieldsStrDuringWrite(writeConfigs));
+     conf.set(FlinkOptions.OPERATION, operation);
+     Schema localSchema = getRecordAvroSchema(schemaStr);
+     conf.set(FlinkOptions.SOURCE_AVRO_SCHEMA, localSchema.toString());

--- a/pr_13718_files/0043.diff
+++ b/pr_13718_files/0043.diff
@@ -1,0 +1,101 @@
+diff --git a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
+index 2a4eb3d61d6a7..a4a69706e4fe2 100644
+--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
++++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableFactory.java
+@@ -112,7 +112,7 @@ void testRequiredOptions() {
+     assertDoesNotThrow(() -> new HoodieTableFactory().createDynamicTableSink(sourceContext11));
+     //miss the pre combine key will be ok
+     HoodieTableSink tableSink11 = (HoodieTableSink) new HoodieTableFactory().createDynamicTableSink(sourceContext11);
+-    assertThat(tableSink11.getConf().get(FlinkOptions.PRECOMBINE_FIELD), is(FlinkOptions.NO_PRE_COMBINE));
++    assertThat(tableSink11.getConf().get(FlinkOptions.ORDERING_FIELDS), is(FlinkOptions.NO_PRE_COMBINE));
+     this.conf.set(FlinkOptions.OPERATION, FlinkOptions.OPERATION.defaultValue());
+ 
+     // a non-exists precombine key will throw exception
+@@ -121,12 +121,12 @@ void testRequiredOptions() {
+         .field("f1", DataTypes.VARCHAR(20))
+         .field("f2", DataTypes.TIMESTAMP(3))
+         .build();
+-    this.conf.set(FlinkOptions.PRECOMBINE_FIELD, "non_exist_field");
++    this.conf.set(FlinkOptions.ORDERING_FIELDS, "non_exist_field");
+     final MockContext sourceContext2 = MockContext.getInstance(this.conf, schema2, "f2");
+     // createDynamicTableSource doesn't call sanity check, will not throw exception
+     assertDoesNotThrow(() -> new HoodieTableFactory().createDynamicTableSource(sourceContext2));
+     assertThrows(HoodieValidationException.class, () -> new HoodieTableFactory().createDynamicTableSink(sourceContext2));
+-    this.conf.set(FlinkOptions.PRECOMBINE_FIELD, FlinkOptions.PRECOMBINE_FIELD.defaultValue());
++    this.conf.set(FlinkOptions.ORDERING_FIELDS, FlinkOptions.ORDERING_FIELDS.defaultValue());
+ 
+     // given the pk but miss the pre combine key will be ok
+     ResolvedSchema schema3 = SchemaBuilder.instance()
+@@ -139,7 +139,7 @@ void testRequiredOptions() {
+     HoodieTableSource tableSource = (HoodieTableSource) new HoodieTableFactory().createDynamicTableSource(sourceContext3);
+     HoodieTableSink tableSink = (HoodieTableSink) new HoodieTableFactory().createDynamicTableSink(sourceContext3);
+     // the precombine field is overwritten
+-    assertThat(tableSink.getConf().get(FlinkOptions.PRECOMBINE_FIELD), is(FlinkOptions.NO_PRE_COMBINE));
++    assertThat(tableSink.getConf().get(FlinkOptions.ORDERING_FIELDS), is(FlinkOptions.NO_PRE_COMBINE));
+     // precombine field not specified, use the default payload clazz
+     assertThat(tableSource.getConf().get(FlinkOptions.PAYLOAD_CLASS_NAME), is(FlinkOptions.PAYLOAD_CLASS_NAME.defaultValue()));
+     assertThat(tableSink.getConf().get(FlinkOptions.PAYLOAD_CLASS_NAME), is(FlinkOptions.PAYLOAD_CLASS_NAME.defaultValue()));
+@@ -147,7 +147,7 @@ void testRequiredOptions() {
+     // append mode given the pk but miss the pre combine key will be ok
+     this.conf.set(FlinkOptions.OPERATION, "insert");
+     HoodieTableSink tableSink3 = (HoodieTableSink) new HoodieTableFactory().createDynamicTableSink(sourceContext3);
+-    assertThat(tableSink3.getConf().get(FlinkOptions.PRECOMBINE_FIELD), is(FlinkOptions.NO_PRE_COMBINE));
++    assertThat(tableSink3.getConf().get(FlinkOptions.ORDERING_FIELDS), is(FlinkOptions.NO_PRE_COMBINE));
+     this.conf.set(FlinkOptions.OPERATION, FlinkOptions.OPERATION.defaultValue());
+ 
+     this.conf.set(FlinkOptions.PAYLOAD_CLASS_NAME, DefaultHoodieRecordPayload.class.getName());
+@@ -185,7 +185,7 @@ void testRequiredOptions() {
+         .field("ts", DataTypes.TIMESTAMP(3))
+         .primaryKey("f0")
+         .build();
+-    this.conf.set(FlinkOptions.PRECOMBINE_FIELD, FlinkOptions.NO_PRE_COMBINE);
++    this.conf.set(FlinkOptions.ORDERING_FIELDS, FlinkOptions.NO_PRE_COMBINE);
+     final MockContext sourceContext6 = MockContext.getInstance(this.conf, schema5, "f2");
+ 
+     assertDoesNotThrow(() -> new HoodieTableFactory().createDynamicTableSource(sourceContext6));
+@@ -266,7 +266,7 @@ void testSupplementTableConfig() throws Exception {
+     tableConf.set(FlinkOptions.PATH, tablePath);
+     tableConf.set(FlinkOptions.TABLE_NAME, "t2");
+     tableConf.set(FlinkOptions.RECORD_KEY_FIELD, "f0,f1");
+-    tableConf.set(FlinkOptions.PRECOMBINE_FIELD, "f2");
++    tableConf.set(FlinkOptions.ORDERING_FIELDS, "f2");
+     tableConf.set(FlinkOptions.TABLE_TYPE, FlinkOptions.TABLE_TYPE_MERGE_ON_READ);
+     tableConf.set(FlinkOptions.PAYLOAD_CLASS_NAME, "my_payload");
+     tableConf.set(FlinkOptions.PARTITION_PATH_FIELD, "partition");
+@@ -292,9 +292,9 @@ void testSupplementTableConfig() throws Exception {
+     assertThat("pk not provided, fallback to table config",
+         sink1.getConf().get(FlinkOptions.RECORD_KEY_FIELD), is("f0,f1"));
+     assertThat("pre-combine key not provided, fallback to table config",
+-        source1.getConf().get(FlinkOptions.PRECOMBINE_FIELD), is("f2"));
++        source1.getConf().get(FlinkOptions.ORDERING_FIELDS), is("f2"));
+     assertThat("pre-combine key not provided, fallback to table config",
+-        sink1.getConf().get(FlinkOptions.PRECOMBINE_FIELD), is("f2"));
++        sink1.getConf().get(FlinkOptions.ORDERING_FIELDS), is("f2"));
+     assertThat("table type not provided, fallback to table config",
+         source1.getConf().get(FlinkOptions.TABLE_TYPE), is(FlinkOptions.TABLE_TYPE_MERGE_ON_READ));
+     assertThat("table type not provided, fallback to table config",
+@@ -307,7 +307,7 @@ void testSupplementTableConfig() throws Exception {
+     // write config always has higher priority
+     // set up a different primary key and pre_combine key with table config options
+     writeConf.set(FlinkOptions.RECORD_KEY_FIELD, "f0");
+-    writeConf.set(FlinkOptions.PRECOMBINE_FIELD, "f1");
++    writeConf.set(FlinkOptions.ORDERING_FIELDS, "f1");
+ 
+     final MockContext sourceContext2 = MockContext.getInstance(writeConf, schema1, "f2");
+     HoodieTableSource source2 = (HoodieTableSource) new HoodieTableFactory().createDynamicTableSource(sourceContext2);
+@@ -317,12 +317,12 @@ void testSupplementTableConfig() throws Exception {
+     assertThat("choose pk from write config",
+         sink2.getConf().get(FlinkOptions.RECORD_KEY_FIELD), is("f0"));
+     assertThat("choose preCombine key from write config",
+-        source2.getConf().get(FlinkOptions.PRECOMBINE_FIELD), is("f1"));
++        source2.getConf().get(FlinkOptions.ORDERING_FIELDS), is("f1"));
+     assertThat("choose preCombine pk from write config",
+-        sink2.getConf().get(FlinkOptions.PRECOMBINE_FIELD), is("f1"));
++        sink2.getConf().get(FlinkOptions.ORDERING_FIELDS), is("f1"));
+ 
+     writeConf.removeConfig(FlinkOptions.RECORD_KEY_FIELD);
+-    writeConf.removeConfig(FlinkOptions.PRECOMBINE_FIELD);
++    writeConf.removeConfig(FlinkOptions.ORDERING_FIELDS);
+ 
+     // pk defined in table config but missing in schema will throw
+     ResolvedSchema schema2 = SchemaBuilder.instance()

--- a/pr_13718_files/0044.diff
+++ b/pr_13718_files/0044.diff
@@ -1,0 +1,31 @@
+diff --git a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableSource.java b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableSource.java
+index ae6320606b2b7..f12fc0b832f75 100644
+--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableSource.java
++++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/TestHoodieTableSource.java
+@@ -270,7 +270,7 @@ void testBucketPruningSpecialKeyDataType(boolean logicalTimestamp) throws Except
+     final String f1 = "f_timestamp";
+     conf1.set(FlinkOptions.INDEX_TYPE, "BUCKET");
+     conf1.set(FlinkOptions.RECORD_KEY_FIELD, f1);
+-    conf1.set(FlinkOptions.PRECOMBINE_FIELD, f1);
++    conf1.set(FlinkOptions.ORDERING_FIELDS, f1);
+     conf1.removeConfig(FlinkOptions.PARTITION_PATH_FIELD);
+     conf1.setString(KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key(), logicalTimestamp + "");
+     int numBuckets = (int)FlinkOptions.BUCKET_INDEX_NUM_BUCKETS.defaultValue();
+@@ -292,7 +292,7 @@ void testBucketPruningSpecialKeyDataType(boolean logicalTimestamp) throws Except
+     String tablePath2 = new Path(tempFile.getAbsolutePath(), "tbl2").toString();
+     conf2.set(FlinkOptions.PATH, tablePath2);
+     conf2.set(FlinkOptions.RECORD_KEY_FIELD, f2);
+-    conf2.set(FlinkOptions.PRECOMBINE_FIELD, f2);
++    conf2.set(FlinkOptions.ORDERING_FIELDS, f2);
+     TestData.writeDataAsBatch(TestData.DATA_SET_INSERT_HOODIE_KEY_SPECIAL_DATA_TYPE, conf2);
+     HoodieTableSource tableSource2 = createHoodieTableSource(conf2);
+     tableSource2.applyFilters(Collections.singletonList(
+@@ -308,7 +308,7 @@ void testBucketPruningSpecialKeyDataType(boolean logicalTimestamp) throws Except
+     String tablePath3 = new Path(tempFile.getAbsolutePath(), "tbl3").toString();
+     conf3.set(FlinkOptions.PATH, tablePath3);
+     conf3.set(FlinkOptions.RECORD_KEY_FIELD, f3);
+-    conf3.set(FlinkOptions.PRECOMBINE_FIELD, f3);
++    conf3.set(FlinkOptions.ORDERING_FIELDS, f3);
+     TestData.writeDataAsBatch(TestData.DATA_SET_INSERT_HOODIE_KEY_SPECIAL_DATA_TYPE, conf3);
+     HoodieTableSource tableSource3 = createHoodieTableSource(conf3);
+     tableSource3.applyFilters(Collections.singletonList(

--- a/pr_13718_files/0045.diff
+++ b/pr_13718_files/0045.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieCatalog.java b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieCatalog.java
+index 3d202be87c4d0..272b54b56f15c 100644
+--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieCatalog.java
++++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieCatalog.java
+@@ -383,7 +383,7 @@ void testCreateTableWithoutPreCombineKey() {
+             + "org.apache.hudi.common.model.DefaultHoodieRecordPayload");
+ 
+     Map<String, String> options2 = getDefaultCatalogOption();
+-    options2.put(FlinkOptions.PRECOMBINE_FIELD.key(), "not_exists");
++    options2.put(FlinkOptions.ORDERING_FIELDS.key(), "not_exists");
+     catalog = new HoodieCatalog("hudi", Configuration.fromMap(options2));
+     catalog.open();
+     ObjectPath tablePath2 = new ObjectPath(TEST_DEFAULT_DATABASE, "tb2");

--- a/pr_13718_files/0046.diff
+++ b/pr_13718_files/0046.diff
@@ -1,0 +1,39 @@
+diff --git a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieHiveCatalog.java b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieHiveCatalog.java
+index a25cf3a84bb14..98ded34cb2b72 100644
+--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieHiveCatalog.java
++++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/table/catalog/TestHoodieHiveCatalog.java
+@@ -76,7 +76,7 @@
+ import java.util.stream.Collectors;
+ 
+ import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
+-import static org.apache.hudi.configuration.FlinkOptions.PRECOMBINE_FIELD;
++import static org.apache.hudi.configuration.FlinkOptions.ORDERING_FIELDS;
+ import static org.apache.hudi.keygen.constant.KeyGeneratorOptions.RECORDKEY_FIELD_NAME;
+ import static org.apache.hudi.table.catalog.HoodieCatalogTestUtils.createStorageConf;
+ import static org.hamcrest.CoreMatchers.containsString;
+@@ -208,7 +208,7 @@ public void testCreateAndGetHoodieTable(HoodieTableType tableType) throws Except
+     assertEquals("hudi", table1.getOptions().get(CONNECTOR.key()));
+     assertEquals(tableType.toString(), table1.getOptions().get(FlinkOptions.TABLE_TYPE.key()));
+     assertEquals("uuid", table1.getOptions().get(FlinkOptions.RECORD_KEY_FIELD.key()));
+-    assertNull(table1.getOptions().get(PRECOMBINE_FIELD.key()), "preCombine key is not declared");
++    assertNull(table1.getOptions().get(ORDERING_FIELDS.key()), "preCombine key is not declared");
+     String tableSchema = table1.getUnresolvedSchema().getColumns().stream()
+         .map(Schema.UnresolvedColumn::toString)
+         .collect(Collectors.joining(","));
+@@ -331,12 +331,12 @@ void testCreateTableWithoutPreCombineKey() throws TableAlreadyExistException, Da
+     options.put(FactoryUtil.CONNECTOR.key(), "hudi");
+ 
+     TypedProperties props = createTableAndReturnTableProperties(options, new ObjectPath(db, "tmptb1"));
+-    assertFalse(props.containsKey("hoodie.table.precombine.field"));
++    assertFalse(props.containsKey(HoodieTableConfig.ORDERING_FIELDS.key()));
+ 
+-    options.put(PRECOMBINE_FIELD.key(), "ts_3");
++    options.put(ORDERING_FIELDS.key(), "ts_3");
+     props = createTableAndReturnTableProperties(options, new ObjectPath(db, "tmptb2"));
+-    assertTrue(props.containsKey("hoodie.table.precombine.field"));
+-    assertEquals("ts_3", props.get("hoodie.table.precombine.field"));
++    assertTrue(props.containsKey(HoodieTableConfig.ORDERING_FIELDS.key()));
++    assertEquals("ts_3", props.get(HoodieTableConfig.ORDERING_FIELDS.key()));
+   }
+ 
+   private TypedProperties createTableAndReturnTableProperties(Map<String, String> options, ObjectPath tablePath)

--- a/pr_13718_files/0047.diff
+++ b/pr_13718_files/0047.diff
@@ -1,0 +1,22 @@
+diff --git a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java
+index d3d9b46708baf..1635278dc08d3 100644
+--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java
++++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/utils/TestStreamerUtil.java
+@@ -77,7 +77,7 @@ void testInitTableIfNotExists() throws IOException {
+     Configuration conf = TestConfigurations.getDefaultConf(tempFile.getAbsolutePath());
+ 
+     // Test for partitioned table.
+-    conf.set(FlinkOptions.PRECOMBINE_FIELD, "ts");
++    conf.set(FlinkOptions.ORDERING_FIELDS, "ts");
+     conf.set(FlinkOptions.PARTITION_PATH_FIELD, "p0,p1");
+     StreamerUtil.initTableIfNotExists(conf);
+ 
+@@ -86,7 +86,7 @@ void testInitTableIfNotExists() throws IOException {
+     assertTrue(metaClient1.getTableConfig().getPartitionFields().isPresent(),
+         "Missing partition columns in the hoodie.properties.");
+     assertArrayEquals(metaClient1.getTableConfig().getPartitionFields().get(), new String[] {"p0", "p1"});
+-    assertEquals(metaClient1.getTableConfig().getPreCombineFieldsStr().get(), "ts");
++    assertEquals(metaClient1.getTableConfig().getOrderingFieldsStr().get(), "ts");
+     assertEquals(metaClient1.getTableConfig().getKeyGeneratorClassName(), SimpleAvroKeyGenerator.class.getName());
+     assertEquals(HoodieTableVersion.current(), metaClient1.getTableConfig().getTableVersion());
+ 

--- a/pr_13718_files/0048.diff
+++ b/pr_13718_files/0048.diff
@@ -1,0 +1,33 @@
+diff --git a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+index 8b37c89a3a6c2..cc70833e560b2 100644
+--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
++++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableConfig.java
+@@ -120,7 +120,7 @@ void testCreate() throws IOException {
+   void testUpdate() throws IOException {
+     Properties updatedProps = new Properties();
+     updatedProps.setProperty(HoodieTableConfig.NAME.key(), "test-table2");
+-    updatedProps.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "new_field");
++    updatedProps.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), "new_field");
+     HoodieTableConfig.update(storage, metaPath, updatedProps);
+ 
+     assertTrue(storage.exists(cfgPath));
+@@ -128,8 +128,8 @@ void testUpdate() throws IOException {
+     HoodieTableConfig config = new HoodieTableConfig(storage, metaPath, null, null, null);
+     assertEquals(8, config.getProps().size());
+     assertEquals("test-table2", config.getTableName());
+-    assertEquals(Collections.singletonList("new_field"), config.getPreCombineFields());
+-    assertEquals(Option.of("new_field"), config.getPreCombineFieldsStr());
++    assertEquals(Collections.singletonList("new_field"), config.getOrderingFields());
++    assertEquals(Option.of("new_field"), config.getOrderingFieldsStr());
+   }
+ 
+   @Test
+@@ -219,7 +219,7 @@ void testConcurrentlyUpdate() throws ExecutionException, InterruptedException {
+       for (int i = 0; i < 100; i++) {
+         Properties updatedProps = new Properties();
+         updatedProps.setProperty(HoodieTableConfig.NAME.key(), "test-table" + i);
+-        updatedProps.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "new_field" + i);
++        updatedProps.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), "new_field" + i);
+         HoodieTableConfig.update(storage, metaPath, updatedProps);
+       }
+     });

--- a/pr_13718_files/0049.diff
+++ b/pr_13718_files/0049.diff
@@ -1,0 +1,22 @@
+diff --git a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
+index dc7c022472c95..fd85ea2581788 100644
+--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
++++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
+@@ -204,7 +204,7 @@ void testCreateMetaClientFromProperties() throws IOException {
+     Properties props = new Properties();
+     props.setProperty(HoodieTableConfig.NAME.key(), "test-table");
+     props.setProperty(HoodieTableConfig.TYPE.key(), HoodieTableType.COPY_ON_WRITE.name());
+-    props.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "timestamp");
++    props.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+ 
+     HoodieTableMetaClient metaClient1 = HoodieTableMetaClient.newTableBuilder()
+         .fromProperties(props)
+@@ -218,7 +218,7 @@ void testCreateMetaClientFromProperties() throws IOException {
+     // test table name and type and precombine field also match
+     assertEquals(metaClient1.getTableConfig().getTableName(), metaClient2.getTableConfig().getTableName());
+     assertEquals(metaClient1.getTableConfig().getTableType(), metaClient2.getTableConfig().getTableType());
+-    assertEquals(metaClient1.getTableConfig().getPreCombineFields(), metaClient2.getTableConfig().getPreCombineFields());
++    assertEquals(metaClient1.getTableConfig().getOrderingFields(), metaClient2.getTableConfig().getOrderingFields());
+     // default table version should be current version
+     assertEquals(HoodieTableVersion.current(), metaClient2.getTableConfig().getTableVersion());
+   }

--- a/pr_13718_files/0050.diff
+++ b/pr_13718_files/0050.diff
@@ -1,0 +1,22 @@
+diff --git a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestCustomRecordMerger.java b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestCustomRecordMerger.java
+index a1a73a3d20a90..b7eae52ad4b3c 100644
+--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestCustomRecordMerger.java
++++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestCustomRecordMerger.java
+@@ -53,7 +53,7 @@
+ 
+ import static org.apache.hudi.common.config.HoodieReaderConfig.RECORD_MERGE_IMPL_CLASSES_WRITE_CONFIG_KEY;
+ import static org.apache.hudi.common.model.HoodieRecord.HoodieRecordType.AVRO;
+-import static org.apache.hudi.common.table.HoodieTableConfig.PRECOMBINE_FIELDS;
++import static org.apache.hudi.common.table.HoodieTableConfig.ORDERING_FIELDS;
+ import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.AVRO_SCHEMA;
+ import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.DELETE;
+ import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.INSERT;
+@@ -68,7 +68,7 @@ protected Properties getMetaProps() {
+     Properties metaProps = super.getMetaProps();
+     metaProps.setProperty(HoodieTableConfig.RECORD_MERGE_MODE.key(), RecordMergeMode.CUSTOM.name());
+     metaProps.setProperty(HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key(), CustomAvroMerger.KEEP_CERTAIN_TIMESTAMP_VALUE_ONLY);
+-    metaProps.setProperty(PRECOMBINE_FIELDS.key(), "timestamp");
++    metaProps.setProperty(ORDERING_FIELDS.key(), "timestamp");
+     return metaProps;
+   }
+ 

--- a/pr_13718_files/0051.diff
+++ b/pr_13718_files/0051.diff
@@ -1,0 +1,22 @@
+diff --git a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestEventTimeMerging.java b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestEventTimeMerging.java
+index debbb57954398..0610dd4d8f837 100644
+--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestEventTimeMerging.java
++++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestEventTimeMerging.java
+@@ -44,7 +44,7 @@
+ import java.util.Properties;
+ import java.util.stream.Stream;
+ 
+-import static org.apache.hudi.common.table.HoodieTableConfig.PRECOMBINE_FIELDS;
++import static org.apache.hudi.common.table.HoodieTableConfig.ORDERING_FIELDS;
+ import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.AVRO_SCHEMA;
+ import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.DELETE;
+ import static org.apache.hudi.common.testutils.reader.DataGenerationPlan.OperationType.INSERT;
+@@ -58,7 +58,7 @@ public class TestEventTimeMerging extends HoodieFileGroupReaderTestHarness {
+   protected Properties getMetaProps() {
+     Properties metaProps =  super.getMetaProps();
+     metaProps.setProperty(HoodieTableConfig.RECORD_MERGE_MODE.key(), RecordMergeMode.EVENT_TIME_ORDERING.name());
+-    metaProps.setProperty(PRECOMBINE_FIELDS.key(), "timestamp");
++    metaProps.setProperty(ORDERING_FIELDS.key(), "timestamp");
+     return metaProps;
+   }
+ 

--- a/pr_13718_files/0052.diff
+++ b/pr_13718_files/0052.diff
@@ -1,0 +1,15 @@
+diff --git a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
+index fc4795d987639..f09898cb25914 100644
+--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
++++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/AbstractRealtimeRecordReader.java
+@@ -90,8 +90,8 @@ public AbstractRealtimeRecordReader(RealtimeSplit split, JobConf job) {
+       metaClient = HoodieTableMetaClient.builder()
+           .setConf(HadoopFSUtils.getStorageConfWithCopy(jobConf)).setBasePath(split.getBasePath()).build();
+       payloadProps.putAll(metaClient.getTableConfig().getProps(true));
+-      if (metaClient.getTableConfig().getPreCombineFieldsStr().isPresent()) {
+-        this.payloadProps.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, metaClient.getTableConfig().getPreCombineFieldsStr().orElse(null));
++      if (metaClient.getTableConfig().getOrderingFieldsStr().isPresent()) {
++        this.payloadProps.setProperty(HoodiePayloadProps.PAYLOAD_ORDERING_FIELD_PROP_KEY, metaClient.getTableConfig().getOrderingFieldsStr().orElse(null));
+       }
+       this.usesCustomPayload = usesCustomPayload(metaClient);
+       LOG.info("usesCustomPayload ==> " + this.usesCustomPayload);

--- a/pr_13718_files/0053.diff
+++ b/pr_13718_files/0053.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieParquetRealtimeInputFormat.java b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieParquetRealtimeInputFormat.java
+index cdeacaada6afe..1abb604b52f0c 100644
+--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieParquetRealtimeInputFormat.java
++++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieParquetRealtimeInputFormat.java
+@@ -114,7 +114,7 @@ void addProjectionToJobConf(final RealtimeSplit realtimeSplit, final JobConf job
+           List<String> fieldsToAdd = new ArrayList<>();
+           if (!realtimeSplit.getDeltaLogPaths().isEmpty()) {
+             HoodieRealtimeInputFormatUtils.addVirtualKeysProjection(jobConf, realtimeSplit.getVirtualKeyInfo());
+-            fieldsToAdd.addAll(tableConfig.getPreCombineFields());
++            fieldsToAdd.addAll(tableConfig.getOrderingFields());
+           }
+ 
+           Option<String[]> partitions = tableConfig.getPartitionFields();

--- a/pr_13718_files/0054.diff
+++ b/pr_13718_files/0054.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/SparkDataSourceContinuousIngestTool.java b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/SparkDataSourceContinuousIngestTool.java
+index a98415fa372cb..59533772a9690 100644
+--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/SparkDataSourceContinuousIngestTool.java
++++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/SparkDataSourceContinuousIngestTool.java
+@@ -61,7 +61,7 @@
+  * hoodie.datasource.write.recordkey.field=VendorID
+  * hoodie.datasource.write.partitionpath.field=date_col
+  * hoodie.datasource.write.operation=upsert
+- * hoodie.datasource.write.precombine.field=tpep_pickup_datetime
++ * hoodie.datasource.write.precombine.fields=tpep_pickup_datetime
+  * hoodie.metadata.enable=false
+  * hoodie.table.name=hudi_tbl
+  */

--- a/pr_13718_files/0055.diff
+++ b/pr_13718_files/0055.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-integ-test/src/main/scala/org/apache/hudi/integ/testsuite/dag/nodes/SparkInsertNode.scala b/hudi-integ-test/src/main/scala/org/apache/hudi/integ/testsuite/dag/nodes/SparkInsertNode.scala
+index b4d028c79c85a..f35ed92785121 100644
+--- a/hudi-integ-test/src/main/scala/org/apache/hudi/integ/testsuite/dag/nodes/SparkInsertNode.scala
++++ b/hudi-integ-test/src/main/scala/org/apache/hudi/integ/testsuite/dag/nodes/SparkInsertNode.scala
+@@ -68,7 +68,7 @@ class SparkInsertNode(dagNodeConfig: Config) extends DagNode[RDD[WriteStatus]] {
+ 
+     inputDF.write.format("hudi")
+       .options(DataSourceWriteOptions.mayBeDerivePartitionPath(context.getWriterContext.getProps.asScala.toMap))
+-      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key(), "test_suite_source_ordering_field")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key(), "test_suite_source_ordering_field")
+       .option(DataSourceWriteOptions.TABLE_NAME.key, context.getHoodieTestSuiteWriter.getCfg.targetTableName)
+       .option(DataSourceWriteOptions.TABLE_TYPE.key, context.getHoodieTestSuiteWriter.getCfg.tableType)
+       .option(HoodieIndexConfig.INDEX_TYPE.key, context.getHoodieTestSuiteWriter.getCfg.indexType)

--- a/pr_13718_files/0056.diff
+++ b/pr_13718_files/0056.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-integ-test/src/main/scala/org/apache/hudi/integ/testsuite/dag/nodes/SparkUpsertNode.scala b/hudi-integ-test/src/main/scala/org/apache/hudi/integ/testsuite/dag/nodes/SparkUpsertNode.scala
+index 9e85fc38d8e3c..ff983741b1971 100644
+--- a/hudi-integ-test/src/main/scala/org/apache/hudi/integ/testsuite/dag/nodes/SparkUpsertNode.scala
++++ b/hudi-integ-test/src/main/scala/org/apache/hudi/integ/testsuite/dag/nodes/SparkUpsertNode.scala
+@@ -68,7 +68,7 @@ class SparkUpsertNode(dagNodeConfig: Config) extends SparkInsertNode(dagNodeConf
+ 
+     inputDF.write.format("hudi")
+       .options(DataSourceWriteOptions.translateSqlOptions(context.getWriterContext.getProps.asScala.toMap))
+-      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key(), "test_suite_source_ordering_field")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key(), "test_suite_source_ordering_field")
+       .option(DataSourceWriteOptions.TABLE_NAME.key, context.getHoodieTestSuiteWriter.getCfg.targetTableName)
+       .option(DataSourceWriteOptions.TABLE_TYPE.key, context.getHoodieTestSuiteWriter.getCfg.tableType)
+       .option(DataSourceWriteOptions.OPERATION.key, getOperation())

--- a/pr_13718_files/0057.diff
+++ b/pr_13718_files/0057.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
+index fd65233f1e36d..5176df32e7753 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/DataSourceUtils.java
+@@ -34,6 +34,7 @@
+ import org.apache.hudi.common.model.HoodieRecordPayload;
+ import org.apache.hudi.common.model.WriteOperationType;
+ import org.apache.hudi.common.table.HoodieTableConfig;
++import org.apache.hudi.common.util.ConfigUtils;
+ import org.apache.hudi.common.util.Option;
+ import org.apache.hudi.common.util.ReflectionUtils;
+ import org.apache.hudi.common.util.StringUtils;
+@@ -206,7 +207,7 @@ public static HoodieWriteConfig createHoodieConfig(String schemaStr, String base
+             .withPayloadClass(parameters.getOrDefault(DataSourceWriteOptions.PAYLOAD_CLASS_NAME().key(),
+                 parameters.getOrDefault(HoodieTableConfig.PAYLOAD_CLASS_NAME.key(), HoodieTableConfig.DEFAULT_PAYLOAD_CLASS_NAME)))
+             .withPayloadOrderingFields(parameters.getOrDefault(DataSourceWriteOptions.PRECOMBINE_FIELD().key(),
+-                parameters.get(HoodieTableConfig.PRECOMBINE_FIELDS)))
++                ConfigUtils.getStringWithAltKeys(parameters, HoodieTableConfig.ORDERING_FIELDS)))
+             .build())
+         // override above with Hoodie configs specified as options.
+         .withProps(parameters).build();

--- a/pr_13718_files/0058.diff
+++ b/pr_13718_files/0058.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
+index 16041fdae5a52..7612ad95fe3c9 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/java/org/apache/hudi/commit/BaseDatasetBulkInsertCommitActionExecutor.java
+@@ -105,7 +105,7 @@ public final HoodieWriteResult execute(Dataset<Row> records, boolean isTablePart
+     preExecute();
+ 
+     BulkInsertPartitioner<Dataset<Row>> bulkInsertPartitionerRows = getPartitioner(populateMetaFields, isTablePartitioned);
+-    Dataset<Row> hoodieDF = HoodieDatasetBulkInsertHelper.prepareForBulkInsert(records, writeConfig, bulkInsertPartitionerRows, instantTime);
++    Dataset<Row> hoodieDF = HoodieDatasetBulkInsertHelper.prepareForBulkInsert(records, writeConfig, table.getMetaClient().getTableConfig(), bulkInsertPartitionerRows, instantTime);
+ 
+     HoodieWriteMetadata<JavaRDD<WriteStatus>> result = buildHoodieWriteMetadata(doExecute(hoodieDF, bulkInsertPartitionerRows.arePartitionRecordsSorted()));
+     afterExecute(result);

--- a/pr_13718_files/0059.diff
+++ b/pr_13718_files/0059.diff
@@ -1,0 +1,30 @@
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+index f1ab811b07673..8e8381b8a0c68 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DataSourceOptions.scala
+@@ -85,6 +85,7 @@ object DataSourceReadOptions {
+     .markAdvanced()
+     .withDocumentation("Comma separated list of file paths to read within a Hudi table.")
+ 
++  @Deprecated
+   val READ_PRE_COMBINE_FIELD = HoodieWriteConfig.PRECOMBINE_FIELD_NAME
+ 
+   val ENABLE_HOODIE_FILE_INDEX: ConfigProperty[Boolean] = ConfigProperty
+@@ -1031,9 +1032,6 @@ object DataSourceOptionsHelper {
+     if (!params.contains(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key()) && tableConfig.getKeyGeneratorClassName != null) {
+       missingWriteConfigs ++= Map(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key() -> tableConfig.getKeyGeneratorClassName)
+     }
+-    if (!params.contains(HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key()) && tableConfig.getPreCombineFieldsStr.isPresent) {
+-      missingWriteConfigs ++= Map(HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key -> tableConfig.getPreCombineFieldsStr.orElse(null))
+-    }
+     if (!params.contains(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key()) && tableConfig.getPayloadClass != null) {
+       missingWriteConfigs ++= Map(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key() -> tableConfig.getPayloadClass)
+     }
+@@ -1073,6 +1071,7 @@ object DataSourceOptionsHelper {
+   /**
+    * Returns optional list of precombine fields from the provided parameteres.
+    */
++  @deprecated("Use preCombine key in table config", "1.1.0")
+   def getPreCombineFields(params: Map[String, String]): Option[java.util.List[String]] = params.get(DataSourceWriteOptions.PRECOMBINE_FIELD.key) match {
+     // NOTE: This is required to compensate for cases when empty string is used to stub
+     //       property value to avoid it being set with the default value

--- a/pr_13718_files/0060.diff
+++ b/pr_13718_files/0060.diff
@@ -1,0 +1,15 @@
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+index 9269315de982d..54ca53794e346 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/DefaultSource.scala
+@@ -135,8 +135,8 @@ class DefaultSource extends RelationProvider
+       .setBasePath(tablePath).build()
+ 
+     // Add preCombineField to options for buildReaderWithPartitionValues properly
+-    val options = if (metaClient.getTableConfig.getPreCombineFieldsStr.isPresent) {
+-      parameters ++ Map(HoodieTableConfig.PRECOMBINE_FIELDS.key -> metaClient.getTableConfig.getPreCombineFieldsStr.orElse(null))
++    val options = if (metaClient.getTableConfig.getOrderingFieldsStr.isPresent) {
++      parameters ++ Map(HoodieTableConfig.ORDERING_FIELDS.key -> metaClient.getTableConfig.getOrderingFieldsStr.orElse(null))
+     } else {
+       parameters
+     }

--- a/pr_13718_files/0061.diff
+++ b/pr_13718_files/0061.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+index 54a3577f7f6c8..5cbfdcef050e4 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieBaseRelation.scala
+@@ -136,7 +136,7 @@ abstract class HoodieBaseRelation(val sqlContext: SQLContext,
+     }
+ 
+   protected lazy val preCombineFields: List[String] = {
+-    val tablePrecombineFields = tableConfig.getPreCombineFields
++    val tablePrecombineFields = tableConfig.getOrderingFields
+     if (tablePrecombineFields.isEmpty) {
+       DataSourceOptionsHelper.getPreCombineFields(optParams)
+         .orElse(java.util.Collections.emptyList[String])

--- a/pr_13718_files/0062.diff
+++ b/pr_13718_files/0062.diff
@@ -1,0 +1,42 @@
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCreateRecordUtils.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCreateRecordUtils.scala
+index 5466a790772f9..0c4f87a244fd0 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCreateRecordUtils.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieCreateRecordUtils.scala
+@@ -58,7 +58,8 @@ object HoodieCreateRecordUtils {
+                                        instantTime: String,
+                                        preppedSparkSqlWrites: Boolean,
+                                        preppedSparkSqlMergeInto: Boolean,
+-                                       preppedWriteOperation: Boolean)
++                                       preppedWriteOperation: Boolean,
++                                       orderingFields: java.util.List[String])
+ 
+   def createHoodieRecordRdd(args: createHoodieRecordRddArgs) = {
+     val df = args.df
+@@ -73,6 +74,7 @@ object HoodieCreateRecordUtils {
+     val preppedSparkSqlWrites = args.preppedSparkSqlWrites
+     val preppedSparkSqlMergeInto = args.preppedSparkSqlMergeInto
+     val preppedWriteOperation = args.preppedWriteOperation
++    val orderingFields = args.orderingFields
+ 
+     val shouldDropPartitionColumns = config.getBoolean(DataSourceWriteOptions.DROP_PARTITION_COLUMNS)
+     val recordType = config.getRecordMerger.getRecordType
+@@ -125,7 +127,6 @@ object HoodieCreateRecordUtils {
+           val consistentLogicalTimestampEnabled = parameters.getOrElse(
+             DataSourceWriteOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key(),
+             DataSourceWriteOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.defaultValue()).toBoolean
+-          val precombineFields = config.getPreCombineFields()
+ 
+           // handle dropping partition columns
+           it.map { avroRec =>
+@@ -143,9 +144,9 @@ object HoodieCreateRecordUtils {
+               avroRecWithoutMeta
+             }
+ 
+-            val hoodieRecord = if (shouldCombine && !precombineFields.isEmpty) {
++            val hoodieRecord = if (shouldCombine && !orderingFields.isEmpty) {
+               val orderingVal = OrderingValues.create(
+-                precombineFields,
++                orderingFields,
+                 JFunction.toJavaFunction[String, Comparable[_]](
+                   field => HoodieAvroUtils.getNestedFieldVal(avroRec, field, false,
+                     consistentLogicalTimestampEnabled).asInstanceOf[Comparable[_]]))

--- a/pr_13718_files/0063.diff
+++ b/pr_13718_files/0063.diff
@@ -1,0 +1,12 @@
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+index 135ade4bf4cc6..48718ff514de7 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieFileIndex.scala
+@@ -529,7 +529,6 @@ object HoodieFileIndex extends Logging {
+ 
+     if (tableConfig != null) {
+       properties.setProperty(RECORDKEY_FIELD.key, tableConfig.getRecordKeyFields.orElse(Array.empty).mkString(","))
+-      properties.setProperty(PRECOMBINE_FIELD.key, tableConfig.getPreCombineFieldsStr.orElse(""))
+       properties.setProperty(PARTITIONPATH_FIELD.key, HoodieTableConfig.getPartitionFieldPropForKeyGenerator(tableConfig).orElse(""))
+ 
+       // for simple bucket index, we need to set the INDEX_TYPE, BUCKET_INDEX_HASH_FIELD, BUCKET_INDEX_NUM_BUCKETS

--- a/pr_13718_files/0064.diff
+++ b/pr_13718_files/0064.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieHadoopFsRelationFactory.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieHadoopFsRelationFactory.scala
+index 0a9bef1ab30c1..1bd61407412dc 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieHadoopFsRelationFactory.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieHadoopFsRelationFactory.scala
+@@ -186,7 +186,7 @@ abstract class HoodieBaseHadoopFsRelationFactory(val sqlContext: SQLContext,
+   }
+ 
+   protected lazy val preCombineFields: List[String] = {
+-    val tablePrecombineFields = tableConfig.getPreCombineFields
++    val tablePrecombineFields = tableConfig.getOrderingFields
+     if (tablePrecombineFields.isEmpty) {
+       DataSourceOptionsHelper.getPreCombineFields(optParams)
+         .orElse(java.util.Collections.emptyList[String])

--- a/pr_13718_files/0065.diff
+++ b/pr_13718_files/0065.diff
@@ -1,0 +1,40 @@
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+index 1ac3a3fb0f3ce..b74467e3ab446 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+@@ -40,7 +40,7 @@ import org.apache.hudi.common.model.HoodieTableType.{COPY_ON_WRITE, MERGE_ON_REA
+ import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, HoodieTableVersion, TableSchemaResolver}
+ import org.apache.hudi.common.table.log.block.HoodieLogBlock.HoodieLogBlockType
+ import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator
+-import org.apache.hudi.common.util.{CommitUtils, Option => HOption, StringUtils}
++import org.apache.hudi.common.util.{CommitUtils, ConfigUtils, Option => HOption, StringUtils}
+ import org.apache.hudi.common.util.ConfigUtils.getAllConfigKeys
+ import org.apache.hudi.config.{HoodieCompactionConfig, HoodieIndexConfig, HoodieInternalConfig, HoodieWriteConfig}
+ import org.apache.hudi.config.HoodieBootstrapConfig.{BASE_PATH, INDEX_CLASS_NAME}
+@@ -310,7 +310,7 @@ class HoodieSparkSqlWriterInternal {
+           .setArchiveLogFolder(archiveLogFolder)
+           // we can't fetch preCombine field from hoodieConfig object, since it falls back to "ts" as default value,
+           // but we are interested in what user has set, hence fetching from optParams.
+-          .setPreCombineFields(optParams.getOrElse(PRECOMBINE_FIELD.key(), null))
++          .setOrderingFields(ConfigUtils.getOrderingFieldsStrDuringWrite(optParams.asJava))
+           .setPartitionFields(partitionColumnsForKeyGenerator)
+           .setPopulateMetaFields(populateMetaFields)
+           .setRecordKeyFields(hoodieConfig.getString(RECORDKEY_FIELD))
+@@ -517,7 +517,7 @@ class HoodieSparkSqlWriterInternal {
+             val hoodieRecords = Try(HoodieCreateRecordUtils.createHoodieRecordRdd(
+               HoodieCreateRecordUtils.createHoodieRecordRddArgs(df, writeConfig, parameters, avroRecordName,
+                 avroRecordNamespace, writerSchema, processedDataSchema, operation, instantTime, preppedSparkSqlWrites,
+-                preppedSparkSqlMergeInto, preppedWriteOperation))) match {
++                preppedSparkSqlMergeInto, preppedWriteOperation, tableConfig.getOrderingFields))) match {
+               case Success(recs) => recs
+               case Failure(e) => throw new HoodieRecordCreationException("Failed to create Hoodie Spark Record", e)
+             }
+@@ -772,7 +772,7 @@ class HoodieSparkSqlWriterInternal {
+           .setPayloadClassName(payloadClass)
+           .setRecordMergeMode(RecordMergeMode.getValue(hoodieConfig.getString(HoodieWriteConfig.RECORD_MERGE_MODE)))
+           .setRecordMergeStrategyId(recordMergerStrategy)
+-          .setPreCombineFields(hoodieConfig.getStringOrDefault(PRECOMBINE_FIELD, null))
++          .setOrderingFields(ConfigUtils.getOrderingFieldsStrDuringWrite(hoodieConfig.getProps))
+           .setBootstrapIndexClass(bootstrapIndexClass)
+           .setBaseFileFormat(baseFileFormat)
+           .setBootstrapBasePath(bootstrapBasePath)

--- a/pr_13718_files/0066.diff
+++ b/pr_13718_files/0066.diff
@@ -1,0 +1,34 @@
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+index b4be1229605e4..83c4dcd8495dc 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieWriterUtils.scala
+@@ -55,7 +55,6 @@ object HoodieWriterUtils {
+     val hoodieConfig: HoodieConfig = new HoodieConfig(props)
+     hoodieConfig.setDefaultValue(OPERATION)
+     hoodieConfig.setDefaultValue(TABLE_TYPE)
+-    hoodieConfig.setDefaultValue(PRECOMBINE_FIELD)
+     hoodieConfig.setDefaultValue(KEYGENERATOR_CLASS_NAME)
+     hoodieConfig.setDefaultValue(ENABLE)
+     hoodieConfig.setDefaultValue(COMMIT_METADATA_KEYPREFIX)
+@@ -248,9 +247,9 @@ object HoodieWriterUtils {
+         }
+ 
+         val datasourcePreCombineKey = params.getOrElse(PRECOMBINE_FIELD.key(), null)
+-        val tableConfigPreCombineKey = tableConfig.getString(HoodieTableConfig.PRECOMBINE_FIELDS)
+-        if (null != datasourcePreCombineKey && null != tableConfigPreCombineKey && datasourcePreCombineKey != tableConfigPreCombineKey) {
+-          diffConfigs.append(s"PreCombineKey:\t$datasourcePreCombineKey\t$tableConfigPreCombineKey\n")
++        val tableConfigOrderingKey = tableConfig.getString(HoodieTableConfig.ORDERING_FIELDS)
++        if (null != datasourcePreCombineKey && null != tableConfigOrderingKey && datasourcePreCombineKey != tableConfigOrderingKey) {
++          diffConfigs.append(s"PreCombineKey:\t$datasourcePreCombineKey\t$tableConfigOrderingKey\n")
+         }
+ 
+         val datasourceKeyGen = getOriginKeyGenerator(params)
+@@ -340,7 +339,7 @@ object HoodieWriterUtils {
+   private val sparkDatasourceConfigsToTableConfigsMap = Map(
+     TABLE_NAME -> HoodieTableConfig.NAME,
+     TABLE_TYPE -> HoodieTableConfig.TYPE,
+-    PRECOMBINE_FIELD -> HoodieTableConfig.PRECOMBINE_FIELDS,
++    PRECOMBINE_FIELD -> HoodieTableConfig.ORDERING_FIELDS,
+     PARTITIONPATH_FIELD -> HoodieTableConfig.PARTITION_FIELDS,
+     RECORDKEY_FIELD -> HoodieTableConfig.RECORDKEY_FIELDS,
+     PAYLOAD_CLASS_NAME -> HoodieTableConfig.PAYLOAD_CLASS_NAME,

--- a/pr_13718_files/0067.diff
+++ b/pr_13718_files/0067.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
+index 99e3fb23b5942..3b548630c72a0 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/CDCFileGroupIterator.scala
+@@ -505,7 +505,7 @@ class CDCFileGroupIterator(split: HoodieCDCFileGroupSplit,
+         Option.empty(), metaClient.getTableConfig, readerProperties))
+     val stats = new HoodieReadStats
+     val recordBuffer = new KeyBasedFileGroupRecordBuffer[InternalRow](readerContext, metaClient, readerContext.getMergeMode,
+-      metaClient.getTableConfig.getPartialUpdateMode, readerProperties, metaClient.getTableConfig.getPreCombineFields,
++      metaClient.getTableConfig.getPartialUpdateMode, readerProperties, metaClient.getTableConfig.getOrderingFields,
+       UpdateProcessor.create(stats, readerContext, true, Option.empty()))
+ 
+     HoodieMergedLogRecordReader.newBuilder[InternalRow]

--- a/pr_13718_files/0068.diff
+++ b/pr_13718_files/0068.diff
@@ -1,0 +1,22 @@
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/HoodieCDCRDD.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/HoodieCDCRDD.scala
+index 0f5f90d49efc2..eedcc98ab25fe 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/HoodieCDCRDD.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/cdc/HoodieCDCRDD.scala
+@@ -92,7 +92,7 @@ class HoodieCDCRDD(
+ 
+   private val props = HoodieFileIndex.getConfigProperties(spark, Map.empty, metaClient.getTableConfig)
+ 
+-  protected val payloadProps: Properties = metaClient.getTableConfig.getPreCombineFieldsStr
++  protected val payloadProps: Properties = metaClient.getTableConfig.getOrderingFieldsStr
+     .map[TypedProperties](JFunction.toJavaFunction(preCombineFields =>
+       HoodiePayloadConfig.newBuilder
+         .withPayloadOrderingFields(preCombineFields)
+@@ -138,7 +138,7 @@ class HoodieCDCRDD(
+       keyFields.head
+     }
+ 
+-    private lazy val preCombineFields: List[String] = metaClient.getTableConfig.getPreCombineFields.asScala.toList
++    private lazy val preCombineFields: List[String] = metaClient.getTableConfig.getOrderingFields.asScala.toList
+ 
+     private lazy val tableState = {
+       val metadataConfig = HoodieMetadataConfig.newBuilder()

--- a/pr_13718_files/0069.diff
+++ b/pr_13718_files/0069.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+index ceb55b9fd94c9..f3fdc5db225d0 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/catalyst/catalog/HoodieCatalogTable.scala
+@@ -130,7 +130,7 @@ class HoodieCatalogTable(val spark: SparkSession, var table: CatalogTable) exten
+   /**
+    * Comparables Field
+    */
+-  lazy val preCombineKeys: java.util.List[String] = tableConfig.getPreCombineFields
++  lazy val orderingFields: java.util.List[String] = tableConfig.getOrderingFields
+ 
+   /**
+    * Partition Fields

--- a/pr_13718_files/0070.diff
+++ b/pr_13718_files/0070.diff
@@ -1,0 +1,25 @@
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieOptionConfig.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieOptionConfig.scala
+index 89472466a2db7..27a1639c710ac 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieOptionConfig.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/HoodieOptionConfig.scala
+@@ -61,7 +61,7 @@ object HoodieOptionConfig {
+   val SQL_KEY_PRECOMBINE_FIELD: HoodieSQLOption[String] = buildConf()
+     .withSqlKey("preCombineField")
+     .withHoodieKey(DataSourceWriteOptions.PRECOMBINE_FIELD.key)
+-    .withTableConfigKey(HoodieTableConfig.PRECOMBINE_FIELDS.key)
++    .withTableConfigKey(HoodieTableConfig.ORDERING_FIELDS.key)
+     .build()
+ 
+   val SQL_PAYLOAD_CLASS: HoodieSQLOption[String] = buildConf()
+@@ -181,11 +181,6 @@ object HoodieOptionConfig {
+       DataSourceWriteOptions.TABLE_TYPE.defaultValue)
+   }
+ 
+-  def getPreCombineField(options: Map[String, String]): Option[String] = {
+-    val params = mapSqlOptionsToDataSourceWriteConfigs(options)
+-    params.get(DataSourceWriteOptions.PRECOMBINE_FIELD.key).filter(_.nonEmpty)
+-  }
+-
+   def deleteHoodieOptions(options: Map[String, String]): Map[String, String] = {
+     options.filterNot(_._1.startsWith("hoodie.")).filterNot(kv => sqlOptionKeyToWriteConfigKey.contains(kv._1))
+   }

--- a/pr_13718_files/0071.diff
+++ b/pr_13718_files/0071.diff
@@ -1,0 +1,114 @@
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+index b087e711dd7a5..ad1bfd30d98a4 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/ProvidesHoodieConfig.scala
+@@ -25,7 +25,7 @@ import org.apache.hudi.common.config.{DFSPropertiesConfiguration, HoodieCommonCo
+ import org.apache.hudi.common.model.WriteOperationType
+ import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.table.HoodieTableConfig.DATABASE_NAME
+-import org.apache.hudi.common.util.{ReflectionUtils, StringUtils}
++import org.apache.hudi.common.util.{ConfigUtils, ReflectionUtils, StringUtils}
+ import org.apache.hudi.config.{HoodieIndexConfig, HoodieInternalConfig, HoodieWriteConfig}
+ import org.apache.hudi.config.HoodieWriteConfig.TBL_NAME
+ import org.apache.hudi.hive.{HiveSyncConfig, HiveSyncConfigHolder, MultiPartKeysValueExtractor}
+@@ -53,6 +53,7 @@ import org.slf4j.LoggerFactory
+ 
+ import java.util.Locale
+ 
++import scala.collection.JavaConverters
+ import scala.collection.JavaConverters._
+ 
+ trait ProvidesHoodieConfig extends Logging {
+@@ -64,7 +65,7 @@ trait ProvidesHoodieConfig extends Logging {
+     // NOTE: Here we fallback to "" to make sure that null value is not overridden with
+     // default value ("ts")
+     // TODO(HUDI-3456) clean up
+-    val preCombineFields = tableConfig.getPreCombineFieldsStr.orElse("")
++    val orderingFields = tableConfig.getOrderingFieldsStr.orElse("")
+     val hiveSyncConfig = buildHiveSyncConfig(sparkSession, hoodieCatalogTable, tableConfig)
+ 
+     val defaultOpts = Map[String, String](
+@@ -82,7 +83,7 @@ trait ProvidesHoodieConfig extends Logging {
+       HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE.key -> hiveSyncConfig.getBoolean(HiveSyncConfigHolder.HIVE_SUPPORT_TIMESTAMP_TYPE).toString
+     )
+ 
+-    val overridingOpts = buildOverridingOpts(hoodieCatalogTable, preCombineFields)
++    val overridingOpts = buildOverridingOpts(hoodieCatalogTable, orderingFields)
+     combineOptions(hoodieCatalogTable, tableConfig, sparkSession.sqlContext.conf,
+       defaultOpts = defaultOpts, overridingOpts = overridingOpts)
+   }
+@@ -90,7 +91,7 @@ trait ProvidesHoodieConfig extends Logging {
+   def buildBucketRescaleHoodieConfig(hoodieCatalogTable: HoodieCatalogTable): Map[String, String] = {
+     val sparkSession: SparkSession = hoodieCatalogTable.spark
+     val tableConfig = hoodieCatalogTable.tableConfig
+-    val preCombineFields = tableConfig.getPreCombineFieldsStr.orElse("")
++    val orderingFields = tableConfig.getOrderingFieldsStr.orElse("")
+     val hiveSyncConfig = buildHiveSyncConfig(sparkSession, hoodieCatalogTable, tableConfig)
+ 
+     val defaultOpts = Map[String, String](
+@@ -103,7 +104,7 @@ trait ProvidesHoodieConfig extends Logging {
+       HiveSyncConfigHolder.HIVE_SYNC_ENABLED.key -> "false"
+     )
+ 
+-    val overridingOpts = buildOverridingOpts(hoodieCatalogTable, preCombineFields)
++    val overridingOpts = buildOverridingOpts(hoodieCatalogTable, orderingFields)
+     combineOptions(hoodieCatalogTable, tableConfig, sparkSession.sqlContext.conf,
+       defaultOpts = defaultOpts, overridingOpts = overridingOpts)
+   }
+@@ -190,8 +191,7 @@ trait ProvidesHoodieConfig extends Logging {
+     // NOTE: Here we fallback to "" to make sure that null value is not overridden with
+     // default value ("ts")
+     // TODO(HUDI-3456) clean up
+-    val preCombineField = combinedOpts.getOrElse(HoodieTableConfig.PRECOMBINE_FIELDS.key,
+-      combinedOpts.getOrElse(PRECOMBINE_FIELD.key, ""))
++    val orderingFieldsStr = Option.apply(ConfigUtils.getOrderingFieldsStrDuringWrite(combinedOpts.asJava)).getOrElse("")
+ 
+     val hiveStylePartitioningEnable = Option(tableConfig.getHiveStylePartitioningEnable).getOrElse("true")
+     val urlEncodePartitioning = Option(tableConfig.getUrlEncodePartitioning).getOrElse("false")
+@@ -215,7 +215,7 @@ trait ProvidesHoodieConfig extends Logging {
+     val insertDupPolicy = combinedOpts.getOrElse(INSERT_DUP_POLICY.key(), INSERT_DUP_POLICY.defaultValue())
+     val isNonStrictMode = insertMode == InsertMode.NON_STRICT
+     val isPartitionedTable = hoodieCatalogTable.partitionFields.nonEmpty
+-    val combineBeforeInsert = !hoodieCatalogTable.preCombineKeys.isEmpty && hoodieCatalogTable.primaryKeys.nonEmpty
++    val combineBeforeInsert = !hoodieCatalogTable.orderingFields.isEmpty && hoodieCatalogTable.primaryKeys.nonEmpty
+ 
+     /*
+      * The sql write operation has higher precedence than the legacy insert mode.
+@@ -232,7 +232,7 @@ trait ProvidesHoodieConfig extends Logging {
+           isNonStrictMode, isPartitionedTable, combineBeforeInsert, insertMode, shouldAutoKeyGen)
+       } else {
+         deduceSparkSqlInsertIntoWriteOperation(isOverwritePartition, isOverwriteTable,
+-          shouldAutoKeyGen, preCombineField, sparkSqlInsertIntoOperationSet, sparkSqlInsertIntoOperation)
++          shouldAutoKeyGen, orderingFieldsStr, sparkSqlInsertIntoOperationSet, sparkSqlInsertIntoOperation)
+       }
+     )
+ 
+@@ -301,7 +301,7 @@ trait ProvidesHoodieConfig extends Logging {
+       HIVE_STYLE_PARTITIONING.key -> hiveStylePartitioningEnable,
+       URL_ENCODE_PARTITIONING.key -> urlEncodePartitioning,
+       RECORDKEY_FIELD.key -> recordKeyConfigValue,
+-      PRECOMBINE_FIELD.key -> preCombineField,
++      HoodieTableConfig.ORDERING_FIELDS.key -> orderingFieldsStr,
+       PARTITIONPATH_FIELD.key -> getPartitionPathFieldWriteConfig(
+         keyGeneratorClassName, partitionFieldsStr, hoodieCatalogTable)
+     ) ++ overwriteTableOpts ++ getDropDupsConfig(useLegacyInsertModeFlow, combinedOpts) ++ staticOverwritePartitionPathOptions
+@@ -398,7 +398,6 @@ trait ProvidesHoodieConfig extends Logging {
+       OPERATION.key -> DataSourceWriteOptions.DELETE_PARTITION_OPERATION_OPT_VAL,
+       PARTITIONS_TO_DELETE.key -> partitionsToDrop,
+       RECORDKEY_FIELD.key -> hoodieCatalogTable.primaryKeys.mkString(","),
+-      PRECOMBINE_FIELD.key -> String.join(",", hoodieCatalogTable.preCombineKeys),
+       PARTITIONPATH_FIELD.key -> getPartitionPathFieldWriteConfig(
+         tableConfig.getKeyGeneratorClassName, partitionFields, hoodieCatalogTable),
+       HoodieSyncConfig.META_SYNC_ENABLED.key -> hiveSyncConfig.getString(HoodieSyncConfig.META_SYNC_ENABLED.key),
+@@ -560,9 +559,9 @@ object ProvidesHoodieConfig {
+     opts.filter { case (_, v) => v != null }
+ 
+   private def buildOverridingOpts(hoodieCatalogTable: HoodieCatalogTable,
+-                                  preCombineFields: String): Map[String, String] = {
++                                  orderingFields: String): Map[String, String] = {
+     buildCommonOverridingOpts(hoodieCatalogTable) ++ Map(
+-      PRECOMBINE_FIELD.key -> preCombineFields
++      HoodieTableConfig.ORDERING_FIELDS.key -> orderingFields
+     )
+   }
+ 

--- a/pr_13718_files/0072.diff
+++ b/pr_13718_files/0072.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
+index 69e09598f7c0e..39d3b9417e106 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/CreateHoodieTableCommand.scala
+@@ -125,7 +125,7 @@ object CreateHoodieTableCommand {
+       val originTableConfig = hoodieCatalogTable.tableConfig.getProps.asScala.toMap
+       val tableOptions = hoodieCatalogTable.catalogProperties
+ 
+-      checkTableConfigEqual(originTableConfig, tableOptions, HoodieTableConfig.PRECOMBINE_FIELDS.key)
++      checkTableConfigEqual(originTableConfig, tableOptions, HoodieTableConfig.ORDERING_FIELDS.key)
+       checkTableConfigEqual(originTableConfig, tableOptions, HoodieTableConfig.PARTITION_FIELDS.key)
+       checkTableConfigEqual(originTableConfig, tableOptions, HoodieTableConfig.RECORDKEY_FIELDS.key)
+       checkTableConfigEqual(originTableConfig, tableOptions, HoodieTableConfig.KEY_GENERATOR_CLASS_NAME.key)

--- a/pr_13718_files/0073.diff
+++ b/pr_13718_files/0073.diff
@@ -1,0 +1,31 @@
+diff --git a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestProvidesHoodieConfig.scala b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestProvidesHoodieConfig.scala
+index 670d96b6b9c10..3f20b67609467 100644
+--- a/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestProvidesHoodieConfig.scala
++++ b/hudi-spark-datasource/hudi-spark-common/src/test/scala/org/apache/spark/sql/hudi/TestProvidesHoodieConfig.scala
+@@ -94,7 +94,7 @@ class TestProvidesHoodieConfig {
+     // catalogProperties won't be passed in correctly, because they were not synced properly
+     when(mockCatalog.catalogProperties).thenReturn(Map.empty[String, String])
+     when(mockCatalog.partitionFields).thenReturn(Array("partition"))
+-    when(mockCatalog.preCombineKeys).thenCallRealMethod()
++    when(mockCatalog.orderingFields).thenCallRealMethod()
+     when(mockCatalog.partitionSchema).thenReturn(StructType(Nil))
+     when(mockCatalog.primaryKeys).thenReturn(Array("key"))
+     when(mockCatalog.table).thenReturn(CatalogTable.apply(
+@@ -103,7 +103,7 @@ class TestProvidesHoodieConfig {
+       CatalogStorageFormat.empty,
+       StructType(Nil)))
+     val props = new TypedProperties()
+-    props.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key, "segment")
++    props.setProperty(HoodieTableConfig.ORDERING_FIELDS.key, "segment")
+     val mockTableConfig = spy(classOf[HoodieTableConfig])
+     when(mockTableConfig.getProps).thenReturn(props)
+     when(mockCatalog.tableConfig).thenReturn(mockTableConfig)
+@@ -140,7 +140,7 @@ class TestProvidesHoodieConfig {
+ 
+     assertEquals(
+       "segment",
+-      combinedConfig.getOrElse(HoodieTableConfig.PRECOMBINE_FIELDS.key, "")
++      combinedConfig.getOrElse(HoodieTableConfig.ORDERING_FIELDS.key, "")
+     )
+ 
+     // write config precombine field should be inferred from table config

--- a/pr_13718_files/0074.diff
+++ b/pr_13718_files/0074.diff
@@ -1,0 +1,22 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/bootstrap/SparkFullBootstrapDataProviderBase.java b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/bootstrap/SparkFullBootstrapDataProviderBase.java
+index 65af0c3543409..bccebeb2db469 100644
+--- a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/bootstrap/SparkFullBootstrapDataProviderBase.java
++++ b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/bootstrap/SparkFullBootstrapDataProviderBase.java
+@@ -72,7 +72,7 @@ public JavaRDD<HoodieRecord> generateInputRecords(String tableName, String sourc
+     HoodieRecordType recordType =  config.getRecordMerger().getRecordType();
+     Dataset inputDataset = sparkSession.read().format(getFormat()).option("basePath", sourceBasePath).load(filePaths);
+     KeyGenerator keyGenerator = HoodieSparkKeyGeneratorFactory.createKeyGenerator(props);
+-    String precombineKey = props.getString("hoodie.datasource.write.precombine.field");
++    String orderingFieldsStr = ConfigUtils.getOrderingFieldsStrDuringWrite(props);
+     String structName = tableName + "_record";
+     String namespace = "hoodie." + tableName;
+     if (recordType == HoodieRecordType.AVRO) {
+@@ -80,7 +80,7 @@ public JavaRDD<HoodieRecord> generateInputRecords(String tableName, String sourc
+           Option.empty());
+       return genericRecords.toJavaRDD().map(gr -> {
+         String orderingVal = HoodieAvroUtils.getNestedFieldValAsString(
+-            gr, precombineKey, false, props.getBoolean(
++            gr, orderingFieldsStr, false, props.getBoolean(
+                 KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key(),
+                 Boolean.parseBoolean(KeyGeneratorOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.defaultValue())));
+         try {

--- a/pr_13718_files/0075.diff
+++ b/pr_13718_files/0075.diff
@@ -1,0 +1,29 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java
+index bd2c44e4370f5..a3be757c377b1 100644
+--- a/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java
++++ b/hudi-spark-datasource/hudi-spark/src/main/java/org/apache/hudi/cli/BootstrapExecutorUtils.java
+@@ -25,6 +25,7 @@
+ import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.common.table.HoodieTableMetaClient;
+ import org.apache.hudi.common.table.HoodieTableVersion;
++import org.apache.hudi.common.util.ConfigUtils;
+ import org.apache.hudi.common.util.Option;
+ import org.apache.hudi.common.util.ReflectionUtils;
+ import org.apache.hudi.common.util.StringUtils;
+@@ -67,7 +68,6 @@
+ import static org.apache.hudi.common.util.ConfigUtils.filterProperties;
+ import static org.apache.hudi.config.HoodieIndexConfig.BUCKET_INDEX_HASH_FIELD;
+ import static org.apache.hudi.config.HoodieIndexConfig.BUCKET_INDEX_NUM_BUCKETS;
+-import static org.apache.hudi.config.HoodieWriteConfig.PRECOMBINE_FIELD_NAME;
+ import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_BUCKET_SYNC;
+ import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_BUCKET_SYNC_SPEC;
+ import static org.apache.hudi.keygen.constant.KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE;
+@@ -237,7 +237,7 @@ private void initializeTable() throws IOException {
+         .setTableName(cfg.tableName)
+         .setTableVersion(bootstrapConfig.getWriteVersion())
+         .setRecordKeyFields(props.getString(RECORDKEY_FIELD_NAME.key()))
+-        .setPreCombineFields(props.getString(PRECOMBINE_FIELD_NAME.key(), null))
++        .setOrderingFields(ConfigUtils.getOrderingFieldsStrDuringWrite(props))
+         .setPopulateMetaFields(props.getBoolean(
+             POPULATE_META_FIELDS.key(), POPULATE_META_FIELDS.defaultValue()))
+         .setArchiveLogFolder(props.getString(

--- a/pr_13718_files/0076.diff
+++ b/pr_13718_files/0076.diff
@@ -1,0 +1,76 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+index 56507994fa69d..398e3f766c1ee 100644
+--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
++++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/MergeIntoHoodieTableCommand.scala
+@@ -268,7 +268,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable,
+       sparkSession.sessionState.conf.resolver,
+       mergeInto.targetTable,
+       mergeInto.sourceTable,
+-      hoodieCatalogTable.preCombineKeys.asScala.toSeq,
++      hoodieCatalogTable.orderingFields.asScala.toSeq,
+       "precombine field",
+       updatingActions.flatMap(_.assignments))
+ 
+@@ -761,7 +761,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable,
+     // NOTE: Here we fallback to "" to make sure that null value is not overridden with
+     // default value ("ts")
+     // TODO(HUDI-3456) clean up
+-    val preCombineFieldsAsString = String.join(",", hoodieCatalogTable.preCombineKeys)
++    val orderingFieldsAsString = String.join(",", hoodieCatalogTable.orderingFields)
+     val hiveSyncConfig = buildHiveSyncConfig(sparkSession, hoodieCatalogTable, tableConfig)
+     // for pkless tables, we need to enable optimized merge
+     val isPrimaryKeylessTable = !hasPrimaryKey()
+@@ -776,7 +776,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable,
+         tableConfig.getRecordMergeMode,
+         tableConfig.getPayloadClass,
+         tableConfig.getRecordMergeStrategyId,
+-        tableConfig.getPreCombineFieldsStr.orElse(null),
++        tableConfig.getOrderingFieldsStr.orElse(null),
+         tableConfig.getTableVersion)
+       inferredMergeConfigs.getLeft.name()
+     } else {
+@@ -785,7 +785,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable,
+     val overridingOpts = Map(
+       "path" -> path,
+       RECORDKEY_FIELD.key -> tableConfig.getRawRecordKeyFieldProp,
+-      PRECOMBINE_FIELD.key -> preCombineFieldsAsString,
++      HoodieTableConfig.ORDERING_FIELDS.key -> orderingFieldsAsString,
+       TBL_NAME.key -> hoodieCatalogTable.tableName,
+       PARTITIONPATH_FIELD.key -> getPartitionPathFieldWriteConfig(
+         tableConfig.getKeyGeneratorClassName, tableConfig.getPartitionFieldProp, hoodieCatalogTable),
+@@ -819,7 +819,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable,
+       HoodieSparkSqlWriter.SQL_MERGE_INTO_WRITES.key -> "true",
+       // Only primary keyless table requires prepped keys and upsert
+       HoodieWriteConfig.SPARK_SQL_MERGE_INTO_PREPPED_KEY -> isPrimaryKeylessTable.toString,
+-      HoodieWriteConfig.COMBINE_BEFORE_UPSERT.key() -> (!StringUtils.isNullOrEmpty(preCombineFieldsAsString)).toString
++      HoodieWriteConfig.COMBINE_BEFORE_UPSERT.key() -> (!StringUtils.isNullOrEmpty(orderingFieldsAsString)).toString
+     )
+ 
+     combineOptions(hoodieCatalogTable, tableConfig, sparkSession.sqlContext.conf,
+@@ -851,7 +851,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable,
+         validateTargetTableAttrExistsInAssignments(
+           sparkSession.sessionState.conf.resolver,
+           mergeInto.targetTable,
+-          hoodieCatalogTable.preCombineKeys.asScala.toSeq,
++          hoodieCatalogTable.orderingFields.asScala.toSeq,
+           "precombine field",
+           action.assignments)
+       )
+@@ -921,7 +921,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable,
+             sparkSession.sessionState.conf.resolver,
+             mergeInto.targetTable,
+             mergeInto.sourceTable,
+-            hoodieCatalogTable.preCombineKeys.asScala.toSeq,
++            hoodieCatalogTable.orderingFields.asScala.toSeq,
+             "precombine field",
+             assignments)
+           associations.foreach(association => validateDataTypes(association._1, association._2, "Precombine field"))
+@@ -934,7 +934,7 @@ case class MergeIntoHoodieTableCommand(mergeInto: MergeIntoTable,
+   }
+ 
+   private def checkUpdatingActions(updateActions: Seq[UpdateAction], props: Map[String, String]): Unit = {
+-    if (hoodieCatalogTable.preCombineKeys.isEmpty && updateActions.nonEmpty) {
++    if (hoodieCatalogTable.orderingFields.isEmpty && updateActions.nonEmpty) {
+       logWarning(s"Updates without precombine can have nondeterministic behavior")
+     }
+     updateActions.foreach(update =>

--- a/pr_13718_files/0077.diff
+++ b/pr_13718_files/0077.diff
@@ -1,0 +1,39 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaApp.java b/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaApp.java
+index 55a986a80c912..c250d15adcee2 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaApp.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaApp.java
+@@ -21,6 +21,7 @@
+ import org.apache.hudi.HoodieDataSourceHelpers;
+ import org.apache.hudi.common.model.HoodieRecord;
+ import org.apache.hudi.common.model.HoodieTableType;
++import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+ import org.apache.hudi.config.HoodieCompactionConfig;
+ import org.apache.hudi.config.HoodieWriteConfig;
+@@ -155,7 +156,7 @@ public void run() throws Exception {
+         // this is the partition to place it into
+         .option(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition")
+         // use to combine duplicate records in input/with disk val
+-        .option(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp")
+         // Used by hive sync and queries
+         .option(HoodieWriteConfig.TBL_NAME.key(), tableName)
+         .option(DataSourceWriteOptions.ASYNC_COMPACT_ENABLE().key(), "false")
+@@ -183,7 +184,7 @@ public void run() throws Exception {
+         .option(DataSourceWriteOptions.TABLE_TYPE().key(), tableType) // Hoodie Table Type
+         .option(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key")
+         .option(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition")
+-        .option(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp")
+         .option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "1")
+         .option(DataSourceWriteOptions.ASYNC_COMPACT_ENABLE().key(), "false")
+         .option(DataSourceWriteOptions.ASYNC_CLUSTERING_ENABLE().key(), "true")
+@@ -208,7 +209,7 @@ public void run() throws Exception {
+         .option(DataSourceWriteOptions.OPERATION().key(), "delete")
+         .option(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key")
+         .option(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition")
+-        .option(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp")
+         .option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "1")
+         .option(DataSourceWriteOptions.ASYNC_COMPACT_ENABLE().key(), "false")
+         .option(DataSourceWriteOptions.ASYNC_CLUSTERING_ENABLE().key(), "true")

--- a/pr_13718_files/0078.diff
+++ b/pr_13718_files/0078.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaGenerateApp.java b/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaGenerateApp.java
+index a41db540ec40f..0f325a0f2f743 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaGenerateApp.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaGenerateApp.java
+@@ -20,6 +20,7 @@
+ import org.apache.hudi.HoodieDataSourceHelpers;
+ import org.apache.hudi.common.model.HoodieRecord;
+ import org.apache.hudi.common.model.HoodieTableType;
++import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+ import org.apache.hudi.common.testutils.InProcessTimeGenerator;
+ import org.apache.hudi.config.HoodieWriteConfig;
+@@ -183,7 +184,7 @@ private void insert(SparkSession spark) throws IOException {
+         // this is the partition to place it into
+         .option(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition")
+         // use to combine duplicate records in input/with disk val
+-        .option(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp")
+         // Used by hive sync and queries
+         .option(HoodieWriteConfig.TBL_NAME.key(), tableName)
+         .mode(commitType);

--- a/pr_13718_files/0079.diff
+++ b/pr_13718_files/0079.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaStreamingApp.java b/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaStreamingApp.java
+index 54a64895c6de7..b18a47dcc443e 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaStreamingApp.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/HoodieJavaStreamingApp.java
+@@ -20,6 +20,7 @@
+ import org.apache.hudi.DataSourceWriteOptions;
+ import org.apache.hudi.HoodieDataSourceHelpers;
+ import org.apache.hudi.common.model.HoodieTableType;
++import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.common.table.HoodieTableMetaClient;
+ import org.apache.hudi.common.table.timeline.HoodieTimeline;
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+@@ -372,7 +373,7 @@ public void stream(Dataset<Row> streamingInput, String operationType, String che
+         .option(DataSourceWriteOptions.TABLE_TYPE().key(), tableType)
+         .option(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key")
+         .option(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition")
+-        .option(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp")
+         .option(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "1")
+         .option(DataSourceWriteOptions.ASYNC_COMPACT_ENABLE().key(), "true")
+         .option(DataSourceWriteOptions.ASYNC_CLUSTERING_ENABLE().key(), "true")

--- a/pr_13718_files/0080.diff
+++ b/pr_13718_files/0080.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDecimalTypeDataWorkflow.scala b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDecimalTypeDataWorkflow.scala
+index c4014bc5719ac..54815dd394a93 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDecimalTypeDataWorkflow.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDecimalTypeDataWorkflow.scala
+@@ -21,6 +21,7 @@ package org.apache.hudi
+ 
+ import org.apache.hudi.DataSourceWriteOptions._
+ import org.apache.hudi.common.config.{HoodieReaderConfig, HoodieStorageConfig}
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.config.HoodieWriteConfig
+ import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+ import org.apache.spark.sql.types.{Decimal, DecimalType, IntegerType, StructField, StructType}
+@@ -66,7 +67,7 @@ class TestDecimalTypeDataWorkflow extends SparkClientFunctionalTestHarness{
+       .toDF("id", "decimal_col").sort("id")
+     insertDf.write.format("hudi")
+       .option(RECORDKEY_FIELD.key(), "id")
+-      .option(PRECOMBINE_FIELD.key(), "decimal_col")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key(), "decimal_col")
+       .option(TABLE_TYPE.key, "MERGE_ON_READ")
+       .option(TABLE_NAME.key, "test_table")
+       .options(opts)

--- a/pr_13718_files/0081.diff
+++ b/pr_13718_files/0081.diff
@@ -1,0 +1,49 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDefaultSparkRecordMerger.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDefaultSparkRecordMerger.java
+index ccdcd1878055d..eaa31036a8726 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDefaultSparkRecordMerger.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDefaultSparkRecordMerger.java
+@@ -42,7 +42,7 @@
+ import java.util.List;
+ 
+ import static org.apache.hudi.common.model.HoodieRecord.HoodieRecordType.SPARK;
+-import static org.apache.hudi.common.table.HoodieTableConfig.PRECOMBINE_FIELDS;
++import static org.apache.hudi.common.table.HoodieTableConfig.ORDERING_FIELDS;
+ import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertThrows;
+@@ -100,7 +100,7 @@ void testMergerWithNewRecordAccepted() throws IOException {
+ 
+     DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
+     TypedProperties props = new TypedProperties();
+-    props.setProperty(PRECOMBINE_FIELDS.key(), INT_COLUMN_NAME);
++    props.setProperty(ORDERING_FIELDS.key(), INT_COLUMN_NAME);
+     Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
+         SPARK_SCHEMA, ANY_NAME, ANY_NAMESPACE);
+     Option<Pair<HoodieRecord, Schema>> merged =
+@@ -127,7 +127,7 @@ void testMergerWithOldRecordAccepted() throws IOException {
+ 
+     DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
+     TypedProperties props = new TypedProperties();
+-    props.setProperty(PRECOMBINE_FIELDS.key(), INT_COLUMN_NAME);
++    props.setProperty(ORDERING_FIELDS.key(), INT_COLUMN_NAME);
+     Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
+         SPARK_SCHEMA, ANY_NAME, ANY_NAMESPACE);
+     Option<Pair<HoodieRecord, Schema>> r =
+@@ -151,7 +151,7 @@ void testMergerWithNewRecordAsDelete() throws IOException {
+ 
+     DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
+     TypedProperties props = new TypedProperties();
+-    props.setProperty(PRECOMBINE_FIELDS.key(), INT_COLUMN_NAME);
++    props.setProperty(ORDERING_FIELDS.key(), INT_COLUMN_NAME);
+     Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
+         SPARK_SCHEMA, ANY_NAME, ANY_NAMESPACE);
+     Option<Pair<HoodieRecord, Schema>> r =
+@@ -172,7 +172,7 @@ void testMergerWithOldRecordAsDelete() throws IOException {
+ 
+     DefaultSparkRecordMerger merger = new DefaultSparkRecordMerger();
+     TypedProperties props = new TypedProperties();
+-    props.setProperty(PRECOMBINE_FIELDS.key(), INT_COLUMN_NAME);
++    props.setProperty(ORDERING_FIELDS.key(), INT_COLUMN_NAME);
+     Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
+         SPARK_SCHEMA, ANY_NAME, ANY_NAMESPACE);
+     Option<Pair<HoodieRecord, Schema>> r =

--- a/pr_13718_files/0082.diff
+++ b/pr_13718_files/0082.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestHoodieMergeHandleWithSparkMerger.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestHoodieMergeHandleWithSparkMerger.java
+index 8cdd41803a85a..633326bbe283e 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestHoodieMergeHandleWithSparkMerger.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestHoodieMergeHandleWithSparkMerger.java
+@@ -86,7 +86,7 @@ public void setUp() throws IOException {
+     properties.setProperty(
+         HoodieTableConfig.BASE_FILE_FORMAT.key(),
+         HoodieTableConfig.BASE_FILE_FORMAT.defaultValue().toString());
+-    properties.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "record_key");
++    properties.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), "record_key");
+     properties.setProperty(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(),"partition_path");
+     properties.setProperty(HoodieTableConfig.PARTITION_FIELDS.key(), "partition_path");
+     metaClient = getHoodieMetaClient(storageConf(), basePath(), HoodieTableType.MERGE_ON_READ, properties);

--- a/pr_13718_files/0083.diff
+++ b/pr_13718_files/0083.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestPositionBasedFileGroupRecordBuffer.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestPositionBasedFileGroupRecordBuffer.java
+index 7b2d825b55db8..f7107fc1e78fc 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestPositionBasedFileGroupRecordBuffer.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestPositionBasedFileGroupRecordBuffer.java
+@@ -95,7 +95,7 @@ private void prepareBuffer(RecordMergeMode mergeMode, String baseFileInstantTime
+     writeConfigs.put(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key(), "parquet");
+     writeConfigs.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "_row_key");
+     writeConfigs.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partition_path");
+-    writeConfigs.put("hoodie.datasource.write.precombine.field", mergeMode.equals(RecordMergeMode.COMMIT_TIME_ORDERING) ? "" : "timestamp");
++    writeConfigs.put(HoodieTableConfig.ORDERING_FIELDS.key(), mergeMode.equals(RecordMergeMode.COMMIT_TIME_ORDERING) ? "" : "timestamp");
+     writeConfigs.put("hoodie.payload.ordering.field", "timestamp");
+     writeConfigs.put(HoodieTableConfig.HOODIE_TABLE_NAME_KEY, "hoodie_test");
+     writeConfigs.put("hoodie.insert.shuffle.parallelism", "4");

--- a/pr_13718_files/0084.diff
+++ b/pr_13718_files/0084.diff
@@ -1,0 +1,22 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
+index 3f2ffcb36704b..cd8b2c9cdc274 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
+@@ -209,7 +209,7 @@ public void testRecordGenerationAPIsForMOR() throws IOException {
+     HoodieTableType tableType = HoodieTableType.MERGE_ON_READ;
+     cleanupClients();
+     Properties props = new Properties();
+-    props.put(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "timestamp");
++    props.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     initMetaClient(tableType, props);
+     cleanupTimelineService();
+     initTimelineService();
+@@ -307,7 +307,7 @@ public void testSecondaryIndexRecordGenerationForMOR() throws IOException {
+     HoodieTableType tableType = HoodieTableType.MERGE_ON_READ;
+     cleanupClients();
+     Properties props = new Properties();
+-    props.put(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "timestamp");
++    props.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     initMetaClient(tableType, props);
+     cleanupTimelineService();
+     initTimelineService();

--- a/pr_13718_files/0085.diff
+++ b/pr_13718_files/0085.diff
@@ -1,0 +1,28 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrap.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrap.java
+index e833919c30ac4..50c8c551f161a 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrap.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrap.java
+@@ -35,6 +35,7 @@
+ import org.apache.hudi.common.model.HoodieKey;
+ import org.apache.hudi.common.model.HoodieRecord;
+ import org.apache.hudi.common.model.HoodieTableType;
++import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.common.table.timeline.HoodieInstant.State;
+ import org.apache.hudi.common.table.timeline.HoodieTimeline;
+ import org.apache.hudi.common.table.timeline.TimelineUtils;
+@@ -255,7 +256,6 @@ private void testBootstrapCommon(boolean partitioned, boolean deltaCommit, Effec
+     long timestamp = Instant.now().toEpochMilli();
+     Schema schema = generateNewDataSetAndReturnSchema(timestamp, totalRecords, partitions, bootstrapBasePath);
+     HoodieWriteConfig config = getConfigBuilder(schema.toString())
+-        .withPreCombineField("timestamp")
+         .withSchema(schema.toString())
+         .withKeyGenerator(keyGeneratorClass)
+         .withCompactionConfig(HoodieCompactionConfig.newBuilder()
+@@ -270,6 +270,7 @@ private void testBootstrapCommon(boolean partitioned, boolean deltaCommit, Effec
+         .withMetadataConfig(HoodieMetadataConfig.newBuilder().enable(true).withMaxNumDeltaCommitsBeforeCompaction(3)
+             .withMetadataIndexColumnStats(false).build()) // HUDI-8774
+         .build();
++    config.setValue(HoodieTableConfig.ORDERING_FIELDS, "timestamp");
+ 
+     SparkRDDWriteClient client = new SparkRDDWriteClient(context, config);
+     client.bootstrap(Option.empty());

--- a/pr_13718_files/0086.diff
+++ b/pr_13718_files/0086.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrapReadBase.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrapReadBase.java
+index e32ddc698a398..33011276c9bdd 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrapReadBase.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBootstrapReadBase.java
+@@ -25,6 +25,7 @@
+ import org.apache.hudi.client.bootstrap.translator.DecodedBootstrapPartitionPathTranslator;
+ import org.apache.hudi.common.config.HoodieMetadataConfig;
+ import org.apache.hudi.common.model.HoodieTableType;
++import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+ import org.apache.hudi.config.HoodieBootstrapConfig;
+ import org.apache.hudi.config.HoodieCompactionConfig;
+@@ -105,7 +106,7 @@ protected Map<String, String> basicOptions() {
+         options.put(HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key(), ComplexKeyGenerator.class.getName());
+       }
+     }
+-    options.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++    options.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     if (tableType.equals(MERGE_ON_READ)) {
+       options.put(HoodieCompactionConfig.INLINE_COMPACT.key(), "true");
+     }

--- a/pr_13718_files/0087.diff
+++ b/pr_13718_files/0087.diff
@@ -1,0 +1,22 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBufferedRecordMerger.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBufferedRecordMerger.java
+index ccc507aba3447..0b3047bc3d858 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBufferedRecordMerger.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBufferedRecordMerger.java
+@@ -76,7 +76,7 @@
+ import static org.apache.hudi.common.config.RecordMergeMode.COMMIT_TIME_ORDERING;
+ import static org.apache.hudi.common.config.RecordMergeMode.EVENT_TIME_ORDERING;
+ import static org.apache.hudi.common.table.HoodieTableConfig.PARTIAL_UPDATE_CUSTOM_MARKER;
+-import static org.apache.hudi.common.table.HoodieTableConfig.PRECOMBINE_FIELDS;
++import static org.apache.hudi.common.table.HoodieTableConfig.ORDERING_FIELDS;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertFalse;
+ import static org.junit.jupiter.api.Assertions.assertNotNull;
+@@ -113,7 +113,7 @@ void setUp() throws IOException {
+     when(tableConfig.getRecordKeyFields()).thenReturn(Option.of(new String[]{"id"}));
+     // Create reader context.
+     props = new TypedProperties();
+-    props.put(PRECOMBINE_FIELDS.key(), "precombine");
++    props.put(ORDERING_FIELDS.key(), "precombine");
+     readerContext = new DummyInternalRowReaderContext(
+         storageConfig, tableConfig, Option.empty(), Option.empty(), new DummyRecordContext(tableConfig));
+   }

--- a/pr_13718_files/0088.diff
+++ b/pr_13718_files/0088.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestColStatsRecordWithMetadataRecord.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestColStatsRecordWithMetadataRecord.java
+index 967508927e430..43bae063ba0ac 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestColStatsRecordWithMetadataRecord.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestColStatsRecordWithMetadataRecord.java
+@@ -220,7 +220,7 @@ public int compare(HoodieRecord<HoodieMetadataPayload> o1, HoodieRecord<HoodieMe
+     while (itr.hasNext()) {
+       GenericRecord genericRecord = (GenericRecord) ((HoodieRecord) itr.next()).getData();
+       HoodieRecord<HoodieMetadataPayload> mdtRec = SpillableMapUtils.convertToHoodieRecordPayload(genericRecord,
+-          mdtWriteConfig.getPayloadClass(), mdtWriteConfig.getPreCombineFields().toArray(new String[0]),
++          mdtWriteConfig.getPayloadClass(), new String[0],
+           Pair.of(mdtMetaClient.getTableConfig().getRecordKeyFieldProp(), mdtMetaClient.getTableConfig().getPartitionFieldProp()),
+           false, Option.of(COLUMN_STATS.getPartitionPath()), Option.empty());
+       allRecords.add(mdtRec);

--- a/pr_13718_files/0089.diff
+++ b/pr_13718_files/0089.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestDataSkippingWithMORColstats.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestDataSkippingWithMORColstats.java
+index beb7141470904..e16ab9fb96c51 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestDataSkippingWithMORColstats.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestDataSkippingWithMORColstats.java
+@@ -25,6 +25,7 @@
+ import org.apache.hudi.common.config.HoodieMetadataConfig;
+ import org.apache.hudi.common.fs.FSUtils;
+ import org.apache.hudi.common.model.HoodieTableType;
++import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.common.table.HoodieTableMetaClient;
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
+ import org.apache.hudi.common.util.Option;
+@@ -333,7 +334,7 @@ private Map<String, String> getOptions() {
+     options.put(DataSourceReadOptions.ENABLE_DATA_SKIPPING().key(), "true");
+     options.put(DataSourceWriteOptions.TABLE_TYPE().key(), DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL());
+     options.put(HoodieWriteConfig.TBL_NAME.key(), "testTable");
+-    options.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++    options.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     options.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+     options.put("hoodie.datasource.write.keygenerator.class", "org.apache.hudi.keygen.NonpartitionedKeyGenerator");
+     options.put(HoodieCompactionConfig.PARQUET_SMALL_FILE_LIMIT.key(), "0");

--- a/pr_13718_files/0090.diff
+++ b/pr_13718_files/0090.diff
@@ -1,0 +1,22 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
+index ecd3dd3f45f98..af6cc16a608b4 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
+@@ -437,7 +437,7 @@ public void testTurnOffMetadataTableAfterEnable() throws Exception {
+     Triple<RecordMergeMode, String, String> inferredMergeConfs =
+         HoodieTableConfig.inferCorrectMergingBehavior(
+             writeConfig.getRecordMergeMode(), writeConfig.getPayloadClass(),
+-            writeConfig.getRecordMergeStrategyId(), String.join(",", writeConfig.getPreCombineFields()),
++            writeConfig.getRecordMergeStrategyId(), String.join(",", table.getMetaClient().getTableConfig().getOrderingFields()),
+             metaClient.getTableConfig().getTableVersion());
+     HoodieTableConfig hoodieTableConfig =
+         new HoodieTableConfig(this.storage, metaClient.getMetaPath(), inferredMergeConfs.getLeft(), inferredMergeConfs.getMiddle(), inferredMergeConfs.getRight());
+@@ -460,7 +460,7 @@ public void testTurnOffMetadataTableAfterEnable() throws Exception {
+     Triple<RecordMergeMode, String, String> inferredMergeConfs2 =
+         HoodieTableConfig.inferCorrectMergingBehavior(
+             writeConfig2.getRecordMergeMode(), writeConfig2.getPayloadClass(),
+-            writeConfig2.getRecordMergeStrategyId(), String.join(",", writeConfig2.getPreCombineFields()),
++            writeConfig2.getRecordMergeStrategyId(), String.join(",", table2.getMetaClient().getTableConfig().getOrderingFields()),
+             metaClient.getTableConfig().getTableVersion());
+     HoodieTableConfig hoodieTableConfig2 =
+         new HoodieTableConfig(this.storage, metaClient.getMetaPath(),

--- a/pr_13718_files/0091.diff
+++ b/pr_13718_files/0091.diff
@@ -1,0 +1,99 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieDatasetBulkInsertHelper.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieDatasetBulkInsertHelper.java
+index 21b1a9be870ea..6f08491f61702 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieDatasetBulkInsertHelper.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieDatasetBulkInsertHelper.java
+@@ -23,6 +23,7 @@
+ import org.apache.hudi.SparkAdapterSupport$;
+ import org.apache.hudi.common.config.TypedProperties;
+ import org.apache.hudi.common.model.HoodieRecord;
++import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.common.util.FileIOUtils;
+ import org.apache.hudi.config.HoodieWriteConfig;
+ import org.apache.hudi.execution.bulkinsert.NonSortPartitionerWithRows;
+@@ -132,7 +133,7 @@ private void testBulkInsertHelperFor(String keyGenClass, String recordKeyField)
+     List<Row> rows = DataSourceTestUtils.generateRandomRows(10);
+     Dataset<Row> dataset = sqlContext.createDataFrame(rows, structType);
+     Dataset<Row> result = HoodieDatasetBulkInsertHelper.prepareForBulkInsert(dataset, config,
+-        new NonSortPartitionerWithRows(), "0000000001");
++        new HoodieTableConfig(), new NonSortPartitionerWithRows(), "0000000001");
+     StructType resultSchema = result.schema();
+ 
+     assertEquals(result.count(), 10);
+@@ -176,7 +177,7 @@ public void testBulkInsertHelperNoMetaFields() {
+         .build();
+     Dataset<Row> dataset = sqlContext.createDataFrame(rows, structType);
+     Dataset<Row> result = HoodieDatasetBulkInsertHelper.prepareForBulkInsert(dataset, config,
+-        new NonSortPartitionerWithRows(), "000001111");
++        new HoodieTableConfig(), new NonSortPartitionerWithRows(), "000001111");
+     StructType resultSchema = result.schema();
+ 
+     assertEquals(result.count(), 10);
+@@ -204,7 +205,10 @@ public void testBulkInsertHelperNoMetaFields() {
+   public void testBulkInsertPreCombine(boolean enablePreCombine) {
+     HoodieWriteConfig config = getConfigBuilder(schemaStr).withProps(getPropsAllSet("_row_key"))
+             .combineInput(enablePreCombine, enablePreCombine)
+-            .withPreCombineField("ts").build();
++            .build();
++    config.setValue(HoodieTableConfig.ORDERING_FIELDS, "ts");
++    HoodieTableConfig tableConfig = new HoodieTableConfig();
++    tableConfig.setValue(HoodieTableConfig.ORDERING_FIELDS, "ts");
+     List<Row> inserts = DataSourceTestUtils.generateRandomRows(10);
+     Dataset<Row> toUpdateDataset = sqlContext.createDataFrame(inserts.subList(0, 5), structType);
+     List<Row> updates = DataSourceTestUtils.updateRowsWithUpdatedTs(toUpdateDataset);
+@@ -213,7 +217,7 @@ public void testBulkInsertPreCombine(boolean enablePreCombine) {
+     rows.addAll(updates);
+     Dataset<Row> dataset = sqlContext.createDataFrame(rows, structType);
+     Dataset<Row> result = HoodieDatasetBulkInsertHelper.prepareForBulkInsert(dataset, config,
+-        new NonSortPartitionerWithRows(), "000001111");
++        tableConfig, new NonSortPartitionerWithRows(), "000001111");
+     StructType resultSchema = result.schema();
+ 
+     assertEquals(result.count(), enablePreCombine ? 10 : 15);
+@@ -317,7 +321,7 @@ public void testNoPropsSet() {
+     Dataset<Row> dataset = sqlContext.createDataFrame(rows, structType);
+     try {
+       Dataset<Row> preparedDF = HoodieDatasetBulkInsertHelper.prepareForBulkInsert(dataset, config,
+-          new NonSortPartitionerWithRows(), "000001111");
++          new HoodieTableConfig(), new NonSortPartitionerWithRows(), "000001111");
+       preparedDF.count();
+       fail("Should have thrown exception");
+     } catch (Exception e) {
+@@ -329,7 +333,7 @@ public void testNoPropsSet() {
+     dataset = sqlContext.createDataFrame(rows, structType);
+     try {
+       Dataset<Row> preparedDF = HoodieDatasetBulkInsertHelper.prepareForBulkInsert(dataset, config,
+-          new NonSortPartitionerWithRows(), "000001111");
++          new HoodieTableConfig(), new NonSortPartitionerWithRows(), "000001111");
+       preparedDF.count();
+       fail("Should have thrown exception");
+     } catch (Exception e) {
+@@ -341,7 +345,7 @@ public void testNoPropsSet() {
+     dataset = sqlContext.createDataFrame(rows, structType);
+     try {
+       Dataset<Row> preparedDF = HoodieDatasetBulkInsertHelper.prepareForBulkInsert(dataset, config,
+-          new NonSortPartitionerWithRows(), "000001111");
++          new HoodieTableConfig(), new NonSortPartitionerWithRows(), "000001111");
+       preparedDF.count();
+       fail("Should have thrown exception");
+     } catch (Exception e) {
+@@ -357,7 +361,10 @@ private ExpressionEncoder getEncoder(StructType schema) {
+   public void testBulkInsertParallelismParam() {
+     HoodieWriteConfig config = getConfigBuilder(schemaStr).withProps(getPropsAllSet("_row_key"))
+         .combineInput(true, true)
+-        .withPreCombineField("ts").build();
++        .build();
++    config.setValue(HoodieTableConfig.ORDERING_FIELDS, "ts");
++    HoodieTableConfig tableConfig = new HoodieTableConfig();
++    tableConfig.setValue(HoodieTableConfig.ORDERING_FIELDS, "ts");
+     int checkParallelism = 7;
+     config.setValue("hoodie.bulkinsert.shuffle.parallelism", String.valueOf(checkParallelism));
+     StageCheckBulkParallelismListener stageCheckBulkParallelismListener =
+@@ -368,7 +375,7 @@ public void testBulkInsertParallelismParam() {
+     assertNotEquals(checkParallelism, HoodieUnsafeUtils.getNumPartitions(dataset));
+     assertNotEquals(checkParallelism, sqlContext.sparkContext().defaultParallelism());
+     Dataset<Row> result = HoodieDatasetBulkInsertHelper.prepareForBulkInsert(dataset, config,
+-        new NonSortPartitionerWithRows(), "000001111");
++        tableConfig, new NonSortPartitionerWithRows(), "000001111");
+     // trigger job
+     result.count();
+     assertEquals(checkParallelism, stageCheckBulkParallelismListener.getParallelism());

--- a/pr_13718_files/0092.diff
+++ b/pr_13718_files/0092.diff
@@ -1,0 +1,16 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieIndex.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieIndex.java
+index c0fc5846f4b25..4b343e33051cf 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieIndex.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieIndex.java
+@@ -182,9 +182,9 @@ private Properties getPropsForKeyGen(IndexType indexType, boolean populateMetaFi
+       properties.put(HoodieTableConfig.RECORDKEY_FIELDS.key(), "_row_key");
+       properties.put("hoodie.datasource.write.keygenerator.class", RawTripTestPayloadKeyGenerator.class.getName());
+       properties.put("hoodie.datasource.write.partitionpath.field", "time");
+-      properties.put("hoodie.datasource.write.precombine.field", "number");
++      properties.put(HoodieTableConfig.ORDERING_FIELDS.key(), "number");
+       properties.put(HoodieTableConfig.PARTITION_FIELDS.key(), "time");
+-      properties.put(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "number");
++      properties.put(HoodieTableConfig.ORDERING_FIELDS.key(), "number");
+     }
+     return properties;
+   }

--- a/pr_13718_files/0093.diff
+++ b/pr_13718_files/0093.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
+index 0ed059fe20fb8..f8f67c14f80dc 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableInsertUpdateDelete.java
+@@ -270,7 +270,7 @@ public void testRepeatedRollbackOfCompaction() throws Exception {
+   @ValueSource(booleans = {true, false})
+   public void testSimpleInsertUpdateAndDelete(boolean populateMetaFields) throws Exception {
+     Properties properties = populateMetaFields ? new Properties() : getPropertiesForKeyGen();
+-    properties.setProperty(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "timestamp");
++    properties.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     properties.setProperty(HoodieTableConfig.BASE_FILE_FORMAT.key(), HoodieTableConfig.BASE_FILE_FORMAT.defaultValue().toString());
+     HoodieTableMetaClient metaClient = getHoodieMetaClient(HoodieTableType.MERGE_ON_READ, properties);
+ 

--- a/pr_13718_files/0094.diff
+++ b/pr_13718_files/0094.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestSparkNonBlockingConcurrencyControl.java b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestSparkNonBlockingConcurrencyControl.java
+index 855c6510f97d0..035e33480be84 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestSparkNonBlockingConcurrencyControl.java
++++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestSparkNonBlockingConcurrencyControl.java
+@@ -617,7 +617,7 @@ private HoodieWriteConfig createHoodieWriteConfig(boolean fullUpdate) {
+     props.put(ENABLE_SCHEMA_CONFLICT_RESOLUTION.key(), "false");
+     String basePath = basePath();
+     return HoodieWriteConfig.newBuilder()
+-        .withProps(Collections.singletonMap(HoodieTableConfig.PRECOMBINE_FIELDS.key(), "ts"))
++        .withProps(Collections.singletonMap(HoodieTableConfig.ORDERING_FIELDS.key(), "ts"))
+         .forTable("test")
+         .withPath(basePath)
+         .withSchema(jsonSchema)

--- a/pr_13718_files/0095.diff
+++ b/pr_13718_files/0095.diff
@@ -1,0 +1,39 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/resources/upgrade-downgrade-fixtures/scala-templates/generate-fixture.scala b/hudi-spark-datasource/hudi-spark/src/test/resources/upgrade-downgrade-fixtures/scala-templates/generate-fixture.scala
+index fbefed9e05dfc..46f4eb43ced42 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/resources/upgrade-downgrade-fixtures/scala-templates/generate-fixture.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/resources/upgrade-downgrade-fixtures/scala-templates/generate-fixture.scala
+@@ -16,6 +16,7 @@
+  */
+ 
+ import org.apache.spark.sql.SaveMode
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.DataSourceWriteOptions._
+ import spark.implicits._
+ 
+@@ -35,7 +36,7 @@ val df = testData.toDF("id", "name", "ts", "partition")
+ 
+ // Write initial batch (creates base files)
+ df.write.format("hudi").
+-  option(PRECOMBINE_FIELD.key, "ts").
++  option(HoodieTableConfig.ORDERING_FIELDS.key, "ts").
+   option(RECORDKEY_FIELD.key, "id").
+   option(PARTITIONPATH_FIELD.key, "partition").
+   option("hoodie.table.name", tableName).
+@@ -61,7 +62,7 @@ val updateData = Seq(
+ val updateDf = updateData.toDF("id", "name", "ts", "partition")
+ 
+ updateDf.write.format("hudi").
+-  option(PRECOMBINE_FIELD.key, "ts").
++  option(HoodieTableConfig.ORDERING_FIELDS.key, "ts").
+   option(RECORDKEY_FIELD.key, "id").
+   option(PARTITIONPATH_FIELD.key, "partition").
+   option("hoodie.table.name", tableName).
+@@ -86,7 +87,7 @@ val insertData = Seq(
+ val insertDf = insertData.toDF("id", "name", "ts", "partition")
+ 
+ insertDf.write.format("hudi").
+-  option(PRECOMBINE_FIELD.key, "ts").
++  option(HoodieTableConfig.ORDERING_FIELDS.key, "ts").
+   option(RECORDKEY_FIELD.key, "id").
+   option(PARTITIONPATH_FIELD.key, "partition").
+   option("hoodie.table.name", tableName).

--- a/pr_13718_files/0096.diff
+++ b/pr_13718_files/0096.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroSchemaResolutionSupport.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroSchemaResolutionSupport.scala
+index 2929534ffa745..7b8f9b737e0f1 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroSchemaResolutionSupport.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestAvroSchemaResolutionSupport.scala
+@@ -20,6 +20,7 @@ package org.apache.hudi
+ 
+ import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieReaderConfig}
+ import org.apache.hudi.common.model.HoodieTableType
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.config.HoodieWriteConfig
+ import org.apache.hudi.exception.SchemaCompatibilityException
+ import org.apache.hudi.testutils.HoodieClientTestBase
+@@ -45,7 +46,7 @@ class TestAvroSchemaResolutionSupport extends HoodieClientTestBase with ScalaAss
+     "hoodie.insert.shuffle.parallelism" -> "1",
+     "hoodie.upsert.shuffle.parallelism" -> "1",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "id",
++    HoodieTableConfig.ORDERING_FIELDS.key() -> "id",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "name",
+     DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> "org.apache.hudi.keygen.SimpleKeyGenerator",
+     HoodieMetadataConfig.ENABLE.key -> "false"

--- a/pr_13718_files/0097.diff
+++ b/pr_13718_files/0097.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestGenericRecordAndRowConsistency.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestGenericRecordAndRowConsistency.scala
+index 54ccfd0fd4b19..f7e132e23636f 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestGenericRecordAndRowConsistency.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestGenericRecordAndRowConsistency.scala
+@@ -17,6 +17,7 @@
+  */
+ package org.apache.hudi
+ 
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.config.HoodieWriteConfig
+ import org.apache.hudi.testutils.HoodieSparkClientTestBase
+ 
+@@ -35,7 +36,7 @@ class TestGenericRecordAndRowConsistency extends HoodieSparkClientTestBase {
+     "hoodie.upsert.shuffle.parallelism" -> "1",
+     DataSourceWriteOptions.TABLE_TYPE.key -> "COPY_ON_WRITE",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "str,eventTime",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "typeId",
++    HoodieTableConfig.ORDERING_FIELDS.key() -> "typeId",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "typeId",
+     DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> "org.apache.hudi.keygen.ComplexKeyGenerator",
+     DataSourceWriteOptions.KEYGENERATOR_CONSISTENT_LOGICAL_TIMESTAMP_ENABLED.key -> "true"

--- a/pr_13718_files/0098.diff
+++ b/pr_13718_files/0098.diff
@@ -1,0 +1,76 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+index 1071cdd8438a7..7fc9b07185d87 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+@@ -76,7 +76,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
+     "hoodie.upsert.shuffle.parallelism" -> "4",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key() -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   )
+ 
+@@ -207,7 +207,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition_path",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "timestamp",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.OPERATION.key -> DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL
+     )
+@@ -353,7 +353,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
+     val writerOpts: Map[String, String] = commonOpts ++ Map(
+       DataSourceWriteOptions.OPERATION.key -> DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
+       RECORDKEY_FIELD.key -> "id",
+-      PRECOMBINE_FIELD.key -> "version",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "version",
+       PARTITIONPATH_FIELD.key -> "dt,hh",
+       HoodieMetadataConfig.ENABLE.key -> useMetadataTable.toString
+     )
+@@ -496,7 +496,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
+     val writerOpts: Map[String, String] = commonOpts ++ Map(
+       DataSourceWriteOptions.OPERATION.key -> DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
+       RECORDKEY_FIELD.key -> "id",
+-      PRECOMBINE_FIELD.key -> "version",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "version",
+       PARTITIONPATH_FIELD.key -> partitionNames.mkString(","),
+       HoodieMetadataConfig.ENABLE.key -> useMetadataTable.toString
+     )
+@@ -551,7 +551,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
+       val writerOpts: Map[String, String] = commonOpts ++ Map(
+         DataSourceWriteOptions.OPERATION.key -> DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
+         RECORDKEY_FIELD.key -> "id",
+-        PRECOMBINE_FIELD.key -> "version",
++        HoodieTableConfig.ORDERING_FIELDS.key() -> "version",
+         PARTITIONPATH_FIELD.key -> "dt,hh"
+       )
+ 
+@@ -613,7 +613,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
+       HoodieMetadataConfig.ENABLE.key -> enableMetadataTable.toString,
+       RECORDKEY_FIELD.key -> "id",
+       PARTITIONPATH_FIELD.key -> "region_code,dt",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "price"
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "price"
+     )
+ 
+     val readerOpts: Map[String, String] = queryOpts ++ Map(
+@@ -734,7 +734,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
+       .options(commonOpts)
+       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+       .option(RECORDKEY_FIELD.key, "id")
+-      .option(PRECOMBINE_FIELD.key, "id")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key, "id")
+       .option(PARTITIONPATH_FIELD.key, partitionBy)
+       .option(HoodieMetadataConfig.ENABLE.key(), useMetaFileList)
+       .mode(SaveMode.Overwrite)
+@@ -765,7 +765,7 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       RECORDKEY_FIELD.key -> "id",
+-      PRECOMBINE_FIELD.key -> "id",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "id",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"
+     ) ++ writeMetadataOpts
+ 

--- a/pr_13718_files/0099.diff
+++ b/pr_13718_files/0099.diff
@@ -1,0 +1,112 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
+index 78ca3d149ed45..fe0f16971cda0 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriter.scala
+@@ -307,7 +307,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+     option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key(), "city").
+     option(HoodieWriteConfig.TBL_NAME.key(), hoodieFooTableName).
+     option("hoodie.datasource.write.recordkey.field", "uuid").
+-    option("hoodie.datasource.write.precombine.field", "rider").
++    option(HoodieTableConfig.ORDERING_FIELDS.key(), "rider").
+     option("hoodie.datasource.write.operation", "bulk_insert").
+     option("hoodie.datasource.write.hive_style_partitioning", "true").
+     option("hoodie.populate.meta.fields", "false").
+@@ -405,7 +405,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+     val recordsSeq = convertRowListToSeq(records)
+     val df = spark.createDataFrame(sc.parallelize(recordsSeq), structType)
+     // write to Hudi
+-    HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, fooTableModifier - DataSourceWriteOptions.PRECOMBINE_FIELD.key, df)
++    HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, fooTableModifier - HoodieTableConfig.ORDERING_FIELDS.key, df)
+ 
+     // collect all partition paths to issue read of parquet files
+     val partitions = Seq(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH,
+@@ -614,7 +614,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+       .setBaseFileFormat(fooTableParams.getOrElse(HoodieWriteConfig.BASE_FILE_FORMAT.key,
+         HoodieTableConfig.BASE_FILE_FORMAT.defaultValue().name))
+       .setArchiveLogFolder(HoodieTableConfig.TIMELINE_HISTORY_PATH.defaultValue())
+-      .setPreCombineFields(fooTableParams.getOrElse(DataSourceWriteOptions.PRECOMBINE_FIELD.key, null))
++      .setOrderingFields(fooTableParams.getOrElse(HoodieTableConfig.ORDERING_FIELDS.key, null))
+       .setPartitionFields(fooTableParams(DataSourceWriteOptions.PARTITIONPATH_FIELD.key))
+       .setKeyGeneratorClassProp(fooTableParams.getOrElse(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key,
+         DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.defaultValue()))
+@@ -763,7 +763,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+     List(DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL, DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL).foreach { tableType =>
+       val baseBootStrapPath = tempBootStrapPath.toAbsolutePath.toString
+       val options = Map(DataSourceWriteOptions.TABLE_TYPE.key -> tableType,
+-        DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "col3",
++        HoodieTableConfig.ORDERING_FIELDS.key -> "col3",
+         DataSourceWriteOptions.RECORDKEY_FIELD.key -> "keyid",
+         DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "",
+         DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> "org.apache.hudi.keygen.NonpartitionedKeyGenerator",
+@@ -963,7 +963,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+   @EnumSource(value = classOf[HoodieTableType])
+   def testNonPartitionTableWithMetatableSupport(tableType: HoodieTableType): Unit = {
+     val options = Map(DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name,
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "col3",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "col3",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "keyid",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "",
+       DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> "org.apache.hudi.keygen.NonpartitionedKeyGenerator",
+@@ -1048,7 +1048,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+   def testUpsertWithCombineBeforeUpsertDisabled(tableType: HoodieTableType): Unit = {
+     val options = Map(
+       DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name,
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "col3",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "col3",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "keyid",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "",
+       DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> "org.apache.hudi.keygen.NonpartitionedKeyGenerator",
+@@ -1079,7 +1079,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+     val df = Seq((1, "a1", 10, 1000L, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "dt"
+     )
+ 
+@@ -1154,7 +1154,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+     val df = Seq((1, "a1", 10, 1000, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts"
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts"
+     )
+ 
+     // case 1: When commit C1 specifies a key generator and commit C2 does not specify key generator
+@@ -1182,7 +1182,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+     val df = Seq((1, "a1", 10, 1000, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "dt"
+     )
+ 
+@@ -1214,7 +1214,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+     val df = Seq((1, "a1", 10, 1000, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "dt"
+     )
+ 
+@@ -1246,7 +1246,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+     val df = Seq((1, "a1", 10, 1000, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "dt"
+     )
+ 
+@@ -1301,7 +1301,7 @@ def testBulkInsertForDropPartitionColumn(): Unit = {
+     val df = Seq((1, "a1", 10, 1000, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       HoodieIndexConfig.BUCKET_INDEX_ENGINE_TYPE.key -> "CONSISTENT_HASHING",
+       HoodieIndexConfig.INDEX_TYPE.key -> "BUCKET"
+     )

--- a/pr_13718_files/0100.diff
+++ b/pr_13718_files/0100.diff
@@ -1,0 +1,67 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriterWithTestFormat.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriterWithTestFormat.scala
+index 312fc6ec24140..e047d0cefe7b0 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriterWithTestFormat.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieSparkSqlWriterWithTestFormat.scala
+@@ -274,7 +274,7 @@ class TestHoodieSparkSqlWriterWithTestFormat extends HoodieSparkWriterTestBase {
+     val recordsSeq = convertRowListToSeq(records)
+     val df = spark.createDataFrame(sc.parallelize(recordsSeq), structType)
+     // write to Hudi
+-    HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, fooTableModifier - DataSourceWriteOptions.PRECOMBINE_FIELD.key, df)
++    HoodieSparkSqlWriter.write(sqlContext, SaveMode.Append, fooTableModifier - HoodieTableConfig.ORDERING_FIELDS.key, df)
+ 
+     // collect all partition paths to issue read of parquet files
+     val partitions = Seq(HoodieTestDataGenerator.DEFAULT_FIRST_PARTITION_PATH, HoodieTestDataGenerator.DEFAULT_SECOND_PARTITION_PATH,
+@@ -485,7 +485,7 @@ class TestHoodieSparkSqlWriterWithTestFormat extends HoodieSparkWriterTestBase {
+       .setBaseFileFormat(fooTableParams.getOrElse(HoodieWriteConfig.BASE_FILE_FORMAT.key,
+         HoodieTableConfig.BASE_FILE_FORMAT.defaultValue().name))
+       .setArchiveLogFolder(HoodieTableConfig.TIMELINE_HISTORY_PATH.defaultValue())
+-      .setPreCombineFields(fooTableParams.getOrElse(DataSourceWriteOptions.PRECOMBINE_FIELD.key, null))
++      .setOrderingFields(fooTableParams.getOrElse(HoodieTableConfig.ORDERING_FIELDS.key, null))
+       .setPartitionFields(fooTableParams(DataSourceWriteOptions.PARTITIONPATH_FIELD.key))
+       .setKeyGeneratorClassProp(fooTableParams.getOrElse(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key,
+         DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.defaultValue()))
+@@ -505,7 +505,7 @@ class TestHoodieSparkSqlWriterWithTestFormat extends HoodieSparkWriterTestBase {
+     val df = Seq((1, "a1", 10, 1000, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       HoodieTableConfig.TABLE_FORMAT.key -> "test-format"
+     )
+ 
+@@ -534,7 +534,7 @@ class TestHoodieSparkSqlWriterWithTestFormat extends HoodieSparkWriterTestBase {
+     val df = Seq((1, "a1", 10, 1000, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "dt",
+       HoodieTableConfig.TABLE_FORMAT.key -> "test-format"
+     )
+@@ -567,7 +567,7 @@ class TestHoodieSparkSqlWriterWithTestFormat extends HoodieSparkWriterTestBase {
+     val df = Seq((1, "a1", 10, 1000, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "dt",
+       HoodieTableConfig.TABLE_FORMAT.key -> "test-format"
+     )
+@@ -600,7 +600,7 @@ class TestHoodieSparkSqlWriterWithTestFormat extends HoodieSparkWriterTestBase {
+     val df = Seq((1, "a1", 10, 1000, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "dt",
+       HoodieTableConfig.TABLE_FORMAT.key -> "test-format"
+     )
+@@ -658,7 +658,7 @@ class TestHoodieSparkSqlWriterWithTestFormat extends HoodieSparkWriterTestBase {
+     val df = Seq((1, "a1", 10, 1000, "2021-10-16")).toDF("id", "name", "value", "ts", "dt")
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       HoodieIndexConfig.BUCKET_INDEX_ENGINE_TYPE.key -> "CONSISTENT_HASHING",
+       HoodieIndexConfig.INDEX_TYPE.key -> "BUCKET",
+       HoodieTableConfig.TABLE_FORMAT.key -> "test-format"

--- a/pr_13718_files/0101.diff
+++ b/pr_13718_files/0101.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestInsertDedupPolicy.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestInsertDedupPolicy.scala
+index 62b02815e4901..376b38d6812da 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestInsertDedupPolicy.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestInsertDedupPolicy.scala
+@@ -21,6 +21,7 @@ package org.apache.hudi
+ 
+ import org.apache.hudi.DataSourceWriteOptions._
+ import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieReaderConfig}
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.config.{HoodieCompactionConfig, HoodieWriteConfig}
+ import org.apache.hudi.exception.HoodieUpsertException
+ import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+@@ -70,7 +71,7 @@ class TestInsertDedupPolicy extends SparkClientFunctionalTestHarness {
+     val inserts = spark.createDataFrame(firstInsertData).toDF(columns: _*)
+     inserts.write.format("hudi").
+       option(RECORDKEY_FIELD.key, "key").
+-      option(PRECOMBINE_FIELD.key, "ts").
++      option(HoodieTableConfig.ORDERING_FIELDS.key, "ts").
+       option(TABLE_TYPE.key, tableType).
+       option(DataSourceWriteOptions.TABLE_NAME.key, "test_table").
+       option(HoodieCompactionConfig.INLINE_COMPACT.key, "false").

--- a/pr_13718_files/0102.diff
+++ b/pr_13718_files/0102.diff
@@ -1,0 +1,22 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestParquetReaderCompatibility.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestParquetReaderCompatibility.scala
+index f9cf1a398d5e8..780e80b9e217f 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestParquetReaderCompatibility.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestParquetReaderCompatibility.scala
+@@ -23,7 +23,7 @@ import org.apache.hudi.TestParquetReaderCompatibility.NullabilityEnum.{NotNullab
+ import org.apache.hudi.client.common.HoodieSparkEngineContext
+ import org.apache.hudi.common.config.HoodieMetadataConfig
+ import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
+-import org.apache.hudi.common.table.ParquetTableSchemaResolver
++import org.apache.hudi.common.table.{HoodieTableConfig, ParquetTableSchemaResolver}
+ import org.apache.hudi.common.testutils.HoodieTestUtils
+ import org.apache.hudi.common.util.ConfigUtils.DEFAULT_HUDI_CONFIG_FOR_READER
+ import org.apache.hudi.config.HoodieWriteConfig
+@@ -202,7 +202,7 @@ class TestParquetReaderCompatibility extends HoodieSparkWriterTestBase {
+     val path = tempBasePath + "_avro_list_update"
+     val options = Map(
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "key",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+       HoodieWriteConfig.TBL_NAME.key -> hoodieFooTableName,
+       "path" -> path

--- a/pr_13718_files/0103.diff
+++ b/pr_13718_files/0103.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
+index abcb98014f78a..d0de175ac5a8c 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
+@@ -239,7 +239,7 @@ class TestHoodieFileGroupReaderOnSpark extends TestHoodieFileGroupReaderBase[Int
+     val inserts = spark.createDataFrame(data).toDF(columns: _*)
+     inserts.write.format("hudi").
+       option(RECORDKEY_FIELD.key(), "key").
+-      option(PRECOMBINE_FIELD.key(), "ts").
++      option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts").
+       option(TABLE_TYPE.key(), tableType).
+       option(DataSourceWriteOptions.TABLE_NAME.key(), "test_table").
+       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").

--- a/pr_13718_files/0104.diff
+++ b/pr_13718_files/0104.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestSpark35RecordPositionMetadataColumn.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestSpark35RecordPositionMetadataColumn.scala
+index fd06f0382e1e2..cbf37e0c6281c 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestSpark35RecordPositionMetadataColumn.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestSpark35RecordPositionMetadataColumn.scala
+@@ -23,6 +23,7 @@ import org.apache.hudi.{DataSourceWriteOptions, HoodieSparkUtils, SparkFileForma
+ import org.apache.hudi.SparkAdapterSupport.sparkAdapter
+ import org.apache.hudi.common.config.{HoodieReaderConfig, HoodieStorageConfig}
+ import org.apache.hudi.common.model.HoodieTableType
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.testutils.HoodieTestTable
+ import org.apache.hudi.common.util
+ import org.apache.hudi.config.HoodieWriteConfig
+@@ -56,7 +57,7 @@ class TestSpark35RecordPositionMetadataColumn extends SparkClientFunctionalTestH
+     // Create the file with record positions.
+     userToCountryDF.write.format("hudi")
+       .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "userid")
+-      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+       .option(HoodieWriteConfig.TBL_NAME.key, "user_to_country")
+       .option(HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key, SPARK_MERGER)
+       .option(HoodieWriteConfig.WRITE_RECORD_POSITIONS.key, "true")

--- a/pr_13718_files/0105.diff
+++ b/pr_13718_files/0105.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/CommonOptionUtils.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/CommonOptionUtils.scala
+index f88fb4ba2efb2..8510a2028ca21 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/CommonOptionUtils.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/CommonOptionUtils.scala
+@@ -35,7 +35,7 @@ object CommonOptionUtils {
+     HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.key() -> "true",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key -> "1"
+   )

--- a/pr_13718_files/0106.diff
+++ b/pr_13718_files/0106.diff
@@ -1,0 +1,22 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/HoodieStatsIndexTestBase.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/HoodieStatsIndexTestBase.scala
+index bf790e216ac05..d3b4122db2174 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/HoodieStatsIndexTestBase.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/HoodieStatsIndexTestBase.scala
+@@ -23,7 +23,7 @@ import org.apache.hudi.client.SparkRDDWriteClient
+ import org.apache.hudi.client.common.HoodieSparkEngineContext
+ import org.apache.hudi.common.config.TypedProperties
+ import org.apache.hudi.common.model.{ActionType, HoodieCommitMetadata, WriteOperationType}
+-import org.apache.hudi.common.table.HoodieTableMetaClient
++import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+ import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieInstantTimeGenerator, MetadataConversionUtils}
+ import org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR
+ import org.apache.hudi.config.HoodieWriteConfig
+@@ -53,7 +53,7 @@ class HoodieStatsIndexTestBase extends HoodieSparkClientTestBase {
+     "hoodie.upsert.shuffle.parallelism" -> "4",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     RECORDKEY_FIELD.key -> "_row_key",
+-    PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.MARKERS_TIMELINE_SERVER_BASED_BATCH_INTERVAL_MS.key -> "10"
+   )
+ 

--- a/pr_13718_files/0107.diff
+++ b/pr_13718_files/0107.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
+index 3fd94ad5cb3a4..95b30bbe6f20a 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/RecordLevelIndexTestBase.scala
+@@ -59,7 +59,7 @@ class RecordLevelIndexTestBase extends HoodieStatsIndexTestBase {
+     RECORDKEY_FIELD.key -> "uuid",
+     SECONDARYKEY_COLUMN_NAME.key -> "city",
+     PARTITIONPATH_FIELD.key -> "state",
+-    PRECOMBINE_FIELD.key -> "ts",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+     HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"
+   ) ++ metadataOpts
+ 

--- a/pr_13718_files/0108.diff
+++ b/pr_13718_files/0108.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBasicSchemaEvolution.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBasicSchemaEvolution.scala
+index 5a0ade3dc0bc3..ced770865878a 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBasicSchemaEvolution.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBasicSchemaEvolution.scala
+@@ -54,7 +54,7 @@ class TestBasicSchemaEvolution extends HoodieSparkClientTestBase with ScalaAsser
+     HoodieWriteConfig.RECORD_MERGE_MODE.key() -> RecordMergeMode.COMMIT_TIME_ORDERING.name(),
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     HoodieMetadataConfig.ENABLE_METADATA_INDEX_PARTITION_STATS.key -> "true"
+   )

--- a/pr_13718_files/0109.diff
+++ b/pr_13718_files/0109.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBloomFiltersIndexSupport.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBloomFiltersIndexSupport.scala
+index fefc9f603ccf3..902071a411582 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBloomFiltersIndexSupport.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestBloomFiltersIndexSupport.scala
+@@ -64,7 +64,7 @@ class TestBloomFiltersIndexSupport extends HoodieSparkClientTestBase {
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     RECORDKEY_FIELD.key -> "_row_key",
+     PARTITIONPATH_FIELD.key -> "partition",
+-    PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"
+   ) ++ metadataOpts
+   var mergedDfList: List[DataFrame] = List.empty

--- a/pr_13718_files/0110.diff
+++ b/pr_13718_files/0110.diff
@@ -1,0 +1,67 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+index 9c5d34d0960e0..70cba8e79d655 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+@@ -191,7 +191,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key() -> "timestamp,rider",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "timestamp,rider",
+       DataSourceWriteOptions.RECORD_MERGE_MODE.key() -> RecordMergeMode.EVENT_TIME_ORDERING.name(),
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+     )
+@@ -443,7 +443,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
+ 
+   @ParameterizedTest
+   @CsvSource(Array("hoodie.datasource.write.recordkey.field,begin_lat", "hoodie.datasource.write.partitionpath.field,end_lon",
+-    "hoodie.datasource.write.keygenerator.class,org.apache.hudi.keygen.NonpartitionedKeyGenerator", "hoodie.datasource.write.precombine.field,fare"))
++    "hoodie.datasource.write.keygenerator.class,org.apache.hudi.keygen.NonpartitionedKeyGenerator", "hoodie.datasource.write.precombine.fields,fare"))
+   def testAlteringRecordKeyConfig(configKey: String, configValue: String) {
+     val recordType = HoodieRecordType.AVRO
+     val (writeOpts, readOpts) = getWriterReaderOpts(recordType, Map(
+@@ -451,7 +451,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       "hoodie.bulkinsert.shuffle.parallelism" -> "2",
+       "hoodie.delete.shuffle.parallelism" -> "1",
+-      "hoodie.datasource.write.precombine.field" -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "timestamp",
+       HoodieMetadataConfig.ENABLE.key -> "false" // this is testing table configs and write configs. disabling metadata to save on test run time.
+     ))
+ 
+@@ -1535,7 +1535,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
+       .option("hoodie.bulkinsert.shuffle.parallelism", "2")
+       .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "id")
+       .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "data_date")
+-      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+       .option(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key, "org.apache.hudi.keygen.TimestampBasedKeyGenerator")
+       .option(TIMESTAMP_TYPE_FIELD.key, "DATE_STRING")
+       .option(TIMESTAMP_INPUT_DATE_FORMAT.key, "yyyy-MM-dd")
+@@ -1663,7 +1663,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
+       .options(writeOpts)
+       .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "uuid")
+       .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "partitionpath")
+-      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+       .option(HoodieWriteConfig.TBL_NAME.key, "hoodie_test")
+       .option(HoodieMetricsConfig.TURN_METRICS_ON.key(), "true")
+@@ -1792,7 +1792,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
+       DataSourceWriteOptions.TABLE_TYPE.key() -> "COPY_ON_WRITE",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key() -> "id",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key() -> "partition",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key() -> "precombine",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "precombine",
+       DataSourceWriteOptions.HIVE_STYLE_PARTITIONING.key() -> "true"
+     )
+ 
+@@ -1804,7 +1804,7 @@ class TestCOWDataSource extends HoodieSparkClientTestBase with ScalaAssertionSup
+       DataSourceWriteOptions.TABLE_TYPE.key() -> "COPY_ON_WRITE",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key() -> "id",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key() -> "partition",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key() -> "precombine"
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "precombine"
+     )
+ 
+     df.filter(df("id") === 1).

--- a/pr_13718_files/0111.diff
+++ b/pr_13718_files/0111.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSourceStorage.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSourceStorage.scala
+index cd77a5f6f674f..dfbd07cabe4a4 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSourceStorage.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSourceStorage.scala
+@@ -24,6 +24,7 @@ import org.apache.hudi.client.validator.{SqlQueryEqualityPreCommitValidator, Sql
+ import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieReaderConfig}
+ import org.apache.hudi.common.config.TimestampKeyGeneratorConfig.{TIMESTAMP_INPUT_DATE_FORMAT, TIMESTAMP_OUTPUT_DATE_FORMAT, TIMESTAMP_TYPE_FIELD}
+ import org.apache.hudi.common.model.WriteOperationType
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator
+ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+@@ -59,7 +60,7 @@ class TestCOWDataSourceStorage extends SparkClientFunctionalTestHarness {
+     "hoodie.delete.shuffle.parallelism" -> "1",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     DataSourceWriteOptions.HIVE_STYLE_PARTITIONING.key -> "false"
+   )

--- a/pr_13718_files/0112.diff
+++ b/pr_13718_files/0112.diff
@@ -1,0 +1,103 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+index 21dedc23d8636..1840c0307e9e0 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+@@ -87,7 +87,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+         HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+         DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+         RECORDKEY_FIELD.key -> "c1",
+-        PRECOMBINE_FIELD.key -> "c1",
++        HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+         HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+         "hoodie.compact.inline.max.delta.commits" -> "10",
+         HoodieWriteConfig.WRITE_TABLE_VERSION.key() -> testCase.tableVersion.toString
+@@ -212,7 +212,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       HoodieWriteConfig.WRITE_TABLE_VERSION.key() -> testCase.tableVersion.toString
+     ) ++ metadataOpts
+@@ -272,7 +272,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key -> partitionCol,
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key -> "5",
+@@ -389,7 +389,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key() -> partitionCol,
+       "hoodie.write.markers.type" -> "DIRECT",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+@@ -520,7 +520,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key() -> partitionCol,
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key() -> "5",
+@@ -577,7 +577,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key() -> partitionCol,
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key() -> "1",
+@@ -643,7 +643,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key() -> partitionCol,
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key() -> "1",
+@@ -712,7 +712,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name(),
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       HoodieWriteConfig.WRITE_TABLE_VERSION.key() -> tableVersion.toString
+     ) ++ metadataOpts
+@@ -763,7 +763,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key() -> "c8",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       HoodieCommonConfig.RECONCILE_SCHEMA.key -> "true",
+@@ -860,7 +860,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       HoodieCommonConfig.RECONCILE_SCHEMA.key -> "true",
+       HoodieWriteConfig.WRITE_TABLE_VERSION.key() -> tableVersion.toString
+@@ -975,7 +975,7 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       HoodieWriteConfig.WRITE_TABLE_VERSION.key() -> tableVersion.toString
+     ) ++ metadataOpts

--- a/pr_13718_files/0113.diff
+++ b/pr_13718_files/0113.diff
@@ -1,0 +1,76 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
+index f05c008361004..5c18aced12884 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndexWithSQL.scala
+@@ -67,7 +67,7 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
+       DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL
+@@ -91,7 +91,7 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
+       DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL
+@@ -328,7 +328,7 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
+       DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL,
+@@ -364,7 +364,7 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
+       DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL,
+@@ -404,7 +404,7 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
+       DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL,
+@@ -431,7 +431,7 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
+       DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL,
+@@ -466,7 +466,7 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
+       DataSourceReadOptions.QUERY_TYPE.key -> DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL,
+@@ -511,7 +511,7 @@ class TestColumnStatsIndexWithSQL extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> tableName,
+       DataSourceWriteOptions.TABLE_TYPE.key -> "mor",
+       RECORDKEY_FIELD.key -> "id",
+-      PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       DataSourceReadOptions.ENABLE_DATA_SKIPPING.key -> "true",
+       HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key() -> "20",

--- a/pr_13718_files/0114.diff
+++ b/pr_13718_files/0114.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
+index 7d6bbdbb6b7fb..7fe676065af87 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestDataSourceForBootstrap.scala
+@@ -23,6 +23,7 @@ import org.apache.hudi.client.bootstrap.selector.{FullRecordBootstrapModeSelecto
+ import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieStorageConfig}
+ import org.apache.hudi.common.model.HoodieRecord
+ import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.table.timeline.{HoodieInstantTimeGenerator, HoodieTimeline}
+ import org.apache.hudi.config.{HoodieBootstrapConfig, HoodieClusteringConfig, HoodieCompactionConfig, HoodieWriteConfig}
+ import org.apache.hudi.functional.TestDataSourceForBootstrap.{dropMetaCols, sort}
+@@ -57,7 +58,7 @@ class TestDataSourceForBootstrap {
+     HoodieBootstrapConfig.PARALLELISM_VALUE.key -> "4",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "false"
+   )

--- a/pr_13718_files/0115.diff
+++ b/pr_13718_files/0115.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestEmptyCommit.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestEmptyCommit.scala
+index c9e1c970f98c4..e85e12e632646 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestEmptyCommit.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestEmptyCommit.scala
+@@ -18,6 +18,7 @@
+ package org.apache.hudi.functional
+ 
+ import org.apache.hudi.{DataSourceWriteOptions, HoodieDataSourceHelpers}
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.config.HoodieWriteConfig
+ import org.apache.hudi.testutils.HoodieSparkClientTestBase
+ 
+@@ -34,7 +35,7 @@ class TestEmptyCommit extends HoodieSparkClientTestBase {
+     "hoodie.upsert.shuffle.parallelism" -> "4",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   )
+ 

--- a/pr_13718_files/0116.diff
+++ b/pr_13718_files/0116.diff
@@ -1,0 +1,22 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieActiveTimeline.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieActiveTimeline.scala
+index 0e581fdbfbf1a..cf1a402079038 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieActiveTimeline.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieActiveTimeline.scala
+@@ -20,7 +20,7 @@ package org.apache.hudi.functional
+ import org.apache.hudi.{DataSourceWriteOptions, HoodieDataSourceHelpers}
+ import org.apache.hudi.client.WriteClientTestUtils
+ import org.apache.hudi.common.model.HoodieFileFormat
+-import org.apache.hudi.common.table.HoodieTableMetaClient
++import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+ import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
+ import org.apache.hudi.common.testutils.HoodieTestUtils
+ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+@@ -46,7 +46,7 @@ class TestHoodieActiveTimeline extends HoodieSparkClientTestBase {
+     "hoodie.upsert.shuffle.parallelism" -> "4",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   )
+ 

--- a/pr_13718_files/0117.diff
+++ b/pr_13718_files/0117.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieMultipleBaseFileFormat.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieMultipleBaseFileFormat.scala
+index bf34735786508..1dab17c13d4cc 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieMultipleBaseFileFormat.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestHoodieMultipleBaseFileFormat.scala
+@@ -50,7 +50,7 @@ class TestHoodieMultipleBaseFileFormat extends HoodieSparkClientTestBase with Sp
+     HoodieTableConfig.MULTIPLE_BASE_FILE_FORMATS_ENABLE.key -> "true",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   )
+   val sparkOpts = Map(

--- a/pr_13718_files/0118.diff
+++ b/pr_13718_files/0118.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadByStateTransitionTime.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadByStateTransitionTime.scala
+index 703138f0c7c15..498c5d3c6c214 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadByStateTransitionTime.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadByStateTransitionTime.scala
+@@ -20,6 +20,7 @@ package org.apache.hudi.functional
+ import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions}
+ import org.apache.hudi.common.config.HoodieMetadataConfig
+ import org.apache.hudi.common.model.HoodieTableType
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling.USE_TRANSITION_TIME
+ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+ import org.apache.hudi.config.HoodieWriteConfig
+@@ -41,7 +42,7 @@ class TestIncrementalReadByStateTransitionTime extends HoodieSparkClientTestBase
+     "hoodie.upsert.shuffle.parallelism" -> "4",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key -> "1"
+   )

--- a/pr_13718_files/0119.diff
+++ b/pr_13718_files/0119.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadWithFullTableScan.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadWithFullTableScan.scala
+index 985fd1f8de03b..615dd88257297 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadWithFullTableScan.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestIncrementalReadWithFullTableScan.scala
+@@ -20,6 +20,7 @@ package org.apache.hudi.functional
+ import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions}
+ import org.apache.hudi.common.config.HoodieMetadataConfig
+ import org.apache.hudi.common.model.HoodieTableType
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieInstantTimeGenerator, InstantComparison}
+ import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator.instantTimeMinusMillis
+ import org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps
+@@ -70,7 +71,7 @@ class TestIncrementalReadWithFullTableScan extends HoodieSparkClientTestBase {
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key -> "1"
+     )

--- a/pr_13718_files/0120.diff
+++ b/pr_13718_files/0120.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLayoutOptimization.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLayoutOptimization.scala
+index 20db00f7d1bdd..00fc5a4dc82c2 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLayoutOptimization.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLayoutOptimization.scala
+@@ -21,6 +21,7 @@ package org.apache.hudi.functional
+ import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions}
+ import org.apache.hudi.HoodieFileIndex.DataSkippingFailureMode
+ import org.apache.hudi.common.config.HoodieMetadataConfig
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.table.timeline.{HoodieInstant, HoodieTimeline}
+ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+ import org.apache.hudi.config.{HoodieClusteringConfig, HoodieWriteConfig}
+@@ -62,7 +63,7 @@ class TestLayoutOptimization extends HoodieSparkClientTestBase {
+     "hoodie.bulkinsert.shuffle.parallelism" -> "4",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key() -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key() -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key() -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key() -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   ) ++ metadataOpts
+ 

--- a/pr_13718_files/0121.diff
+++ b/pr_13718_files/0121.diff
@@ -1,0 +1,108 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
+index 9176369a4d67a..5e8ca57664c62 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
+@@ -69,7 +69,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
+     "hoodie.upsert.shuffle.parallelism" -> "4",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   )
+   val sparkOpts = Map(
+@@ -142,11 +142,11 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
+     var (writeOpts, _) = getWriterReaderOpts(writeType)
+     readOpts = readOpts ++ Map(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> logType)
+     writeOpts = writeOpts ++ Map(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> logType)
+-    readOpts = readOpts - DataSourceWriteOptions.PRECOMBINE_FIELD.key
++    readOpts = readOpts - HoodieTableConfig.ORDERING_FIELDS.key
+     if (!hasPreCombineField) {
+-      writeOpts = writeOpts - DataSourceWriteOptions.PRECOMBINE_FIELD.key
++      writeOpts = writeOpts - HoodieTableConfig.ORDERING_FIELDS.key
+     } else {
+-      writeOpts = writeOpts ++ Map(DataSourceWriteOptions.PRECOMBINE_FIELD.key ->
++      writeOpts = writeOpts ++ Map(HoodieTableConfig.ORDERING_FIELDS.key ->
+         (if (isNullOrEmpty(precombineField)) "" else precombineField))
+     }
+     if (!isNullOrEmpty(recordMergeMode)) {
+@@ -206,14 +206,14 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
+         Map(HoodieTableConfig.VERSION.key -> HoodieTableVersion.SIX.versionCode().toString)
+       } ++
+       (if (hasPreCombineField && !isNullOrEmpty(precombineField)) {
+-        Map(HoodieTableConfig.PRECOMBINE_FIELDS.key -> precombineField)
++        Map(HoodieTableConfig.ORDERING_FIELDS.key -> precombineField)
+       } else {
+         Map()
+       })).asJava
+     val nonExistentConfigs: java.util.List[String] = (if (hasPreCombineField) {
+       Seq[String]()
+     } else {
+-      Seq(HoodieTableConfig.PRECOMBINE_FIELDS.key)
++      Seq(HoodieTableConfig.ORDERING_FIELDS.key)
+     }).asJava
+     HoodieTestUtils.validateTableConfig(storage, basePath, expectedConfigs, nonExistentConfigs)
+     val commit1CompletionTime = if (
+@@ -773,7 +773,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
+       .option(PAYLOAD_CLASS_NAME.key, classOf[DefaultHoodieRecordPayload].getCanonicalName)
+       .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL)
+       .option(RECORDKEY_FIELD.key, "id")
+-      .option(PRECOMBINE_FIELD.key, "version")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key, "version")
+       .option(PARTITIONPATH_FIELD.key, "")
+       .mode(SaveMode.Append)
+       .save(basePath)
+@@ -1144,7 +1144,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.OPERATION.key() -> DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
+       DataSourceWriteOptions.TABLE_TYPE.key()-> DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL,
+@@ -1186,7 +1186,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.OPERATION.key() -> DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
+       DataSourceWriteOptions.TABLE_TYPE.key() -> DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL,
+@@ -1330,7 +1330,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
+     val options = Map[String, String](
+       DataSourceWriteOptions.TABLE_TYPE.key -> HoodieTableType.MERGE_ON_READ.name,
+       DataSourceWriteOptions.OPERATION.key -> UPSERT_OPERATION_OPT_VAL,
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> precombineField,
++      HoodieTableConfig.ORDERING_FIELDS.key -> precombineField,
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> recordKeyField,
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "",
+       DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> "org.apache.hudi.keygen.NonpartitionedKeyGenerator",
+@@ -1428,7 +1428,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
+     val options = Map[String, String](
+       DataSourceWriteOptions.TABLE_TYPE.key -> HoodieTableType.MERGE_ON_READ.name,
+       DataSourceWriteOptions.OPERATION.key -> UPSERT_OPERATION_OPT_VAL,
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> precombineField,
++      HoodieTableConfig.ORDERING_FIELDS.key -> precombineField,
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> recordKeyField,
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "",
+       DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> "org.apache.hudi.keygen.NonpartitionedKeyGenerator",
+@@ -1741,7 +1741,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key() -> "timestamp,rider",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "timestamp,rider",
+       DataSourceWriteOptions.RECORD_MERGE_MODE.key() -> RecordMergeMode.EVENT_TIME_ORDERING.name(),
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+     )
+@@ -1934,7 +1934,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
+     Map(
+       // Don't override table name - let fixture table configuration take precedence
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",         // Fixture uses 'id' as record key
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",        // Fixture uses 'ts' as precombine field
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",        // Fixture uses 'ts' as precombine field
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition", // Fixture uses 'partition' as partition field
+       "hoodie.upsert.shuffle.parallelism" -> "2",
+       "hoodie.insert.shuffle.parallelism" -> "2"

--- a/pr_13718_files/0122.diff
+++ b/pr_13718_files/0122.diff
@@ -1,0 +1,40 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSourceStorage.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSourceStorage.scala
+index 487ec0f1418cf..2a8163dd3b6f4 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSourceStorage.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSourceStorage.scala
+@@ -69,7 +69,7 @@ class TestMORDataSourceStorage extends SparkClientFunctionalTestHarness {
+       "hoodie.delete.shuffle.parallelism" -> "1",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition_path",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       HoodieWriteConfig.MARKERS_TIMELINE_SERVER_BASED_BATCH_INTERVAL_MS.key -> "10"
+     )
+@@ -79,7 +79,7 @@ class TestMORDataSourceStorage extends SparkClientFunctionalTestHarness {
+     var options: Map[String, String] = commonOpts +
+       (HoodieMetadataConfig.ENABLE.key -> String.valueOf(isMetadataEnabled))
+     if (!StringUtils.isNullOrEmpty(preCombineField)) {
+-      options += (DataSourceWriteOptions.PRECOMBINE_FIELD.key() -> preCombineField)
++      options += (HoodieTableConfig.ORDERING_FIELDS.key() -> preCombineField)
+     }
+     if (useFileGroupReader) {
+       options += (HoodieReaderConfig.FILE_GROUP_READER_ENABLED.key() -> String.valueOf(useFileGroupReader))
+@@ -155,7 +155,7 @@ class TestMORDataSourceStorage extends SparkClientFunctionalTestHarness {
+       HoodieWriteConfig.WRITE_RECORD_POSITIONS.key -> "true",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition_path",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+     )
+ 
+@@ -207,7 +207,7 @@ class TestMORDataSourceStorage extends SparkClientFunctionalTestHarness {
+       HoodieWriteConfig.WRITE_RECORD_POSITIONS.key -> writeRecordPosition.toString,
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+       DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key -> classOf[NonpartitionedKeyGenerator].getName,
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       HoodieIndexConfig.INDEX_TYPE.key -> (if (enableNBCC) BUCKET.name else SIMPLE.name),
+       HoodieLockConfig.LOCK_PROVIDER_CLASS_NAME.key() -> classOf[InProcessLockProvider].getName,

--- a/pr_13718_files/0123.diff
+++ b/pr_13718_files/0123.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSourceWithBucketIndex.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSourceWithBucketIndex.scala
+index e88cc35b36ce3..718a12518f65a 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSourceWithBucketIndex.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSourceWithBucketIndex.scala
+@@ -18,6 +18,7 @@
+ package org.apache.hudi.functional
+ 
+ import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieDataSourceHelpers}
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator
+ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+ import org.apache.hudi.config.{HoodieIndexConfig, HoodieLayoutConfig, HoodieWriteConfig}
+@@ -45,7 +46,7 @@ class TestMORDataSourceWithBucketIndex extends HoodieSparkClientTestBase {
+     "hoodie.bulkinsert.shuffle.parallelism" -> "2",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     HoodieIndexConfig.INDEX_TYPE.key -> IndexType.BUCKET.name,
+     HoodieIndexConfig.BUCKET_INDEX_NUM_BUCKETS.key -> "8",

--- a/pr_13718_files/0124.diff
+++ b/pr_13718_files/0124.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataRecordIndex.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataRecordIndex.scala
+index e1ece6d88ecb2..3e386e7f029a9 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataRecordIndex.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataRecordIndex.scala
+@@ -56,7 +56,7 @@ class TestMetadataRecordIndex extends HoodieSparkClientTestBase {
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     RECORDKEY_FIELD.key -> "_row_key",
+     PARTITIONPATH_FIELD.key -> "partition",
+-    PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"
+   ) ++ metadataOpts
+   var mergedDfList: List[DataFrame] = List.empty

--- a/pr_13718_files/0125.diff
+++ b/pr_13718_files/0125.diff
@@ -1,0 +1,22 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
+index 59f24a0ad173b..5bbcbe0ce0791 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetadataTableWithSparkDataSource.scala
+@@ -23,7 +23,7 @@ import org.apache.hudi.avro.HoodieAvroUtils
+ import org.apache.hudi.client.common.HoodieSparkEngineContext
+ import org.apache.hudi.common.config.HoodieMetadataConfig
+ import org.apache.hudi.common.model.HoodieColumnRangeMetadata
+-import org.apache.hudi.common.table.HoodieTableMetaClient
++import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+ import org.apache.hudi.common.table.timeline.HoodieTimeline
+ import org.apache.hudi.common.table.view.FileSystemViewManager
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator
+@@ -62,7 +62,7 @@ class TestMetadataTableWithSparkDataSource extends SparkClientFunctionalTestHarn
+     "hoodie.bulkinsert.shuffle.parallelism" -> "2",
+     "hoodie.delete.shuffle.parallelism" -> "1",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   )
+ 

--- a/pr_13718_files/0126.diff
+++ b/pr_13718_files/0126.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetricsReporter.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetricsReporter.scala
+index 5f6b86662af34..a41fe883b8466 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetricsReporter.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMetricsReporter.scala
+@@ -20,6 +20,7 @@ package org.apache.hudi.functional
+ import org.apache.hudi.{DataSourceWriteOptions, SparkDatasetMixin}
+ import org.apache.hudi.HoodieConversionUtils.toJavaOption
+ import org.apache.hudi.common.config.HoodieMetadataConfig
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+ import org.apache.hudi.common.util.Option
+ import org.apache.hudi.config.HoodieWriteConfig
+@@ -48,7 +49,7 @@ class TestMetricsReporter extends HoodieSparkClientTestBase with SparkDatasetMix
+     "hoodie.upsert.shuffle.parallelism" -> "4",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   )
+ 

--- a/pr_13718_files/0127.diff
+++ b/pr_13718_files/0127.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestParquetColumnProjection.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestParquetColumnProjection.scala
+index 3be899b43e4ac..8784e254ea5d0 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestParquetColumnProjection.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestParquetColumnProjection.scala
+@@ -50,7 +50,7 @@ class TestParquetColumnProjection extends SparkClientFunctionalTestHarness with
+     "hoodie.bulkinsert.shuffle.parallelism" -> "2",
+     "hoodie.delete.shuffle.parallelism" -> "1",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     HoodieMetadataConfig.ENABLE.key -> "true"
+     // NOTE: It's critical that we use non-partitioned table, since the way we track amount of bytes read

--- a/pr_13718_files/0128.diff
+++ b/pr_13718_files/0128.diff
@@ -1,0 +1,30 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartialUpdateAvroPayload.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartialUpdateAvroPayload.scala
+index 98ff000262239..ec5dd8dabf03d 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartialUpdateAvroPayload.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartialUpdateAvroPayload.scala
+@@ -23,6 +23,7 @@ import org.apache.hudi.HoodieConversionUtils.toJavaOption
+ import org.apache.hudi.QuickstartUtils.{convertToStringList, getQuickstartWriteConfigs}
+ import org.apache.hudi.common.config.{HoodieReaderConfig, RecordMergeMode}
+ import org.apache.hudi.common.model.HoodieTableType
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.util.Option
+ import org.apache.hudi.config.HoodieWriteConfig
+ import org.apache.hudi.testutils.HoodieClientTestBase
+@@ -85,7 +86,7 @@ class TestPartialUpdateAvroPayload extends HoodieClientTestBase {
+       .option(DataSourceWriteOptions.TABLE_TYPE.key(), hoodieTableType.name())
+       .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "uuid")
+       .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "partitionpath")
+-      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+       .option(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key, "org.apache.hudi.common.model.PartialUpdateAvroPayload")
+       .option(HoodieWriteConfig.RECORD_MERGE_MODE.key(), RecordMergeMode.CUSTOM.name())
+@@ -118,7 +119,7 @@ class TestPartialUpdateAvroPayload extends HoodieClientTestBase {
+       .option(DataSourceWriteOptions.TABLE_TYPE.key(), hoodieTableType.name())
+       .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "uuid")
+       .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "partitionpath")
+-      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+       .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
+       .option(HoodieWriteConfig.TBL_NAME.key, "hoodie_test")
+       .option(HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key, "org.apache.hudi.common.model.PartialUpdateAvroPayload")

--- a/pr_13718_files/0129.diff
+++ b/pr_13718_files/0129.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndexWithSql.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndexWithSql.scala
+index d58b5d81e8c2e..dd23cdd13e5fa 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndexWithSql.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndexWithSql.scala
+@@ -146,7 +146,7 @@ class TestPartitionStatsIndexWithSql extends HoodieSparkSqlTestBase {
+         val properties = metaClient.getTableConfig.getProps.asScala.toMap
+         assertResult(true)(properties.contains(HoodieTableConfig.CREATE_SCHEMA.key))
+         assertResult("dt")(properties(HoodieTableConfig.PARTITION_FIELDS.key))
+-        assertResult("ts")(properties(HoodieTableConfig.PRECOMBINE_FIELDS.key))
++        assertResult("ts")(properties(HoodieTableConfig.ORDERING_FIELDS.key))
+         assertResult(tableName)(metaClient.getTableConfig.getTableName)
+         // Validate partition_stats index exists
+         assertTrue(metaClient.getTableConfig.getMetadataPartitions.contains(PARTITION_STATS.getPartitionPath))

--- a/pr_13718_files/0130.diff
+++ b/pr_13718_files/0130.diff
@@ -1,0 +1,40 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsPruning.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsPruning.scala
+index 26f9aa71ab311..c961b5ff93cd6 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsPruning.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsPruning.scala
+@@ -58,7 +58,7 @@ class TestPartitionStatsPruning extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key() -> "c8",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"
+     ) ++ metadataOpts
+@@ -87,7 +87,7 @@ class TestPartitionStatsPruning extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key() -> "c8",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       "hoodie.compact.inline.max.delta.commits" -> "10"
+@@ -195,7 +195,7 @@ class TestPartitionStatsPruning extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key -> partitionCol,
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true",
+       HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key -> "3"
+@@ -306,7 +306,7 @@ class TestPartitionStatsPruning extends ColumnStatIndexTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+       DataSourceWriteOptions.TABLE_TYPE.key -> testCase.tableType.toString,
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key() -> partitionCol,
+       "hoodie.write.markers.type" -> "DIRECT",
+       HoodieTableConfig.POPULATE_META_FIELDS.key -> "true"

--- a/pr_13718_files/0131.diff
+++ b/pr_13718_files/0131.diff
@@ -1,0 +1,31 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionedRecordLevelIndex.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionedRecordLevelIndex.scala
+index d3a02ab4debbc..a9ec4d984ad64 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionedRecordLevelIndex.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionedRecordLevelIndex.scala
+@@ -27,7 +27,7 @@ import org.apache.hudi.common.config.{HoodieMetadataConfig, TypedProperties}
+ import org.apache.hudi.common.data.HoodieListData
+ import org.apache.hudi.common.fs.FSUtils
+ import org.apache.hudi.common.model.{HoodieRecordGlobalLocation, HoodieTableType}
+-import org.apache.hudi.common.table.TableSchemaResolver
++import org.apache.hudi.common.table.{HoodieTableConfig, TableSchemaResolver}
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator
+ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+ import org.apache.hudi.common.util.{Option => HOption}
+@@ -69,7 +69,7 @@ class TestPartitionedRecordLevelIndex extends RecordLevelIndexTestBase {
+       DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name(),
+       RECORDKEY_FIELD.key -> "_row_key",
+       PARTITIONPATH_FIELD.key -> "data_partition_path",
+-      PRECOMBINE_FIELD.key -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+       HoodieMetadataConfig.RECORD_INDEX_ENABLE_PROP.key()-> "false",
+       HoodieMetadataConfig.PARTITIONED_RECORD_INDEX_ENABLE_PROP.key() -> "true",
+       HoodieMetadataConfig.STREAMING_WRITE_ENABLED.key() -> streamingWriteEnabled.toString,
+@@ -342,7 +342,7 @@ class TestPartitionedRecordLevelIndex extends RecordLevelIndexTestBase {
+       DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name(),
+       RECORDKEY_FIELD.key -> "_row_key",
+       PARTITIONPATH_FIELD.key -> "data_partition_path",
+-      PRECOMBINE_FIELD.key -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+       HoodieMetadataConfig.RECORD_INDEX_ENABLE_PROP.key()-> "false",
+       HoodieMetadataConfig.SECONDARY_INDEX_ENABLE_PROP.key() -> "false",
+       HoodieMetadataConfig.STREAMING_WRITE_ENABLED.key() -> streamingWriteEnabled.toString,

--- a/pr_13718_files/0132.diff
+++ b/pr_13718_files/0132.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
+index 647ee6868df5c..27be7429af2c2 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPayloadDeprecationFlow.scala
+@@ -52,7 +52,7 @@ class TestPayloadDeprecationFlow extends SparkClientFunctionalTestHarness {
+     val inserts = spark.createDataFrame(data).toDF(columns: _*)
+     inserts.write.format("hudi").
+       option(RECORDKEY_FIELD.key(), "key").
+-      option(PRECOMBINE_FIELD.key(), "ts").
++      option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts").
+       option(TABLE_TYPE.key(), tableType).
+       option(DataSourceWriteOptions.TABLE_NAME.key(), "test_table").
+       option(HoodieCompactionConfig.INLINE_COMPACT.key(), "false").

--- a/pr_13718_files/0133.diff
+++ b/pr_13718_files/0133.diff
@@ -1,0 +1,22 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
+index f412b696174cf..a1af34331cdb3 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSecondaryIndexPruning.scala
+@@ -27,7 +27,7 @@ import org.apache.hudi.client.transaction.SimpleConcurrentFileWritesConflictReso
+ import org.apache.hudi.client.transaction.lock.InProcessLockProvider
+ import org.apache.hudi.common.config.{HoodieMetadataConfig, RecordMergeMode, TypedProperties}
+ import org.apache.hudi.common.model._
+-import org.apache.hudi.common.table.HoodieTableMetaClient
++import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+ import org.apache.hudi.common.table.timeline.HoodieInstant
+ import org.apache.hudi.common.table.view.HoodieTableFileSystemView
+ import org.apache.hudi.common.testutils.HoodieTestUtils
+@@ -76,7 +76,7 @@ class TestSecondaryIndexPruning extends SparkClientFunctionalTestHarness {
+     RECORDKEY_FIELD.key -> "record_key_col",
+     PARTITIONPATH_FIELD.key -> "partition_key_col",
+     HIVE_STYLE_PARTITIONING.key -> "true",
+-    PRECOMBINE_FIELD.key -> "ts",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+     HoodieWriteConfig.WRITE_PAYLOAD_CLASS_NAME.key() -> "org.apache.hudi.common.model.OverwriteWithLatestAvroPayload",
+     DataSourceWriteOptions.RECORD_MERGE_MODE.key() -> RecordMergeMode.COMMIT_TIME_ORDERING.name()
+   ) ++ metadataOpts

--- a/pr_13718_files/0134.diff
+++ b/pr_13718_files/0134.diff
@@ -1,0 +1,22 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSevenToEightUpgrade.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSevenToEightUpgrade.scala
+index 92d920f90e094..231c4b303e967 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSevenToEightUpgrade.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSevenToEightUpgrade.scala
+@@ -107,7 +107,7 @@ class TestSevenToEightUpgrade extends RecordLevelIndexTestBase {
+       assertEquals(RecordMergeMode.COMMIT_TIME_ORDERING.name, metaClient.getTableConfig.getRecordMergeMode.name)
+       assertEquals(HoodieRecordMerger.COMMIT_TIME_BASED_MERGE_STRATEGY_UUID, metaClient.getTableConfig.getRecordMergeStrategyId)
+     } else {
+-      if (metaClient.getTableConfig.getPreCombineFieldsStr.isPresent && StringUtils.isNullOrEmpty(metaClient.getTableConfig.getPreCombineFieldsStr.get())) {
++      if (metaClient.getTableConfig.getOrderingFieldsStr.isPresent && StringUtils.isNullOrEmpty(metaClient.getTableConfig.getOrderingFieldsStr.get())) {
+         assertEquals(classOf[OverwriteWithLatestAvroPayload].getName, metaClient.getTableConfig.getPayloadClass)
+         assertEquals(RecordMergeMode.COMMIT_TIME_ORDERING.name, metaClient.getTableConfig.getRecordMergeMode.name)
+         assertEquals(HoodieRecordMerger.COMMIT_TIME_BASED_MERGE_STRATEGY_UUID, metaClient.getTableConfig.getRecordMergeStrategyId)
+@@ -133,7 +133,7 @@ class TestSevenToEightUpgrade extends RecordLevelIndexTestBase {
+     val hudiOptions = Map[String, String](
+       "hoodie.table.name" -> tableName,
+       RECORDKEY_FIELD.key -> "id",
+-      PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       TABLE_TYPE.key -> HoodieTableType.MERGE_ON_READ.name(),
+       OPERATION.key -> UPSERT_OPERATION_OPT_VAL,
+       KEYGENERATOR_CLASS_NAME.key -> classOf[NonpartitionedKeyGenerator].getName,

--- a/pr_13718_files/0135.diff
+++ b/pr_13718_files/0135.diff
@@ -1,0 +1,30 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkDataSource.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkDataSource.scala
+index d891ed7c302b2..4dcbede1ca716 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkDataSource.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkDataSource.scala
+@@ -23,6 +23,7 @@ import org.apache.hudi.{AvroConversionUtils, DataSourceReadOptions, DataSourceWr
+ import org.apache.hudi.common.config.{HoodieMetadataConfig, RecordMergeMode}
+ import org.apache.hudi.common.model.{HoodieRecord, HoodieTableType}
+ import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator
+ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+ import org.apache.hudi.config.{HoodieCompactionConfig, HoodieIndexConfig, HoodieWriteConfig}
+@@ -55,7 +56,7 @@ class TestSparkDataSource extends SparkClientFunctionalTestHarness {
+     "hoodie.bulkinsert.shuffle.parallelism" -> s"$parallelism",
+     "hoodie.delete.shuffle.parallelism" -> s"$parallelism",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   )
+ 
+@@ -312,7 +313,7 @@ class TestSparkDataSource extends SparkClientFunctionalTestHarness {
+     var (writeOpts, readOpts) = getWriterReaderOpts(HoodieRecordType.AVRO)
+     writeOpts = writeOpts ++ Map("hoodie.write.table.version" -> tableVersion.toString,
+       "hoodie.datasource.write.table.type" -> tableType.name(),
+-      "hoodie.datasource.write.precombine.field" -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "ts",
+       "hoodie.write.record.merge.mode" -> mergeMode.name(),
+       "hoodie.index.type" -> indexType.name(),
+       "hoodie.metadata.record.index.enable" -> "true",

--- a/pr_13718_files/0136.diff
+++ b/pr_13718_files/0136.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkDataSourceDAGExecution.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkDataSourceDAGExecution.scala
+index 0255b22c77e92..2410dd8df505f 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkDataSourceDAGExecution.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkDataSourceDAGExecution.scala
+@@ -56,7 +56,7 @@ class TestSparkDataSourceDAGExecution extends HoodieSparkClientTestBase with Sca
+     HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.key() -> "true",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     HoodieMetadataConfig.ENABLE.key -> "false"
+   )

--- a/pr_13718_files/0137.diff
+++ b/pr_13718_files/0137.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlWithCustomKeyGenerator.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlWithCustomKeyGenerator.scala
+index 712b66c84cbc1..5672d4e95f11d 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlWithCustomKeyGenerator.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlWithCustomKeyGenerator.scala
+@@ -625,7 +625,7 @@ class TestSparkSqlWithCustomKeyGenerator extends HoodieSparkSqlTestBase {
+       .option("hoodie.datasource.write.keygenerator.class", keyGenClassName)
+       .option("hoodie.datasource.write.partitionpath.field", writePartitionFields)
+       .option("hoodie.datasource.write.recordkey.field", "id")
+-      .option("hoodie.datasource.write.precombine.field", "name")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key(), "name")
+       .option("hoodie.table.name", tableName)
+       .option("hoodie.insert.shuffle.parallelism", "1")
+       .option("hoodie.upsert.shuffle.parallelism", "1")

--- a/pr_13718_files/0138.diff
+++ b/pr_13718_files/0138.diff
@@ -1,0 +1,31 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamSourceReadByStateTransitionTime.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamSourceReadByStateTransitionTime.scala
+index d61963f365b80..e364f046dc21a 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamSourceReadByStateTransitionTime.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamSourceReadByStateTransitionTime.scala
+@@ -23,7 +23,7 @@ import org.apache.hudi.client.{SparkRDDWriteClient, WriteClientTestUtils}
+ import org.apache.hudi.client.common.HoodieSparkEngineContext
+ import org.apache.hudi.common.engine.EngineType
+ import org.apache.hudi.common.model.{HoodieFailedWritesCleaningPolicy, HoodieRecord, HoodieTableType}
+-import org.apache.hudi.common.table.HoodieTableMetaClient
++import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator
+ import org.apache.hudi.common.testutils.HoodieTestTable.makeNewCommitTime
+ import org.apache.hudi.config.{HoodieCleanConfig, HoodieWriteConfig}
+@@ -39,7 +39,7 @@ class TestStreamSourceReadByStateTransitionTime extends StreamTest  {
+ 
+   protected val commonOptions: Map[String, String] = Map(
+     RECORDKEY_FIELD.key -> "id",
+-    PRECOMBINE_FIELD.key -> "ts",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+     INSERT_PARALLELISM_VALUE.key -> "4",
+     UPSERT_PARALLELISM_VALUE.key -> "4",
+     DELETE_PARALLELISM_VALUE.key -> "4",
+@@ -64,7 +64,7 @@ class TestStreamSourceReadByStateTransitionTime extends StreamTest  {
+         HoodieTableMetaClient.newTableBuilder()
+           .setTableType(tableType)
+           .setTableName(s"test_stream_${tableType.name()}")
+-          .setPreCombineFields("timestamp")
++          .setOrderingFields("timestamp")
+           .setPartitionFields("partition_path")
+           .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
+ 

--- a/pr_13718_files/0139.diff
+++ b/pr_13718_files/0139.diff
@@ -1,0 +1,85 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
+index 5915f93f1a0d2..45d112b0ed3e5 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStreamingSource.scala
+@@ -22,7 +22,7 @@ import org.apache.hudi.DataSourceReadOptions.{START_OFFSET, STREAMING_READ_TABLE
+ import org.apache.hudi.DataSourceWriteOptions.{PRECOMBINE_FIELD, RECORDKEY_FIELD}
+ import org.apache.hudi.common.model.HoodieTableType
+ import org.apache.hudi.common.model.HoodieTableType.{COPY_ON_WRITE, MERGE_ON_READ}
+-import org.apache.hudi.common.table.{HoodieTableMetaClient, HoodieTableVersion}
++import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, HoodieTableVersion}
+ import org.apache.hudi.common.table.timeline.HoodieTimeline
+ import org.apache.hudi.config.{HoodieClusteringConfig, HoodieCompactionConfig}
+ import org.apache.hudi.config.HoodieWriteConfig.{DELETE_PARALLELISM_VALUE, INSERT_PARALLELISM_VALUE, TBL_NAME, UPSERT_PARALLELISM_VALUE, WRITE_TABLE_VERSION}
+@@ -38,7 +38,7 @@ class TestStreamingSource extends StreamTest {
+   import testImplicits._
+   protected val commonOptions: Map[String, String] = Map(
+     RECORDKEY_FIELD.key -> "id",
+-    PRECOMBINE_FIELD.key -> "ts",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+     INSERT_PARALLELISM_VALUE.key -> "4",
+     UPSERT_PARALLELISM_VALUE.key -> "4",
+     DELETE_PARALLELISM_VALUE.key -> "4"
+@@ -61,7 +61,7 @@ class TestStreamingSource extends StreamTest {
+         .setTableType(COPY_ON_WRITE)
+         .setTableName(getTableName(tablePath))
+         .setRecordKeyFields("id")
+-        .setPreCombineFields("ts")
++        .setOrderingFields("ts")
+         .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
+ 
+       addData(tablePath, Seq(("1", "a1", "10", "000")))
+@@ -112,7 +112,7 @@ class TestStreamingSource extends StreamTest {
+         .setTableType(MERGE_ON_READ)
+         .setTableName(getTableName(tablePath))
+         .setRecordKeyFields("id")
+-        .setPreCombineFields("ts")
++        .setOrderingFields("ts")
+         .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
+ 
+       addData(tablePath, Seq(("1", "a1", "10", "000")))
+@@ -157,7 +157,7 @@ class TestStreamingSource extends StreamTest {
+         .setTableType(COPY_ON_WRITE)
+         .setTableName(getTableName(tablePath))
+         .setRecordKeyFields("id")
+-        .setPreCombineFields("ts")
++        .setOrderingFields("ts")
+         .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
+ 
+       addData(tablePath, Seq(("1", "a1", "10", "000")))
+@@ -188,7 +188,7 @@ class TestStreamingSource extends StreamTest {
+         .setTableType(COPY_ON_WRITE)
+         .setTableName(getTableName(tablePath))
+         .setRecordKeyFields("id")
+-        .setPreCombineFields("ts")
++        .setOrderingFields("ts")
+         .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
+ 
+       addData(tablePath, Seq(("1", "a1", "10", "000")))
+@@ -220,7 +220,7 @@ class TestStreamingSource extends StreamTest {
+         .setTableType(MERGE_ON_READ)
+         .setTableName(getTableName(tablePath))
+         .setRecordKeyFields("id")
+-        .setPreCombineFields("ts")
++        .setOrderingFields("ts")
+         .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
+ 
+       addData(tablePath, Seq(("1", "a1", "10", "000")))
+@@ -262,7 +262,7 @@ class TestStreamingSource extends StreamTest {
+           .setTableType(MERGE_ON_READ)
+           .setTableName(getTableName(tablePath))
+           .setRecordKeyFields("id")
+-          .setPreCombineFields("ts")
++          .setOrderingFields("ts")
+           .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
+ 
+         addData(tablePath, Seq(("1", "a1", "10", "000")))
+@@ -305,7 +305,7 @@ class TestStreamingSource extends StreamTest {
+         .setTableName(getTableName(tablePath))
+         .setTableVersion(writeTableVersion)
+         .setRecordKeyFields("id")
+-        .setPreCombineFields("ts")
++        .setOrderingFields("ts")
+         .initTable(HadoopFSUtils.getStorageConf(spark.sessionState.newHadoopConf()), tablePath)
+ 
+       // Add initial data

--- a/pr_13718_files/0140.diff
+++ b/pr_13718_files/0140.diff
@@ -1,0 +1,31 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala
+index 56b77919bd224..1025e43b9bdfb 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestStructuredStreaming.scala
+@@ -23,7 +23,7 @@ import org.apache.hudi.HoodieStreamingSink.SINK_CHECKPOINT_KEY
+ import org.apache.hudi.client.transaction.lock.InProcessLockProvider
+ import org.apache.hudi.common.config.HoodieStorageConfig
+ import org.apache.hudi.common.model.{FileSlice, HoodieTableType, WriteConcurrencyMode}
+-import org.apache.hudi.common.table.HoodieTableMetaClient
++import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+ import org.apache.hudi.common.table.timeline.HoodieTimeline
+ import org.apache.hudi.common.testutils.{HoodieTestDataGenerator, HoodieTestTable, HoodieTestUtils}
+ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+@@ -60,7 +60,7 @@ class TestStructuredStreaming extends HoodieSparkClientTestBase {
+     "hoodie.upsert.shuffle.parallelism" -> "4",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "_row_key",
+     DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   )
+ 
+@@ -526,7 +526,7 @@ class TestStructuredStreaming extends HoodieSparkClientTestBase {
+       DataSourceWriteOptions.TABLE_TYPE.key() -> tableType,
+       DataSourceWriteOptions.RECORD_MERGE_MODE.key() -> mergeMode,
+       HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key() -> "parquet",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "weight")
++      HoodieTableConfig.ORDERING_FIELDS.key -> "weight")
+     if (mergeMode == "CUSTOM") {
+       opts = opts ++ Map(DataSourceWriteOptions.RECORD_MERGE_STRATEGY_ID.key() -> HoodieSparkDeleteRecordMerger.DELETE_MERGER_STRATEGY,
+         DataSourceWriteOptions.RECORD_MERGE_IMPL_CLASSES.key() -> classOf[HoodieSparkDeleteRecordMerger].getName)

--- a/pr_13718_files/0141.diff
+++ b/pr_13718_files/0141.diff
@@ -1,0 +1,31 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestTimeTravelQuery.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestTimeTravelQuery.scala
+index 7f95db48d8bd2..93c80f9479206 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestTimeTravelQuery.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestTimeTravelQuery.scala
+@@ -21,7 +21,7 @@ import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, ScalaAsse
+ import org.apache.hudi.common.config.HoodieMetadataConfig
+ import org.apache.hudi.common.model.{HoodieCleaningPolicy, HoodieTableType}
+ import org.apache.hudi.common.model.HoodieTableType.{COPY_ON_WRITE, MERGE_ON_READ}
+-import org.apache.hudi.common.table.TableSchemaResolver
++import org.apache.hudi.common.table.{HoodieTableConfig, TableSchemaResolver}
+ import org.apache.hudi.common.table.timeline.TimelineUtils
+ import org.apache.hudi.common.testutils.HoodieTestTable
+ import org.apache.hudi.config.{HoodieArchivalConfig, HoodieCleanConfig, HoodieCompactionConfig, HoodieWriteConfig}
+@@ -46,7 +46,7 @@ class TestTimeTravelQuery extends HoodieSparkClientTestBase with ScalaAssertionS
+     "hoodie.bulkinsert.shuffle.parallelism" -> "2",
+     "hoodie.delete.shuffle.parallelism" -> "1",
+     DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-    DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "version",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "version",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test"
+   )
+ 
+@@ -177,7 +177,7 @@ class TestTimeTravelQuery extends HoodieSparkClientTestBase with ScalaAssertionS
+     val opts = commonOpts ++ Map(
+       DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name,
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "version",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "version",
+       DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "dt"
+     )
+ 

--- a/pr_13718_files/0142.diff
+++ b/pr_13718_files/0142.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/HoodieCDCTestBase.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/HoodieCDCTestBase.scala
+index 6f13c9257bd3e..0694f582f9037 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/HoodieCDCTestBase.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/HoodieCDCTestBase.scala
+@@ -54,7 +54,7 @@ abstract class HoodieCDCTestBase extends HoodieSparkClientTestBase {
+     "hoodie.bulkinsert.shuffle.parallelism" -> "2",
+     "hoodie.delete.shuffle.parallelism" -> "1",
+     RECORDKEY_FIELD.key -> "_row_key",
+-    PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieWriteConfig.TBL_NAME.key -> "hoodie_test",
+     HoodieMetadataConfig.COMPACT_NUM_DELTA_COMMITS.key -> "1",
+     HoodieCleanConfig.AUTO_CLEAN.key -> "false",

--- a/pr_13718_files/0143.diff
+++ b/pr_13718_files/0143.diff
@@ -1,0 +1,22 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCDataFrameSuite.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCDataFrameSuite.scala
+index 1416470fec40d..ae09b9a96ff5b 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCDataFrameSuite.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCDataFrameSuite.scala
+@@ -643,7 +643,7 @@ class TestCDCDataFrameSuite extends HoodieCDCTestBase {
+     val options = Map(
+       "hoodie.table.name" -> "test",
+       "hoodie.datasource.write.recordkey.field" -> "id",
+-      "hoodie.datasource.write.precombine.field" -> "replicadmstimestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "replicadmstimestamp",
+       "hoodie.datasource.write.keygenerator.class" -> "org.apache.hudi.keygen.NonpartitionedKeyGenerator",
+       "hoodie.datasource.write.partitionpath.field" -> "",
+       "hoodie.datasource.write.payload.class" -> "org.apache.hudi.common.model.AWSDmsAvroPayload",
+@@ -702,7 +702,7 @@ class TestCDCDataFrameSuite extends HoodieCDCTestBase {
+       "hoodie.bulkinsert.shuffle.parallelism" -> "2",
+       "hoodie.delete.shuffle.parallelism" -> "1",
+       "hoodie.datasource.write.recordkey.field" -> "_row_key",
+-      "hoodie.datasource.write.precombine.field" -> "timestamp",
++      HoodieTableConfig.ORDERING_FIELDS.key() -> "timestamp",
+       "hoodie.table.name" -> ("hoodie_test" + loggingMode.name()),
+       "hoodie.clean.automatic" -> "true",
+       "hoodie.clean.commits.retained" -> "1"

--- a/pr_13718_files/0144.diff
+++ b/pr_13718_files/0144.diff
@@ -1,0 +1,40 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCStreamingSuite.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCStreamingSuite.scala
+index 4ba1eb76b739e..d39ba79c9f0db 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCStreamingSuite.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/cdc/TestCDCStreamingSuite.scala
+@@ -70,7 +70,7 @@ class TestCDCStreamingSuite extends HoodieCDCTestBase {
+       .option(HoodieTableConfig.CDC_ENABLED.key, "true")
+       .option(HoodieTableConfig.CDC_SUPPLEMENTAL_LOGGING_MODE.key, loggingMode.name())
+       .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "userid")
+-      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+       .option(HoodieWriteConfig.TBL_NAME.key, "user_to_country")
+       .save(userToCountryTblPath)
+ 
+@@ -82,7 +82,7 @@ class TestCDCStreamingSuite extends HoodieCDCTestBase {
+     countryToPopulationDF.write.format("hudi")
+       .options(commonOptions)
+       .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "country")
+-      .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++      .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+       .option(HoodieWriteConfig.TBL_NAME.key, "country_to_population")
+       .save(countryToPopulationTblPath)
+ 
+@@ -98,7 +98,7 @@ class TestCDCStreamingSuite extends HoodieCDCTestBase {
+           .options(commonOptions)
+           .option(HoodieTableConfig.CDC_ENABLED.key, "true")
+           .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "userid")
+-          .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(HoodieWriteConfig.TBL_NAME.key, "user_to_country")
+           .mode(SaveMode.Append)
+           .save(userToCountryTblPath)
+@@ -147,7 +147,7 @@ class TestCDCStreamingSuite extends HoodieCDCTestBase {
+           .write.format("hudi")
+           .options(commonOptions)
+           .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "country")
+-          .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(HoodieWriteConfig.TBL_NAME.key, "country_to_population")
+           .mode(SaveMode.Append)
+           .save(countryToPopulationTblPath)

--- a/pr_13718_files/0145.diff
+++ b/pr_13718_files/0145.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieOptionConfig.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieOptionConfig.scala
+index daadfb6a37679..e6d1e9282bf63 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieOptionConfig.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/TestHoodieOptionConfig.scala
+@@ -59,7 +59,7 @@ class TestHoodieOptionConfig extends SparkClientFunctionalTestHarness {
+ 
+     assertTrue(tableConfigs.size == 5)
+     assertTrue(tableConfigs(HoodieTableConfig.RECORDKEY_FIELDS.key) == "id,addr")
+-    assertTrue(tableConfigs(HoodieTableConfig.PRECOMBINE_FIELDS.key) == "timestamp")
++    assertTrue(tableConfigs(HoodieTableConfig.ORDERING_FIELDS.key) == "timestamp")
+     assertTrue(tableConfigs(HoodieTableConfig.TYPE.key) == "MERGE_ON_READ")
+     assertTrue(tableConfigs("hoodie.index.type") == "INMEMORY")
+     assertTrue(tableConfigs("hoodie.compact.inline") == "true")

--- a/pr_13718_files/0146.diff
+++ b/pr_13718_files/0146.diff
@@ -1,0 +1,75 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTableDropPartition.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTableDropPartition.scala
+index 57d79f8c13825..c8aafefb46614 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTableDropPartition.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestAlterTableDropPartition.scala
+@@ -20,6 +20,7 @@ package org.apache.spark.sql.hudi.ddl
+ import org.apache.hudi.{DataSourceWriteOptions, HoodieCLIUtils}
+ import org.apache.hudi.avro.model.{HoodieCleanMetadata, HoodieCleanPartitionMetadata}
+ import org.apache.hudi.common.model.{HoodieCleaningPolicy, HoodieCommitMetadata}
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.table.timeline.HoodieInstant
+ import org.apache.hudi.common.util.{Option => HOption, PartitionPathEncodeUtils, StringUtils}
+ import org.apache.hudi.config.{HoodieCleanConfig, HoodieWriteConfig}
+@@ -121,7 +122,7 @@ class TestAlterTableDropPartition extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+           .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL)
+           .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "id")
+-          .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "dt")
+           .option(DataSourceWriteOptions.URL_ENCODE_PARTITIONING.key(), urlencode)
+           .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")
+@@ -140,7 +141,7 @@ class TestAlterTableDropPartition extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+           .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL)
+           .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "id")
+-          .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "dt")
+           .option(DataSourceWriteOptions.URL_ENCODE_PARTITIONING.key(), urlencode)
+           .option(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key, classOf[SimpleKeyGenerator].getName)
+@@ -199,7 +200,7 @@ class TestAlterTableDropPartition extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+           .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL)
+           .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "id")
+-          .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "dt")
+           .option(DataSourceWriteOptions.URL_ENCODE_PARTITIONING.key(), urlencode)
+           .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")
+@@ -305,7 +306,7 @@ class TestAlterTableDropPartition extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+           .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL)
+           .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "id")
+-          .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "year,month,day")
+           .option(DataSourceWriteOptions.HIVE_STYLE_PARTITIONING.key, hiveStyle)
+           .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")
+@@ -329,7 +330,7 @@ class TestAlterTableDropPartition extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+           .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL)
+           .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "id")
+-          .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "year,month,day")
+           .option(DataSourceWriteOptions.HIVE_STYLE_PARTITIONING.key, hiveStyle)
+           .option(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key, classOf[ComplexKeyGenerator].getName)
+@@ -385,7 +386,7 @@ class TestAlterTableDropPartition extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+           .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL)
+           .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "id")
+-          .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "year,month,day")
+           .option(DataSourceWriteOptions.HIVE_STYLE_PARTITIONING.key, hiveStyle)
+           .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")
+@@ -409,7 +410,7 @@ class TestAlterTableDropPartition extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+           .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.COW_TABLE_TYPE_OPT_VAL)
+           .option(DataSourceWriteOptions.RECORDKEY_FIELD.key, "id")
+-          .option(DataSourceWriteOptions.PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(DataSourceWriteOptions.PARTITIONPATH_FIELD.key, "year,month,day")
+           .option(DataSourceWriteOptions.HIVE_STYLE_PARTITIONING.key, hiveStyle)
+           .option(DataSourceWriteOptions.KEYGENERATOR_CLASS_NAME.key, classOf[ComplexKeyGenerator].getName)

--- a/pr_13718_files/0147.diff
+++ b/pr_13718_files/0147.diff
@@ -1,0 +1,83 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+index 6c9d57e8c175b..a0c24c5bfc386 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestCreateTable.scala
+@@ -139,7 +139,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
+     assertResult(true)(tableConfig.contains(HoodieTableConfig.CREATE_SCHEMA.key))
+     assertResult("dt")(tableConfig(HoodieTableConfig.PARTITION_FIELDS.key))
+     assertResult("id")(tableConfig(HoodieTableConfig.RECORDKEY_FIELDS.key))
+-    assertResult("ts")(tableConfig(HoodieTableConfig.PRECOMBINE_FIELDS.key))
++    assertResult("ts")(tableConfig(HoodieTableConfig.ORDERING_FIELDS.key))
+     assertResult(KeyGeneratorType.SIMPLE.name())(tableConfig(HoodieTableConfig.KEY_GENERATOR_TYPE.key))
+     assertResult("default")(tableConfig(HoodieTableConfig.DATABASE_NAME.key()))
+     assertResult(tableName)(tableConfig(HoodieTableConfig.NAME.key()))
+@@ -877,7 +877,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, s"original_$tableName")
+           .option(TABLE_TYPE.key, COW_TABLE_TYPE_OPT_VAL)
+           .option(RECORDKEY_FIELD.key, "id")
+-          .option(PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(PARTITIONPATH_FIELD.key, "dt")
+           .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")
+           .option(HoodieWriteConfig.UPSERT_PARALLELISM_VALUE.key, "1")
+@@ -907,7 +907,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
+         val properties = metaClient.getTableConfig.getProps.asScala.toMap
+         assertResult(true)(properties.contains(HoodieTableConfig.CREATE_SCHEMA.key))
+         assertResult("dt")(properties(HoodieTableConfig.PARTITION_FIELDS.key))
+-        assertResult("ts")(properties(HoodieTableConfig.PRECOMBINE_FIELDS.key))
++        assertResult("ts")(properties(HoodieTableConfig.ORDERING_FIELDS.key))
+         assertResult("hudi_database")(metaClient.getTableConfig.getDatabaseName)
+         assertResult(s"original_$tableName")(metaClient.getTableConfig.getTableName)
+ 
+@@ -956,7 +956,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+           .option(TABLE_TYPE.key, MOR_TABLE_TYPE_OPT_VAL)
+           .option(RECORDKEY_FIELD.key, "id")
+-          .option(PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(PARTITIONPATH_FIELD.key, "day,hh")
+           .option(URL_ENCODE_PARTITIONING.key, "true")
+           .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")
+@@ -978,7 +978,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
+         val properties = metaClient.getTableConfig.getProps.asScala.toMap
+         assertResult(true)(properties.contains(HoodieTableConfig.CREATE_SCHEMA.key))
+         assertResult("day,hh")(properties(HoodieTableConfig.PARTITION_FIELDS.key))
+-        assertResult("ts")(properties(HoodieTableConfig.PRECOMBINE_FIELDS.key))
++        assertResult("ts")(properties(HoodieTableConfig.ORDERING_FIELDS.key))
+ 
+         val escapedPathPart = escapePathName(day)
+ 
+@@ -1025,7 +1025,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
+         .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+         .option(TABLE_TYPE.key, COW_TABLE_TYPE_OPT_VAL)
+         .option(RECORDKEY_FIELD.key, "id")
+-        .option(PRECOMBINE_FIELD.key, "ts")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+         .option(PARTITIONPATH_FIELD.key, "")
+         .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")
+         .option(HoodieWriteConfig.UPSERT_PARALLELISM_VALUE.key, "1")
+@@ -1045,7 +1045,7 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
+       val metaClient = createMetaClient(spark, tmp.getCanonicalPath)
+       val properties = metaClient.getTableConfig.getProps.asScala.toMap
+       assertResult(true)(properties.contains(HoodieTableConfig.CREATE_SCHEMA.key))
+-      assertResult("ts")(properties(HoodieTableConfig.PRECOMBINE_FIELDS.key))
++      assertResult("ts")(properties(HoodieTableConfig.ORDERING_FIELDS.key))
+ 
+       // Test insert into
+       spark.sql(s"insert into $tableName values(2, 'a2', 10, 1000)")
+@@ -1448,13 +1448,13 @@ class TestCreateTable extends HoodieSparkSqlTestBase {
+              | tblproperties (
+              |  hoodie.table.recordkey.fields ='id',
+              |  hoodie.table.type = '$tableType',
+-             |  hoodie.table.precombine.field = 'ts'
++             |  hoodie.table.ordering.fields = 'ts'
+              | )
+        """.stripMargin)
+         val hoodieCatalogTable = HoodieCatalogTable(spark, TableIdentifier(tableName))
+         assertResult(Array("id"))(hoodieCatalogTable.primaryKeys)
+         assertResult(tableType)(hoodieCatalogTable.tableTypeName)
+-        assertResult(java.util.Collections.singletonList[String]("ts"))(hoodieCatalogTable.preCombineKeys)
++        assertResult(java.util.Collections.singletonList[String]("ts"))(hoodieCatalogTable.orderingFields)
+       }
+     }
+   }

--- a/pr_13718_files/0148.diff
+++ b/pr_13718_files/0148.diff
@@ -1,0 +1,48 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestRepairTable.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestRepairTable.scala
+index ebbdc1a6a1c00..3b60c2cef6d4e 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestRepairTable.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestRepairTable.scala
+@@ -20,6 +20,7 @@
+ package org.apache.spark.sql.hudi.ddl
+ 
+ import org.apache.hudi.DataSourceWriteOptions.{PARTITIONPATH_FIELD, PRECOMBINE_FIELD, RECORDKEY_FIELD}
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.common.table.HoodieTableConfig.HIVE_STYLE_PARTITIONING_ENABLE
+ import org.apache.hudi.config.HoodieWriteConfig.TBL_NAME
+ 
+@@ -85,7 +86,7 @@ class TestRepairTable extends HoodieSparkSqlTestBase {
+           .toDF("id", "name", "ts", "dt", "hh")
+         df.write.format("hudi")
+           .option(RECORDKEY_FIELD.key, "id")
+-          .option(PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(PARTITIONPATH_FIELD.key, "dt,hh")
+           .option(HIVE_STYLE_PARTITIONING_ENABLE.key, hiveStylePartitionEnable)
+           .mode(SaveMode.Append)
+@@ -111,7 +112,7 @@ class TestRepairTable extends HoodieSparkSqlTestBase {
+         df.write.format("hudi")
+           .option(TBL_NAME.key(), tableName)
+           .option(RECORDKEY_FIELD.key, "id")
+-          .option(PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(PARTITIONPATH_FIELD.key, "dt,hh")
+           .option(HIVE_STYLE_PARTITIONING_ENABLE.key, hiveStylePartitionEnable)
+           .mode(SaveMode.Append)
+@@ -162,7 +163,7 @@ class TestRepairTable extends HoodieSparkSqlTestBase {
+         df1.write.format("hudi")
+           .option(TBL_NAME.key(), tableName)
+           .option(RECORDKEY_FIELD.key, "id")
+-          .option(PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(PARTITIONPATH_FIELD.key, "dt")
+           .option(HIVE_STYLE_PARTITIONING_ENABLE.key, hiveStylePartitionEnable)
+           .mode(SaveMode.Append)
+@@ -177,7 +178,7 @@ class TestRepairTable extends HoodieSparkSqlTestBase {
+         df2.write.format("hudi")
+           .option(TBL_NAME.key(), tableName)
+           .option(RECORDKEY_FIELD.key, "id")
+-          .option(PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(PARTITIONPATH_FIELD.key, "dt")
+           .option(HIVE_STYLE_PARTITIONING_ENABLE.key, hiveStylePartitionEnable)
+           .mode(SaveMode.Overwrite)

--- a/pr_13718_files/0149.diff
+++ b/pr_13718_files/0149.diff
@@ -1,0 +1,40 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestSpark3DDL.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestSpark3DDL.scala
+index df3382b356dec..5585d49603ca5 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestSpark3DDL.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestSpark3DDL.scala
+@@ -21,7 +21,7 @@ import org.apache.hudi.{DataSourceWriteOptions, DefaultSparkRecordMerger, Quicks
+ import org.apache.hudi.common.config.{HoodieReaderConfig, HoodieStorageConfig}
+ import org.apache.hudi.common.model.{HoodieRecord, HoodieTableType}
+ import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
+-import org.apache.hudi.common.table.TableSchemaResolver
++import org.apache.hudi.common.table.{HoodieTableConfig, TableSchemaResolver}
+ import org.apache.hudi.common.table.timeline.HoodieInstant
+ import org.apache.hudi.common.testutils.{HoodieTestDataGenerator, RawTripTestPayload}
+ import org.apache.hudi.config.HoodieWriteConfig
+@@ -205,7 +205,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
+         val df = spark.createDataFrame(rowRdd, structType)
+         df.write.format("hudi")
+           .option("hoodie.datasource.write.recordkey.field", "id")
+-          .option("hoodie.datasource.write.precombine.field", "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts")
+           .option("hoodie.datasource.write.partitionpath.field", "partition")
+           .option("hoodie.table.name", tableName)
+           .option("hoodie.datasource.write.table.type", tableType.name())
+@@ -224,7 +224,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
+         val df2 = spark.createDataFrame(rowRdd2, structType)
+         df2.write.format("hudi")
+           .option("hoodie.datasource.write.recordkey.field", "id")
+-          .option("hoodie.datasource.write.precombine.field", "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts")
+           .option("hoodie.datasource.write.partitionpath.field", "partition")
+           .option("hoodie.table.name", tableName)
+           .option("hoodie.datasource.write.table.type", tableType.name())
+@@ -250,7 +250,7 @@ class TestSpark3DDL extends HoodieSparkSqlTestBase {
+         val df3 = spark.createDataFrame(rowRdd3, structType3)
+         df3.write.format("hudi")
+           .option("hoodie.datasource.write.recordkey.field", "id")
+-          .option("hoodie.datasource.write.precombine.field", "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts")
+           .option("hoodie.datasource.write.partitionpath.field", "partition")
+           .option("hoodie.table.name", tableName)
+           .option("hoodie.datasource.write.table.type", tableType.name())

--- a/pr_13718_files/0150.diff
+++ b/pr_13718_files/0150.diff
@@ -1,0 +1,30 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestTruncateTable.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestTruncateTable.scala
+index 3d290d589e249..247161d2f50b1 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestTruncateTable.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/ddl/TestTruncateTable.scala
+@@ -20,6 +20,7 @@
+ package org.apache.spark.sql.hudi.ddl
+ 
+ import org.apache.hudi.DataSourceWriteOptions._
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.config.HoodieWriteConfig
+ 
+ import org.apache.spark.sql.SaveMode
+@@ -73,7 +74,7 @@ class TestTruncateTable extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+           .option(TABLE_TYPE.key, MOR_TABLE_TYPE_OPT_VAL)
+           .option(RECORDKEY_FIELD.key, "id")
+-          .option(PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(PARTITIONPATH_FIELD.key, "dt")
+           .option(URL_ENCODE_PARTITIONING.key(), urlencode)
+           .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")
+@@ -114,7 +115,7 @@ class TestTruncateTable extends HoodieSparkSqlTestBase {
+           .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+           .option(TABLE_TYPE.key, COW_TABLE_TYPE_OPT_VAL)
+           .option(RECORDKEY_FIELD.key, "id")
+-          .option(PRECOMBINE_FIELD.key, "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+           .option(PARTITIONPATH_FIELD.key, "year,month,day")
+           .option(HIVE_STYLE_PARTITIONING.key, hiveStyle)
+           .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")

--- a/pr_13718_files/0151.diff
+++ b/pr_13718_files/0151.diff
@@ -1,0 +1,22 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/insert/TestInsertTable.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/insert/TestInsertTable.scala
+index da6a44ef4865e..9001995712c68 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/insert/TestInsertTable.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/insert/TestInsertTable.scala
+@@ -1168,7 +1168,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
+             .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+             .option(TABLE_TYPE.key, COW_TABLE_TYPE_OPT_VAL)
+             .option(RECORDKEY_FIELD.key, "id")
+-            .option(PRECOMBINE_FIELD.key, "ts")
++            .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+             .option(HoodieWriteConfig.BULKINSERT_PARALLELISM_VALUE.key, "1")
+             // test specific settings
+             .option(OPERATION.key, WriteOperationType.BULK_INSERT.value)
+@@ -1492,7 +1492,7 @@ class TestInsertTable extends HoodieSparkSqlTestBase {
+         .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+         .option(TABLE_TYPE.key, MOR_TABLE_TYPE_OPT_VAL)
+         .option(RECORDKEY_FIELD.key, "id")
+-        .option(PRECOMBINE_FIELD.key, "ts")
++        .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+         .option(PARTITIONPATH_FIELD.key, "day,hh")
+         .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")
+         .option(HoodieWriteConfig.UPSERT_PARALLELISM_VALUE.key, "1")

--- a/pr_13718_files/0152.diff
+++ b/pr_13718_files/0152.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestDeleteTable.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestDeleteTable.scala
+index 0e7223b35fbdd..06f0a77e93f38 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestDeleteTable.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestDeleteTable.scala
+@@ -20,6 +20,7 @@
+ package org.apache.spark.sql.hudi.dml.others
+ 
+ import org.apache.hudi.DataSourceWriteOptions._
++import org.apache.hudi.common.table.HoodieTableConfig
+ import org.apache.hudi.config.HoodieWriteConfig
+ 
+ import org.apache.spark.sql.SaveMode
+@@ -337,7 +338,7 @@ class TestDeleteTable extends HoodieSparkSqlTestBase {
+             .option(HoodieWriteConfig.TBL_NAME.key, tableName)
+             .option(TABLE_TYPE.key, MOR_TABLE_TYPE_OPT_VAL)
+             .option(RECORDKEY_FIELD.key, "id")
+-            .option(PRECOMBINE_FIELD.key, "ts")
++            .option(HoodieTableConfig.ORDERING_FIELDS.key, "ts")
+             .option(PARTITIONPATH_FIELD.key, "dt")
+             .option(URL_ENCODE_PARTITIONING.key(), urlencode)
+             .option(HoodieWriteConfig.INSERT_PARALLELISM_VALUE.key, "1")

--- a/pr_13718_files/0153.diff
+++ b/pr_13718_files/0153.diff
@@ -1,0 +1,19 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeCommitTimeOrdering.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeCommitTimeOrdering.scala
+index 2b359d483ba0f..60c2626e3ab77 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeCommitTimeOrdering.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeCommitTimeOrdering.scala
+@@ -75,12 +75,12 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
+         HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key -> COMMIT_TIME_BASED_MERGE_STRATEGY_UUID)
+     }
+     val nonExistentConfigs = if (tableVersion.toInt == 6) {
+-      Seq(HoodieTableConfig.RECORD_MERGE_MODE.key, HoodieTableConfig.PRECOMBINE_FIELDS.key)
++      Seq(HoodieTableConfig.RECORD_MERGE_MODE.key, HoodieTableConfig.ORDERING_FIELDS.key)
+     } else {
+       if (setRecordMergeConfigs) {
+         Seq()
+       } else {
+-        Seq(HoodieTableConfig.PRECOMBINE_FIELDS.key)
++        Seq(HoodieTableConfig.ORDERING_FIELDS.key)
+       }
+     }
+ 

--- a/pr_13718_files/0154.diff
+++ b/pr_13718_files/0154.diff
@@ -1,0 +1,19 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeEventTimeOrdering.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeEventTimeOrdering.scala
+index 572eaa82744b4..d9d3282dc316c 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeEventTimeOrdering.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeEventTimeOrdering.scala
+@@ -71,12 +71,12 @@ class TestMergeModeEventTimeOrdering extends HoodieSparkSqlTestBase {
+       Map(
+         HoodieTableConfig.VERSION.key -> "6",
+         HoodieTableConfig.PAYLOAD_CLASS_NAME.key -> classOf[DefaultHoodieRecordPayload].getName,
+-        HoodieTableConfig.PRECOMBINE_FIELDS.key -> "ts"
++        HoodieTableConfig.ORDERING_FIELDS.key -> "ts"
+       )
+     } else {
+       Map(
+         HoodieTableConfig.VERSION.key -> String.valueOf(HoodieTableVersion.current().versionCode()),
+-        HoodieTableConfig.PRECOMBINE_FIELDS.key -> "ts",
++        HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+         HoodieTableConfig.RECORD_MERGE_MODE.key -> EVENT_TIME_ORDERING.name(),
+         HoodieTableConfig.PAYLOAD_CLASS_NAME.key -> classOf[DefaultHoodieRecordPayload].getName,
+         HoodieTableConfig.RECORD_MERGE_STRATEGY_ID.key -> EVENT_TIME_BASED_MERGE_STRATEGY_UUID)

--- a/pr_13718_files/0155.diff
+++ b/pr_13718_files/0155.diff
@@ -1,0 +1,40 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestExpressionIndex.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestExpressionIndex.scala
+index 230895caf4fb7..2d8361a77ba67 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestExpressionIndex.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestExpressionIndex.scala
+@@ -29,7 +29,7 @@ import org.apache.hudi.client.utils.SparkMetadataWriterUtils
+ import org.apache.hudi.common.config.{HoodieMetadataConfig, HoodieStorageConfig, TypedProperties}
+ import org.apache.hudi.common.fs.FSUtils
+ import org.apache.hudi.common.model.{FileSlice, HoodieIndexDefinition}
+-import org.apache.hudi.common.table.{HoodieTableMetaClient, HoodieTableVersion}
++import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, HoodieTableVersion}
+ import org.apache.hudi.common.table.view.{FileSystemViewManager, HoodieTableFileSystemView}
+ import org.apache.hudi.common.testutils.HoodieTestUtils
+ import org.apache.hudi.common.util.Option
+@@ -1984,7 +1984,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
+         "hoodie.upsert.shuffle.parallelism" -> "4",
+         HoodieWriteConfig.TBL_NAME.key -> tableName,
+         RECORDKEY_FIELD.key -> "c1",
+-        PRECOMBINE_FIELD.key -> "c1",
++        HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+         PARTITIONPATH_FIELD.key() -> "c8",
+         "hoodie.metadata.index.column.stats.enable" -> "false"
+       )
+@@ -2070,7 +2070,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
+         HoodieWriteConfig.TBL_NAME.key -> tableName,
+         TABLE_TYPE.key -> "MERGE_ON_READ",
+         RECORDKEY_FIELD.key -> "c1",
+-        PRECOMBINE_FIELD.key -> "c1",
++        HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+         PARTITIONPATH_FIELD.key() -> "c8",
+         // setting IndexType to be INMEMORY to simulate Global Index nature
+         HoodieIndexConfig.INDEX_TYPE.key -> HoodieIndex.IndexType.INMEMORY.name(),
+@@ -2142,7 +2142,7 @@ class TestExpressionIndex extends HoodieSparkSqlTestBase {
+       HoodieWriteConfig.TBL_NAME.key -> "testGetExpressionIndexRecordsUsingBloomFilter",
+       TABLE_TYPE.key -> "MERGE_ON_READ",
+       RECORDKEY_FIELD.key -> "c1",
+-      PRECOMBINE_FIELD.key -> "c1",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "c1",
+       PARTITIONPATH_FIELD.key() -> "c8",
+       // setting IndexType to be INMEMORY to simulate Global Index nature
+       HoodieIndexConfig.INDEX_TYPE.key -> HoodieIndex.IndexType.INMEMORY.name()

--- a/pr_13718_files/0156.diff
+++ b/pr_13718_files/0156.diff
@@ -1,0 +1,25 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/testHoodieBackedTableMetadataIndexLookup.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestHoodieBackedTableMetadataIndexLookup.scala
+similarity index 99%
+rename from hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/testHoodieBackedTableMetadataIndexLookup.scala
+rename to hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestHoodieBackedTableMetadataIndexLookup.scala
+index 88a2c13436ed1..6371fb7925ad9 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/testHoodieBackedTableMetadataIndexLookup.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestHoodieBackedTableMetadataIndexLookup.scala
+@@ -24,7 +24,7 @@ import org.apache.hudi.client.common.HoodieSparkEngineContext
+ import org.apache.hudi.common.data.{HoodieListData, HoodiePairData}
+ import org.apache.hudi.common.engine.EngineType
+ import org.apache.hudi.common.model.HoodieRecordLocation
+-import org.apache.hudi.common.table.HoodieTableMetaClient
++import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+ import org.apache.hudi.common.testutils.HoodieTestDataGenerator
+ import org.apache.hudi.common.util.HoodieDataUtils
+ import org.apache.hudi.config.HoodieWriteConfig
+@@ -179,7 +179,7 @@ abstract class HoodieBackedTableMetadataIndexLookupTestBase extends HoodieSparkS
+       "hoodie.insert.shuffle.parallelism" -> "4",
+       "hoodie.upsert.shuffle.parallelism" -> "4",
+       DataSourceWriteOptions.RECORDKEY_FIELD.key -> "id",
+-      DataSourceWriteOptions.PRECOMBINE_FIELD.key -> "ts",
++      HoodieTableConfig.ORDERING_FIELDS.key -> "ts",
+       HoodieWriteConfig.TBL_NAME.key -> tableName,
+       DataSourceWriteOptions.OPERATION.key -> DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL
+     )

--- a/pr_13718_files/0157.diff
+++ b/pr_13718_files/0157.diff
@@ -1,0 +1,31 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestSecondaryIndex.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestSecondaryIndex.scala
+index aedd18e0ead34..232fa431f5ee2 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestSecondaryIndex.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/index/TestSecondaryIndex.scala
+@@ -23,7 +23,7 @@ import org.apache.hudi.{DataSourceReadOptions, DataSourceWriteOptions, HoodieSpa
+ import org.apache.hudi.DataSourceWriteOptions._
+ import org.apache.hudi.common.config.{HoodieMetadataConfig, RecordMergeMode}
+ import org.apache.hudi.common.model.WriteOperationType
+-import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
++import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, TableSchemaResolver}
+ import org.apache.hudi.common.testutils.{HoodieTestDataGenerator, HoodieTestUtils}
+ import org.apache.hudi.common.testutils.RawTripTestPayload.recordsToStrings
+ import org.apache.hudi.config.{HoodieClusteringConfig, HoodieCompactionConfig, HoodieWriteConfig}
+@@ -53,7 +53,7 @@ class TestSecondaryIndex extends HoodieSparkSqlTestBase {
+     "hoodie.upsert.shuffle.parallelism" -> "4",
+     RECORDKEY_FIELD.key -> "_row_key",
+     PARTITIONPATH_FIELD.key -> "partition_path",
+-    PRECOMBINE_FIELD.key -> "timestamp",
++    HoodieTableConfig.ORDERING_FIELDS.key -> "timestamp",
+     HoodieClusteringConfig.INLINE_CLUSTERING.key -> "true",
+     HoodieClusteringConfig.INLINE_CLUSTERING_MAX_COMMITS.key -> "4",
+     HoodieCompactionConfig.INLINE_COMPACT.key() -> "true",
+@@ -1174,7 +1174,7 @@ class TestSecondaryIndex extends HoodieSparkSqlTestBase {
+           .option("hoodie.table.name", tableName)
+           .option("hoodie.datasource.write.table.type", "COPY_ON_WRITE")
+           .option("hoodie.datasource.write.recordkey.field", "id")
+-          .option("hoodie.datasource.write.precombine.field", "ts")
++          .option(HoodieTableConfig.ORDERING_FIELDS.key(), "ts")
+           .option("hoodie.datasource.write.operation", "upsert")
+           .option("hoodie.schema.on.read.enable", "true")
+           .mode("append")

--- a/pr_13718_files/0158.diff
+++ b/pr_13718_files/0158.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestBootstrapProcedure.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestBootstrapProcedure.scala
+index 6f81377b22aeb..78dae86cdf3f1 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestBootstrapProcedure.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestBootstrapProcedure.scala
+@@ -246,7 +246,7 @@ class TestBootstrapProcedure extends HoodieSparkProcedureTestBase {
+       }
+ 
+       spark.sql("set hoodie.bootstrap.parallelism = 20")
+-      spark.sql("set hoodie.datasource.write.precombine.field=timestamp")
++      spark.sql("set hoodie.datasource.write.precombine.fields=timestamp")
+       spark.sql("set hoodie.metadata.index.column.stats.enable = false")
+ 
+       checkAnswer(

--- a/pr_13718_files/0159.diff
+++ b/pr_13718_files/0159.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRepairsProcedure.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRepairsProcedure.scala
+index a5e9e56fb81d0..d36b41ae48f1d 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRepairsProcedure.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestRepairsProcedure.scala
+@@ -149,7 +149,7 @@ class TestRepairsProcedure extends HoodieSparkProcedureTestBase {
+           |[hoodie.table.initial.version,$tableVersion,$tableVersion]
+           |[hoodie.table.keygenerator.type,NON_PARTITION,null]
+           |[hoodie.table.name,,]
+-          |[hoodie.table.precombine.field,ts,null]
++          |[hoodie.table.ordering.fields,ts,null]
+           |[hoodie.table.recordkey.fields,id,null]
+           |[hoodie.table.type,COPY_ON_WRITE,COPY_ON_WRITE]
+           |[hoodie.table.version,,]

--- a/pr_13718_files/0160.diff
+++ b/pr_13718_files/0160.diff
@@ -1,0 +1,22 @@
+diff --git a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestTTLProcedure.scala b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestTTLProcedure.scala
+index 0c4fb7a29b884..39a6deb6f59f8 100644
+--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestTTLProcedure.scala
++++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/procedure/TestTTLProcedure.scala
+@@ -31,7 +31,7 @@ import org.apache.hudi.config.HoodieWriteConfig
+ 
+ import org.apache.spark.api.java.JavaSparkContext
+ 
+-import java.util.Properties
++import java.util.{Collections, Properties}
+ 
+ import scala.collection.JavaConverters._
+ 
+@@ -114,7 +114,6 @@ class TestTTLProcedure extends HoodieSparkProcedureTestBase with SparkDatasetMix
+       .newBuilder
+       .withPath(basePath)
+       .withSchema(TRIP_EXAMPLE_SCHEMA)
+-      .withPreCombineField("_row_key")
+       .forTable(tableName)
+-
++      .withProps(Collections.singletonMap(HoodieTableConfig.ORDERING_FIELDS.key(), "_row_key"))
+ }

--- a/pr_13718_files/0161.diff
+++ b/pr_13718_files/0161.diff
@@ -1,0 +1,24 @@
+diff --git a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/processor/maxwell/MaxwellJsonKafkaSourcePostProcessor.java b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/processor/maxwell/MaxwellJsonKafkaSourcePostProcessor.java
+index 50fd71c949f85..73ff2fc9ce25e 100644
+--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/processor/maxwell/MaxwellJsonKafkaSourcePostProcessor.java
++++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/processor/maxwell/MaxwellJsonKafkaSourcePostProcessor.java
+@@ -20,9 +20,9 @@
+ 
+ import org.apache.hudi.common.config.TypedProperties;
+ import org.apache.hudi.common.model.HoodieRecord;
++import org.apache.hudi.common.util.ConfigUtils;
+ import org.apache.hudi.common.util.DateTimeUtils;
+ import org.apache.hudi.common.util.Option;
+-import org.apache.hudi.config.HoodieWriteConfig;
+ import org.apache.hudi.utilities.config.JsonKafkaPostProcessorConfig;
+ import org.apache.hudi.utilities.exception.HoodieSourcePostProcessException;
+ import org.apache.hudi.utilities.sources.processor.JsonKafkaSourcePostProcessor;
+@@ -124,7 +124,7 @@ private String processDelete(JsonNode inputJson, ObjectNode result) {
+ 
+     // we can update the `update_time`(delete time) only when it is in timestamp format.
+     if (!preCombineFieldType.equals(NON_TIMESTAMP)) {
+-      String preCombineField = this.props.getString(HoodieWriteConfig.PRECOMBINE_FIELD_NAME.key(), null);
++      String preCombineField = ConfigUtils.getOrderingFieldsStrDuringWrite(props);
+ 
+       // ts from maxwell
+       long ts = inputJson.get(TS).longValue();

--- a/pr_13718_files/0162.diff
+++ b/pr_13718_files/0162.diff
@@ -1,0 +1,21 @@
+diff --git a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BootstrapExecutor.java b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BootstrapExecutor.java
+index a5ea67823f5b0..cd0948ed4703d 100644
+--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BootstrapExecutor.java
++++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/BootstrapExecutor.java
+@@ -59,7 +59,6 @@
+ import static org.apache.hudi.common.table.HoodieTableConfig.POPULATE_META_FIELDS;
+ import static org.apache.hudi.common.table.HoodieTableConfig.TIMELINE_HISTORY_PATH;
+ import static org.apache.hudi.common.table.HoodieTableConfig.TIMELINE_TIMEZONE;
+-import static org.apache.hudi.config.HoodieWriteConfig.PRECOMBINE_FIELD_NAME;
+ import static org.apache.hudi.config.HoodieWriteConfig.WRITE_TABLE_VERSION;
+ import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_BUCKET_SYNC;
+ import static org.apache.hudi.hive.HiveSyncConfigHolder.HIVE_SYNC_BUCKET_SYNC_SPEC;
+@@ -207,7 +206,7 @@ private void initializeTable() throws IOException {
+         .setTableType(cfg.tableType)
+         .setTableName(cfg.targetTableName)
+         .setRecordKeyFields(props.getString(RECORDKEY_FIELD_NAME.key()))
+-        .setPreCombineFields(props.getString(PRECOMBINE_FIELD_NAME.key(), null))
++        .setOrderingFields(ConfigUtils.getOrderingFieldsStrDuringWrite(props))
+         .setTableVersion(ConfigUtils.getIntWithAltKeys(props, WRITE_TABLE_VERSION))
+         .setTableFormat(props.getString(HoodieTableConfig.TABLE_FORMAT.key(), HoodieTableConfig.TABLE_FORMAT.defaultValue()))
+         .setPopulateMetaFields(props.getBoolean(

--- a/pr_13718_files/0163.diff
+++ b/pr_13718_files/0163.diff
@@ -1,0 +1,15 @@
+diff --git a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
+index 02b189e382f4d..f3693a9dae384 100644
+--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
++++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
+@@ -272,8 +272,8 @@ public static class Config implements Serializable {
+             + "JsonKafkaSource, AvroKafkaSource, HiveIncrPullSource}")
+     public String sourceClassName = JsonDFSSource.class.getName();
+ 
+-    @Parameter(names = {"--source-ordering-field"}, description = "Comma separated list of fields within source record to decide how"
+-        + " to break ties between records with same key in input data.")
++    @Parameter(names = {"--source-ordering-fields", "--source-ordering-field"}, description = "Comma separated list of fields within source record to decide how"
++        + " to break ties between records with same key in input data. --source-ordering-field is deprecated, please use --source-ordering-fields instead")
+     public String sourceOrderingFields = null;
+ 
+     @Parameter(names = {"--payload-class"}, description = "Deprecated. "

--- a/pr_13718_files/0164.diff
+++ b/pr_13718_files/0164.diff
@@ -1,0 +1,13 @@
+diff --git a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+index a8d5c2a0907a0..894b7c70b0be1 100644
+--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
++++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+@@ -444,7 +444,7 @@ HoodieTableMetaClient initializeEmptyTable(HoodieTableMetaClient.TableBuilder ta
+         .setPopulateMetaFields(props.getBoolean(HoodieTableConfig.POPULATE_META_FIELDS.key(),
+             HoodieTableConfig.POPULATE_META_FIELDS.defaultValue()))
+         .setKeyGeneratorClassProp(keyGenClassName)
+-        .setPreCombineFields(cfg.sourceOrderingFields)
++        .setOrderingFields(cfg.sourceOrderingFields)
+         .setPartitionMetafileUseBaseFormat(props.getBoolean(HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.key(),
+             HoodieTableConfig.PARTITION_METAFILE_USE_BASE_FORMAT.defaultValue()))
+         .setCDCEnabled(props.getBoolean(HoodieTableConfig.CDC_ENABLED.key(),

--- a/pr_13718_files/0165.diff
+++ b/pr_13718_files/0165.diff
@@ -1,0 +1,120 @@
+diff --git a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
+index 4d88ef28bd070..b305469f44227 100644
+--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
++++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMetadataTableValidator.java
+@@ -34,6 +34,7 @@
+ import org.apache.hudi.common.model.HoodieLogFile;
+ import org.apache.hudi.common.model.HoodieRecord;
+ import org.apache.hudi.common.model.WriteOperationType;
++import org.apache.hudi.common.table.HoodieTableConfig;
+ import org.apache.hudi.common.table.HoodieTableMetaClient;
+ import org.apache.hudi.common.table.log.HoodieLogFormat;
+ import org.apache.hudi.common.table.log.block.HoodieAvroDataBlock;
+@@ -191,7 +192,7 @@ public void testMetadataTableValidation(String viewStorageTypeForFSListing, Stri
+     writeOptions.put(DataSourceWriteOptions.TABLE_NAME().key(), "test_table");
+     writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), "MERGE_ON_READ");
+     writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+-    writeOptions.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++    writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     writeOptions.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition_path");
+ 
+     Dataset<Row> inserts = makeInsertDf("000", 5).cache();
+@@ -250,7 +251,7 @@ void missingLogFileFailsValidation() throws Exception {
+     writeOptions.put("hoodie.table.name", "test_table");
+     writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), "MERGE_ON_READ");
+     writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+-    writeOptions.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++    writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     writeOptions.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition_path");
+ 
+     Dataset<Row> inserts = makeInsertDf("000", 5).cache();
+@@ -314,7 +315,7 @@ public void testSecondaryIndexValidation() throws Exception {
+               + "hoodie.metadata.record.index.enable = 'true', "
+               + "hoodie.datasource.write.recordkey.field = 'record_key_col', "
+               + "hoodie.enable.data.skipping = 'true', "
+-              + "hoodie.datasource.write.precombine.field = 'ts', "
++              + "hoodie.datasource.write.precombine.fields = 'ts', "
+               + "hoodie.datasource.write.payload.class = 'org.apache.hudi.common.model.OverwriteWithLatestAvroPayload'"
+               + ") "
+               + "partitioned by(partition_key_col) "
+@@ -365,7 +366,7 @@ public void testGetFSSecondaryKeyToRecordKeys() throws Exception {
+               + "hoodie.metadata.record.index.enable = 'true', "
+               + "hoodie.datasource.write.recordkey.field = 'record_key_col', "
+               + "hoodie.enable.data.skipping = 'true', "
+-              + "hoodie.datasource.write.precombine.field = 'ts'"
++              + "hoodie.datasource.write.precombine.fields = 'ts'"
+               + ") "
+               + "partitioned by(partition_key_col) "
+               + "location '" + basePath + "'");
+@@ -417,7 +418,7 @@ public void testColumnStatsValidation(String tableType) {
+     writeOptions.put("hoodie.table.name", "test_table");
+     writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), tableType);
+     writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+-    writeOptions.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++    writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     writeOptions.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition_path");
+     writeOptions.put(HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key(), "true");
+ 
+@@ -449,7 +450,7 @@ public void testPartitionStatsValidation(String tableType) throws Exception {
+       writeOptions.put("hoodie.table.name", "test_table");
+       writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), tableType);
+       writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+-      writeOptions.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++      writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+       writeOptions.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition_path");
+       writeOptions.put(HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key(), "true");
+ 
+@@ -517,7 +518,7 @@ public void testAdditionalPartitionsinMDT(boolean testFailureCase) throws IOExce
+     writeOptions.put(DataSourceWriteOptions.TABLE_NAME().key(), "test_table");
+     writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), "MERGE_ON_READ");
+     writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+-    writeOptions.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++    writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     writeOptions.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition_path");
+ 
+     // constructor of HoodieMetadataValidator instantiates HoodieTableMetaClient. hence creating an actual table. but rest of tests is mocked.
+@@ -598,7 +599,7 @@ public void testAdditionalFilesInMetadata(Integer lastNFileSlices, boolean ignor
+       writeOptions.put(DataSourceWriteOptions.TABLE_NAME().key(), "test_table");
+       writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), "MERGE_ON_READ");
+       writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+-      writeOptions.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++      writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+       writeOptions.put(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "2");
+ 
+       Dataset<Row> inserts = makeInsertDf("000", 10).cache();
+@@ -721,7 +722,7 @@ public void testAdditionalPartitionsinMdtEndToEnd(boolean ignoreFailed) throws E
+       writeOptions.put("hoodie.table.name", "test_table");
+       writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), "MERGE_ON_READ");
+       writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+-      writeOptions.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++      writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+       writeOptions.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(),"partition_path");
+       writeOptions.put(HoodieCompactionConfig.INLINE_COMPACT_NUM_DELTA_COMMITS.key(), "2");
+ 
+@@ -1178,7 +1179,7 @@ public void testRecordIndexMismatch(boolean ignoreFailed) throws IOException {
+     writeOptions.put("hoodie.table.name", "test_table");
+     writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), "COPY_ON_WRITE");
+     writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+-    writeOptions.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++    writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     writeOptions.put(DataSourceWriteOptions.OPERATION().key(),"bulk_insert");
+     writeOptions.put(HoodieMetadataConfig.RECORD_INDEX_ENABLE_PROP.key(), "true");
+ 
+@@ -1275,7 +1276,7 @@ public void testRliValidationFalsePositiveCase() throws Exception {
+       writeOptions.put(DataSourceWriteOptions.TABLE_NAME().key(), "test_table");
+       writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), "MERGE_ON_READ");
+       writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+-      writeOptions.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++      writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+       writeOptions.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition_path");
+ 
+       Dataset<Row> inserts = makeInsertDf("000", 5).cache();
+@@ -1401,7 +1402,7 @@ void testLogDetailMaxLength() {
+     writeOptions.put("hoodie.table.name", "test_table");
+     writeOptions.put(DataSourceWriteOptions.TABLE_TYPE().key(), "MERGE_ON_READ");
+     writeOptions.put(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "_row_key");
+-    writeOptions.put(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "timestamp");
++    writeOptions.put(HoodieTableConfig.ORDERING_FIELDS.key(), "timestamp");
+     writeOptions.put(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "partition_path");
+ 
+     // Create a large dataset to generate long validation messages

--- a/pr_13718_files/0166.diff
+++ b/pr_13718_files/0166.diff
@@ -1,0 +1,13 @@
+diff --git a/packaging/bundle-validation/utilities/hoodieapp.properties b/packaging/bundle-validation/utilities/hoodieapp.properties
+index 6d2382fc89045..2718c52c364b6 100644
+--- a/packaging/bundle-validation/utilities/hoodieapp.properties
++++ b/packaging/bundle-validation/utilities/hoodieapp.properties
+@@ -16,7 +16,7 @@
+ 
+ hoodie.datasource.write.recordkey.field=key
+ hoodie.datasource.write.partitionpath.field=date
+-hoodie.datasource.write.precombine.field=ts
++hoodie.datasource.write.precombine.fields=ts
+ hoodie.metadata.enable=true
+ hoodie.deltastreamer.source.dfs.root=file:///opt/bundle-validation/data/stocks/data
+ hoodie.deltastreamer.schemaprovider.target.schema.file=file:///opt/bundle-validation/data/stocks/schema.avsc


### PR DESCRIPTION
### Change Logs

This PR renames the `precombine.field` configuration to `ordering.fields` across Hudi, including `HoodieTableConfig` and `FlinkOptions`, to better reflect its purpose for record ordering. It introduces support for specifying multiple ordering fields and updates various internal code paths, examples, and tests to align with the new terminology and multi-field capability. Efforts were made to maintain backward compatibility with legacy configurations.

### Impact

*   **Public API/User-facing:**
    *   The primary configuration key for record ordering has changed from `hoodie.table.precombine.field` to `hoodie.table.ordering.fields`.
    *   The datasource write option `hoodie.datasource.write.precombine.field` is deprecated in favor of `hoodie.table.ordering.fields`.
    *   Users can now specify multiple comma-separated fields for record ordering.
*   **Behavioral:** Improved handling of multi-field ordering in record merging.
*   **Compatibility:** Fallback logic is introduced to support older configurations, but some paths may still require explicit updates from users or further code changes to fully recognize all legacy keys.

### Risk level (write none, low medium or high below)
Medium

_This change involves renaming a fundamental configuration, which carries a risk of breaking existing deployments if all code paths and integrations do not correctly handle the new and deprecated keys, especially for multi-field ordering. The current PR addresses many such paths, but some gaps remain (e.g., full recognition of `hoodie.datasource.write.precombine.fields` in all `ConfigUtils` methods, and complete multi-field handling in `SparkFullBootstrapDataProviderBase` and `StreamerUtil.checkPreCombineKey`). Extensive unit and integration testing is crucial to ensure backward compatibility and correct behavior with multi-field ordering._

### Documentation Update

-   The config descriptions for `hoodie.table.ordering.fields` and its deprecated alternatives must be updated.
-   Examples (`HoodiePySparkQuickstart`, `HoodieSparkQuickstart`) and utility documentation should be updated to reflect the new `ordering.fields` terminology and multi-field usage.
-   A Jira ticket for website updates is required to reflect these changes.

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed

---
<a href="https://cursor.com/background-agent?bcId=bc-eec73cf0-9c5b-44b4-8b1f-b04437559293">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eec73cf0-9c5b-44b4-8b1f-b04437559293">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

