### PR TITLE
[MINOR] review 13742

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandleWithChangeLog.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieMergeHandleWithChangeLog.java
@@ -84,15 +84,14 @@ public class HoodieMergeHandleWithChangeLog<T, I, K, O> extends HoodieWriteMerge
         IOUtils.getMaxMemoryPerPartitionMerge(taskContextSupplier, config));
   }
 
-  protected boolean writeUpdateRecord(HoodieRecord<T> newRecord, HoodieRecord<T> oldRecord, Option<HoodieRecord> combinedRecordOpt, Schema writerSchema)
+  protected boolean writeUpdateRecord(HoodieRecord<T> newRecord, HoodieRecord<T> oldRecord, HoodieRecord combinedRecord, Schema writerSchema)
       throws IOException {
     // TODO [HUDI-5019] Remove these unnecessary newInstance invocations
-    Option<HoodieRecord> savedCombineRecordOp = combinedRecordOpt.map(HoodieRecord::newInstance);
-    final boolean result = super.writeUpdateRecord(newRecord, oldRecord, combinedRecordOpt, writerSchema);
+    HoodieRecord savedCombineRecord = combinedRecord.newInstance();
+    final boolean result = super.writeUpdateRecord(newRecord, oldRecord, combinedRecord, writerSchema);
     if (result) {
       boolean isDelete = HoodieOperation.isDelete(newRecord.getOperation());
-      Option<IndexedRecord> avroRecordOpt = savedCombineRecordOp.flatMap(r ->
-          toAvroRecord(r, writerSchema, config.getPayloadConfig().getProps()));
+      Option<IndexedRecord> avroRecordOpt = toAvroRecord(savedCombineRecord, writerSchema, config.getPayloadConfig().getProps());
       cdcLogger.put(newRecord, (GenericRecord) oldRecord.getData(), isDelete ? Option.empty() : avroRecordOpt);
     }
     return result;

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieSortedMergeHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieSortedMergeHandle.java
@@ -92,7 +92,7 @@ public class HoodieSortedMergeHandle<T, I, K, O> extends HoodieWriteMergeHandle<
         throw new HoodieUpsertException("Insert/Update not in sorted order");
       }
       try {
-        writeRecord(hoodieRecord, Option.of(hoodieRecord), newSchema, config.getProps());
+        writeRecord(hoodieRecord, hoodieRecord, newSchema, config.getProps());
         insertRecordsWritten++;
         writtenRecordKeys.add(keyToPreWrite);
       } catch (IOException e) {
@@ -112,9 +112,9 @@ public class HoodieSortedMergeHandle<T, I, K, O> extends HoodieWriteMergeHandle<
         HoodieRecord<T> hoodieRecord = keyToNewRecords.get(key);
         if (!writtenRecordKeys.contains(hoodieRecord.getRecordKey())) {
           if (preserveMetadata) {
-            writeRecord(hoodieRecord, Option.of(hoodieRecord), writeSchemaWithMetaFields, config.getProps());
+            writeRecord(hoodieRecord, hoodieRecord, writeSchemaWithMetaFields, config.getProps());
           } else {
-            writeRecord(hoodieRecord, Option.of(hoodieRecord), writeSchema, config.getProps());
+            writeRecord(hoodieRecord, hoodieRecord, writeSchema, config.getProps());
           }
           insertRecordsWritten++;
           writtenRecordKeys.add(hoodieRecord.getRecordKey());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieSortedMergeHandleWithChangeLog.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieSortedMergeHandleWithChangeLog.java
@@ -19,7 +19,6 @@
 package org.apache.hudi.io;
 
 import org.apache.hudi.common.engine.TaskContextSupplier;
-import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.Option;
@@ -28,6 +27,7 @@ import org.apache.hudi.keygen.BaseKeyGenerator;
 import org.apache.hudi.table.HoodieTable;
 
 import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -53,10 +53,10 @@ public class HoodieSortedMergeHandleWithChangeLog<T, I, K, O> extends HoodieMerg
     super(config, instantTime, hoodieTable, keyToNewRecords, partitionPath, fileId, dataFileToBeMerged, taskContextSupplier, keyGeneratorOpt);
   }
 
-  protected boolean writeRecord(HoodieRecord<T> newRecord, Option<HoodieRecord> insertRecord, Schema schema, Properties props)
+  protected boolean writeRecord(HoodieRecord<T> newRecord, HoodieRecord insertRecord, Schema schema, Properties props)
       throws IOException {
     final boolean result = super.writeRecord(newRecord, insertRecord, schema, props);
-    this.cdcLogger.put(newRecord, null, insertRecord.map(rec -> ((HoodieAvroIndexedRecord) rec).getData()));
+    this.cdcLogger.put(newRecord, null, Option.ofNullable((IndexedRecord) insertRecord.getData()));
     return result;
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/SecondaryIndexStreamingTracker.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/SecondaryIndexStreamingTracker.java
@@ -152,7 +152,7 @@ public class SecondaryIndexStreamingTracker {
    * secondary index stats.
    *
    * @param hoodieKey                 The hoodie key
-   * @param combinedRecordOpt         New record merged with the old record
+   * @param combinedRecord            New record merged with the old record
    * @param oldRecord                 The old record
    * @param isDelete                  Whether the record is a DELETE
    * @param writeStatus               The Write status
@@ -162,7 +162,7 @@ public class SecondaryIndexStreamingTracker {
    * @param keyGeneratorOpt           Option containing key generator
    * @param config                    Hoodie write config
    */
-  static <T> void trackSecondaryIndexStats(@Nullable HoodieKey hoodieKey, Option<HoodieRecord> combinedRecordOpt, @Nullable HoodieRecord<T> oldRecord, boolean isDelete,
+  static <T> void trackSecondaryIndexStats(@Nullable HoodieKey hoodieKey, HoodieRecord combinedRecord, @Nullable HoodieRecord<T> oldRecord, boolean isDelete,
                                            WriteStatus writeStatus, Schema writeSchemaWithMetaFields, Supplier<Schema> newSchemaSupplier,
                                            List<HoodieIndexDefinition> secondaryIndexDefns, Option<BaseKeyGenerator> keyGeneratorOpt, HoodieWriteConfig config) {
 
@@ -185,9 +185,9 @@ public class SecondaryIndexStreamingTracker {
       boolean hasNewValue = false;
       Object newSecondaryKey = null;
 
-      if (combinedRecordOpt.isPresent() && !isDelete) {
+      if (!isDelete) {
         Schema newSchema = newSchemaSupplier.get();
-        newSecondaryKey = combinedRecordOpt.get().getColumnValueAsJava(newSchema, secondaryIndexSourceField, config.getProps());
+        newSecondaryKey = combinedRecord.getColumnValueAsJava(newSchema, secondaryIndexSourceField, config.getProps());
         hasNewValue = true;
       }
 
@@ -212,8 +212,7 @@ public class SecondaryIndexStreamingTracker {
       if (shouldUpdate) {
         String recordKey = Option.ofNullable(hoodieKey).map(HoodieKey::getRecordKey)
             .or(() -> Option.ofNullable(oldRecord).map(rec -> rec.getRecordKey(writeSchemaWithMetaFields, keyGeneratorOpt)))
-            .or(() -> combinedRecordOpt.map(HoodieRecord::getRecordKey))
-            .get();
+            .orElseGet(combinedRecord::getRecordKey);
 
         // Delete old secondary index entry if old record exists.
         if (hasOldValue) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/BaseWriteHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/commit/BaseWriteHelper.java
@@ -25,7 +25,6 @@ import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.engine.RecordContext;
 import org.apache.hudi.common.function.SerializableFunctionUnchecked;
 import org.apache.hudi.common.model.HoodieKey;
-import org.apache.hudi.common.model.HoodieOperation;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableConfig;
@@ -161,8 +160,7 @@ public abstract class BaseWriteHelper<T, I, K, O, R> extends ParallelismHelper<I
       HoodieRecord<T> reducedRecord = merged.map(bufferedRecord -> recordContext.constructHoodieRecord(bufferedRecord, next.getPartitionPath())).orElse(previous);
       boolean choosePrevious = merged.isEmpty();
       HoodieKey reducedKey = choosePrevious ? previous.getKey() : next.getKey();
-      HoodieOperation operation = choosePrevious ? previous.getOperation() : next.getOperation();
-      return reducedRecord.newInstance(reducedKey, operation);
+      return reducedRecord.newInstance(reducedKey);
     } catch (IOException e) {
       throw new HoodieException(String.format("Error to merge two records, %s, %s", previous, next), e);
     }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/TestHoodieWriteHandle.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/io/TestHoodieWriteHandle.java
@@ -165,7 +165,7 @@ class TestHoodieWriteHandle {
 
     Map<String, String> existingMetadata = new HashMap<>();
     existingMetadata.put("existing_key", "existing_value");
-    HoodieRecord hoodieRecord = new HoodieAvroIndexedRecord(null, record, HoodieOperation.INSERT, Option.of(existingMetadata));
+    HoodieRecord hoodieRecord = new HoodieAvroIndexedRecord(null, record, HoodieOperation.INSERT, Option.of(existingMetadata), null);
 
     DummyHoodieWriteHandle testWriteHandle = mockWriteHandle(true, "event_time");
 

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/CommitTimeFlinkRecordMerger.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/CommitTimeFlinkRecordMerger.java
@@ -21,7 +21,6 @@ package org.apache.hudi.client.model;
 
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieRecord;
-import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 
 import org.apache.avro.Schema;
@@ -39,12 +38,12 @@ public class CommitTimeFlinkRecordMerger extends HoodieFlinkRecordMerger {
   }
 
   @Override
-  public Option<Pair<HoodieRecord, Schema>> merge(
+  public Pair<HoodieRecord, Schema> merge(
       HoodieRecord older,
       Schema oldSchema,
       HoodieRecord newer,
       Schema newSchema,
       TypedProperties props) throws IOException {
-    return Option.of(Pair.of(newer, newSchema));
+    return Pair.of(newer, newSchema);
   }
 }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/EventTimeFlinkRecordMerger.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/EventTimeFlinkRecordMerger.java
@@ -22,7 +22,6 @@ package org.apache.hudi.client.model;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.ConfigUtils;
-import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
 
@@ -43,7 +42,7 @@ public class EventTimeFlinkRecordMerger extends HoodieFlinkRecordMerger {
   }
 
   @Override
-  public Option<Pair<HoodieRecord, Schema>> merge(
+  public Pair<HoodieRecord, Schema> merge(
       HoodieRecord older,
       Schema oldSchema,
       HoodieRecord newer,
@@ -57,9 +56,9 @@ public class EventTimeFlinkRecordMerger extends HoodieFlinkRecordMerger {
       orderingFields = ConfigUtils.getOrderingFields(props);
     }
     if (older.getOrderingValue(oldSchema, props, orderingFields).compareTo(newer.getOrderingValue(newSchema, props, orderingFields)) > 0) {
-      return Option.of(Pair.of(older, oldSchema));
+      return Pair.of(older, oldSchema);
     } else {
-      return Option.of(Pair.of(newer, newSchema));
+      return Pair.of(newer, newSchema);
     }
   }
 }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/HoodieFlinkRecord.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/HoodieFlinkRecord.java
@@ -89,7 +89,7 @@ public class HoodieFlinkRecord extends HoodieRecord<RowData> {
 
   @Override
   public HoodieRecord<RowData> newInstance(HoodieKey key) {
-    throw new UnsupportedOperationException("Not supported for " + this.getClass().getSimpleName());
+    return new HoodieFlinkRecord(key, operation, orderingValue, data);
   }
 
   @Override
@@ -267,7 +267,7 @@ public class HoodieFlinkRecord extends HoodieRecord<RowData> {
         HoodieStorageConfig.WRITE_UTC_TIMEZONE.key(), HoodieStorageConfig.WRITE_UTC_TIMEZONE.defaultValue().toString()));
     RowDataQueryContext rowDataQueryContext = RowDataAvroQueryContexts.fromAvroSchema(recordSchema, utcTimezone);
     IndexedRecord indexedRecord = (IndexedRecord) rowDataQueryContext.getRowDataToAvroConverter().convert(recordSchema, getData());
-    return Option.of(new HoodieAvroIndexedRecord(getKey(), indexedRecord, getOperation(), getMetadata()));
+    return Option.of(new HoodieAvroIndexedRecord(getKey(), indexedRecord, getOperation(), getMetadata(), orderingValue));
   }
 
   @Override

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/PartialUpdateFlinkRecordMerger.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/client/model/PartialUpdateFlinkRecordMerger.java
@@ -22,7 +22,6 @@ package org.apache.hudi.client.model;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.ConfigUtils;
-import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.util.RowDataAvroQueryContexts;
@@ -90,7 +89,7 @@ public class PartialUpdateFlinkRecordMerger extends HoodieFlinkRecordMerger {
   }
 
   @Override
-  public Option<Pair<HoodieRecord, Schema>> merge(
+  public Pair<HoodieRecord, Schema> merge(
       HoodieRecord older,
       Schema oldSchema,
       HoodieRecord newer,
@@ -105,15 +104,15 @@ public class PartialUpdateFlinkRecordMerger extends HoodieFlinkRecordMerger {
     }
     if (older.getOrderingValue(oldSchema, props, orderingFields).compareTo(newer.getOrderingValue(newSchema, props, orderingFields)) > 0) {
       if (older.isDelete(oldSchema, props) || newer.isDelete(newSchema, props)) {
-        return Option.of(Pair.of(older, oldSchema));
+        return Pair.of(older, oldSchema);
       } else {
-        return Option.of(Pair.of(mergeRecord(newer, newSchema, older, oldSchema, newSchema, props), newSchema));
+        return Pair.of(mergeRecord(newer, newSchema, older, oldSchema, newSchema, props), newSchema);
       }
     } else {
       if (newer.isDelete(newSchema, props) || older.isDelete(oldSchema, props)) {
-        return Option.of(Pair.of(newer, newSchema));
+        return Pair.of(newer, newSchema);
       } else {
-        return Option.of(Pair.of(mergeRecord(older, oldSchema, newer, newSchema, newSchema, props), newSchema));
+        return Pair.of(mergeRecord(older, oldSchema, newer, newSchema, newSchema, props), newSchema);
       }
     }
   }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkMergeAndReplaceHandleWithChangeLog.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/io/FlinkMergeAndReplaceHandleWithChangeLog.java
@@ -67,15 +67,16 @@ public class FlinkMergeAndReplaceHandleWithChangeLog<T, I, K, O>
         IOUtils.getMaxMemoryPerPartitionMerge(taskContextSupplier, config));
   }
 
-  protected boolean writeUpdateRecord(HoodieRecord<T> newRecord, HoodieRecord<T> oldRecord, Option<HoodieRecord> combineRecordOpt, Schema writerSchema)
+  @Override
+  protected boolean writeUpdateRecord(HoodieRecord<T> newRecord, HoodieRecord<T> oldRecord, HoodieRecord combineRecord, Schema writerSchema)
       throws IOException {
     // TODO [HUDI-5019] Remove these unnecessary newInstance invocations
-    Option<HoodieRecord> savedCombineRecordOp = combineRecordOpt.map(HoodieRecord::newInstance);
-    final boolean result = super.writeUpdateRecord(newRecord, oldRecord, combineRecordOpt, writerSchema);
+    HoodieRecord savedCombineRecord = combineRecord.newInstance();
+    final boolean result = super.writeUpdateRecord(newRecord, oldRecord, combineRecord, writerSchema);
     if (result) {
       boolean isDelete = HoodieOperation.isDelete(newRecord.getOperation());
       Option<IndexedRecord> newAvroRecordOpt =
-          isDelete ? Option.empty() : savedCombineRecordOp.flatMap(r -> toAvroRecord(r, writerSchema, config.getProps()));
+          isDelete ? Option.empty() : toAvroRecord(savedCombineRecord, writerSchema, config.getProps());
       GenericRecord oldAvroRecord = (GenericRecord) toAvroRecord(oldRecord, writeSchemaWithMetaFields, config.getProps()).get();
       cdcLogger.put(newRecord, oldAvroRecord, newAvroRecordOpt);
     }

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/RowDataUtils.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/RowDataUtils.java
@@ -135,6 +135,23 @@ public class RowDataUtils {
     return value;
   }
 
+  public static Object convertValueFromFlinkType(Object value) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof StringData) {
+      return ((StringData) value).toString();
+    }
+    if (value instanceof DecimalData) {
+      DecimalData decimalVal = (DecimalData) value;
+      return decimalVal.toBigDecimal();
+    }
+    if (value instanceof TimestampData) {
+      return ((TimestampData) value).toTimestamp();
+    }
+    return value;
+  }
+
   /**
    * Returns the precision of the given TIMESTAMP type.
    */

--- a/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/merge/TestHoodieFlinkRecordMerger.java
+++ b/hudi-client/hudi-flink-client/src/test/java/org/apache/hudi/merge/TestHoodieFlinkRecordMerger.java
@@ -19,9 +19,9 @@
 
 package org.apache.hudi.merge;
 
+import org.apache.hudi.client.model.CommitTimeFlinkRecordMerger;
 import org.apache.hudi.client.model.EventTimeFlinkRecordMerger;
 import org.apache.hudi.client.model.HoodieFlinkRecord;
-import org.apache.hudi.client.model.CommitTimeFlinkRecordMerger;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieEmptyRecord;
 import org.apache.hudi.common.model.HoodieKey;
@@ -29,7 +29,6 @@ import org.apache.hudi.common.model.HoodieOperation;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
 import org.apache.hudi.common.util.CollectionUtils;
-import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.util.AvroSchemaConverter;
 
@@ -97,9 +96,8 @@ public class TestHoodieFlinkRecordMerger {
     HoodieEmptyRecord deleteRecord = new HoodieEmptyRecord<>(key, HoodieOperation.DELETE, 2L, HoodieRecord.HoodieRecordType.FLINK);
 
     EventTimeFlinkRecordMerger merger = new EventTimeFlinkRecordMerger();
-    Option<Pair<HoodieRecord, Schema>> mergingResult = merger.merge(oldRecord, schema, deleteRecord, schema, new TypedProperties());
-    assertTrue(mergingResult.isPresent());
-    assertTrue(mergingResult.get().getLeft().isDelete(schema, CollectionUtils.emptyProps()));
+    Pair<HoodieRecord, Schema> mergingResult = merger.merge(oldRecord, schema, deleteRecord, schema, new TypedProperties());
+    assertTrue(mergingResult.getLeft().isDelete(schema, CollectionUtils.emptyProps()));
   }
 
   @Test
@@ -112,9 +110,8 @@ public class TestHoodieFlinkRecordMerger {
     HoodieEmptyRecord deleteRecord = new HoodieEmptyRecord<>(key, HoodieOperation.DELETE, 2L, HoodieRecord.HoodieRecordType.FLINK);
 
     EventTimeFlinkRecordMerger merger = new EventTimeFlinkRecordMerger();
-    Option<Pair<HoodieRecord, Schema>> mergingResult = merger.merge(deleteRecord, schema, newRecord, schema, new TypedProperties());
-    assertTrue(mergingResult.isPresent());
-    assertTrue(mergingResult.get().getLeft().isDelete(schema, CollectionUtils.emptyProps()));
+    Pair<HoodieRecord, Schema> mergingResult = merger.merge(deleteRecord, schema, newRecord, schema, new TypedProperties());
+    assertTrue(mergingResult.getLeft().isDelete(schema, CollectionUtils.emptyProps()));
   }
 
   @Test
@@ -128,9 +125,8 @@ public class TestHoodieFlinkRecordMerger {
     HoodieFlinkRecord newRecord = new HoodieFlinkRecord(key, HoodieOperation.INSERT, 2L, newRow);
 
     EventTimeFlinkRecordMerger merger = new EventTimeFlinkRecordMerger();
-    Option<Pair<HoodieRecord, Schema>> mergingResult = merger.merge(oldRecord, schema, newRecord, schema, new TypedProperties());
-    assertTrue(mergingResult.isPresent());
-    assertEquals(oldRecord.getData(), mergingResult.get().getLeft().getData());
+    Pair<HoodieRecord, Schema> mergingResult = merger.merge(oldRecord, schema, newRecord, schema, new TypedProperties());
+    assertEquals(oldRecord.getData(), mergingResult.getLeft().getData());
   }
 
   @Test
@@ -144,9 +140,8 @@ public class TestHoodieFlinkRecordMerger {
     HoodieFlinkRecord newRecord = new HoodieFlinkRecord(key, HoodieOperation.INSERT, 2L, newRow);
 
     EventTimeFlinkRecordMerger merger = new EventTimeFlinkRecordMerger();
-    Option<Pair<HoodieRecord, Schema>> mergingResult = merger.merge(oldRecord, schema, newRecord, schema, new TypedProperties());
-    assertTrue(mergingResult.isPresent());
-    assertEquals(newRecord.getData(), mergingResult.get().getLeft().getData());
+    Pair<HoodieRecord, Schema> mergingResult = merger.merge(oldRecord, schema, newRecord, schema, new TypedProperties());
+    assertEquals(newRecord.getData(), mergingResult.getLeft().getData());
   }
 
   @Test
@@ -160,9 +155,8 @@ public class TestHoodieFlinkRecordMerger {
     HoodieFlinkRecord newRecord = new HoodieFlinkRecord(key, HoodieOperation.INSERT, 1L, newRow);
 
     CommitTimeFlinkRecordMerger merger = new CommitTimeFlinkRecordMerger();
-    Option<Pair<HoodieRecord, Schema>> mergingResult = merger.merge(oldRecord, schema, newRecord, schema, new TypedProperties());
-    assertTrue(mergingResult.isPresent());
-    assertEquals(newRecord.getData(), mergingResult.get().getLeft().getData());
+    Pair<HoodieRecord, Schema> mergingResult = merger.merge(oldRecord, schema, newRecord, schema, new TypedProperties());
+    assertEquals(newRecord.getData(), mergingResult.getLeft().getData());
   }
 
   private RowData createRow(HoodieKey key, String commitTime, String seqNo, String filePath,

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/DefaultSparkRecordMerger.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/DefaultSparkRecordMerger.java
@@ -24,7 +24,6 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.model.HoodieSparkRecord;
 import org.apache.hudi.common.util.ConfigUtils;
-import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.merge.SparkRecordMergingUtils;
 
@@ -45,8 +44,8 @@ public class DefaultSparkRecordMerger extends HoodieSparkRecordMerger {
   }
 
   @Override
-  public Option<Pair<HoodieRecord, Schema>> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException {
-    Option<Pair<HoodieRecord, Schema>> deleteHandlingResult = handleDeletes(older, oldSchema, newer, newSchema, props);
+  public Pair<HoodieRecord, Schema> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException {
+    Pair<HoodieRecord, Schema> deleteHandlingResult = handleDeletes(older, oldSchema, newer, newSchema, props);
     if (deleteHandlingResult != null) {
       return deleteHandlingResult;
     }
@@ -55,15 +54,15 @@ public class DefaultSparkRecordMerger extends HoodieSparkRecordMerger {
       orderingFields = ConfigUtils.getOrderingFields(props);
     }
     if (older.getOrderingValue(oldSchema, props, orderingFields).compareTo(newer.getOrderingValue(newSchema, props, orderingFields)) > 0) {
-      return Option.of(Pair.of(older, oldSchema));
+      return Pair.of(older, oldSchema);
     } else {
-      return Option.of(Pair.of(newer, newSchema));
+      return Pair.of(newer, newSchema);
     }
   }
 
   @Override
-  public Option<Pair<HoodieRecord, Schema>> partialMerge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, Schema readerSchema, TypedProperties props) throws IOException {
-    Option<Pair<HoodieRecord, Schema>> deleteHandlingResult = handleDeletes(older, oldSchema, newer, newSchema, props);
+  public Pair<HoodieRecord, Schema> partialMerge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, Schema readerSchema, TypedProperties props) throws IOException {
+    Pair<HoodieRecord, Schema> deleteHandlingResult = handleDeletes(older, oldSchema, newer, newSchema, props);
     if (deleteHandlingResult != null) {
       return deleteHandlingResult;
     }
@@ -72,11 +71,11 @@ public class DefaultSparkRecordMerger extends HoodieSparkRecordMerger {
       orderingFields = ConfigUtils.getOrderingFields(props);
     }
     if (older.getOrderingValue(oldSchema, props, orderingFields).compareTo(newer.getOrderingValue(newSchema, props, orderingFields)) > 0) {
-      return Option.of(SparkRecordMergingUtils.mergePartialRecords(
-          (HoodieSparkRecord) newer, newSchema, (HoodieSparkRecord) older, oldSchema, readerSchema, props));
+      return SparkRecordMergingUtils.mergePartialRecords(
+          (HoodieSparkRecord) newer, newSchema, (HoodieSparkRecord) older, oldSchema, readerSchema, props);
     } else {
-      return Option.of(SparkRecordMergingUtils.mergePartialRecords(
-          (HoodieSparkRecord) older, oldSchema, (HoodieSparkRecord) newer, newSchema, readerSchema, props));
+      return SparkRecordMergingUtils.mergePartialRecords(
+          (HoodieSparkRecord) older, oldSchema, (HoodieSparkRecord) newer, newSchema, readerSchema, props);
     }
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/OverwriteWithLatestSparkRecordMerger.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/OverwriteWithLatestSparkRecordMerger.java
@@ -22,7 +22,6 @@ package org.apache.hudi;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieSparkRecord;
-import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.merge.SparkRecordMergingUtils;
 
@@ -41,17 +40,17 @@ public class OverwriteWithLatestSparkRecordMerger extends HoodieSparkRecordMerge
   }
 
   @Override
-  public Option<Pair<HoodieRecord, Schema>> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException {
-    return Option.of(Pair.of(newer, newSchema));
+  public Pair<HoodieRecord, Schema> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException {
+    return Pair.of(newer, newSchema);
   }
 
   @Override
-  public Option<Pair<HoodieRecord, Schema>> partialMerge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, Schema readerSchema, TypedProperties props) throws IOException {
-    Option<Pair<HoodieRecord, Schema>> deleteHandlingResult = handleDeletes(older, oldSchema, newer, newSchema, props);
+  public Pair<HoodieRecord, Schema> partialMerge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, Schema readerSchema, TypedProperties props) throws IOException {
+    Pair<HoodieRecord, Schema> deleteHandlingResult = handleDeletes(older, oldSchema, newer, newSchema, props);
     if (deleteHandlingResult != null) {
       return deleteHandlingResult;
     }
-    return Option.of(SparkRecordMergingUtils.mergePartialRecords(
-        (HoodieSparkRecord) older, oldSchema, (HoodieSparkRecord) newer, newSchema, readerSchema, props));
+    return SparkRecordMergingUtils.mergePartialRecords(
+        (HoodieSparkRecord) older, oldSchema, (HoodieSparkRecord) newer, newSchema, readerSchema, props);
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/common/model/HoodieSparkRecord.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/common/model/HoodieSparkRecord.java
@@ -120,8 +120,9 @@ public class HoodieSparkRecord extends HoodieRecord<InternalRow> {
     this.schema = schema;
   }
 
-  public HoodieSparkRecord(HoodieKey key, InternalRow data, StructType schema, boolean copy, HoodieOperation hoodieOperation, boolean isDelete) {
+  public HoodieSparkRecord(HoodieKey key, InternalRow data, StructType schema, boolean copy, HoodieOperation hoodieOperation, Comparable orderingValue, boolean isDelete) {
     super(key, data, hoodieOperation, isDelete, Option.empty());
+    this.orderingValue = orderingValue;
 
     validateRow(data, schema);
     this.copy = copy;
@@ -257,7 +258,11 @@ public class HoodieSparkRecord extends HoodieRecord<InternalRow> {
 
   @Override
   protected boolean checkIsDelete(Schema recordSchema, Properties props) {
-    if (null == data) {
+    if (data == null) {
+      return true;
+    }
+
+    if (HoodieOperation.isDelete(getOperation())) {
       return true;
     }
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieSparkDeleteRecordMerger.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieSparkDeleteRecordMerger.java
@@ -21,8 +21,10 @@ package org.apache.hudi.testutils;
 
 import org.apache.hudi.HoodieSparkRecordMerger;
 import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieEmptyRecord;
+import org.apache.hudi.common.model.HoodieOperation;
 import org.apache.hudi.common.model.HoodieRecord;
-import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.common.util.collection.Pair;
 
 import org.apache.avro.Schema;
@@ -37,8 +39,8 @@ public class HoodieSparkDeleteRecordMerger extends HoodieSparkRecordMerger {
   public static final String DELETE_MERGER_STRATEGY = "aea2e14e-19a2-4e33-bc37-f8871d55bd5b";
 
   @Override
-  public Option<Pair<HoodieRecord, Schema>> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException {
-    return Option.empty();
+  public Pair<HoodieRecord, Schema> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException {
+    return Pair.of(new HoodieEmptyRecord<>(older.getKey(), HoodieOperation.DELETE, OrderingValues.getDefault(), HoodieRecord.HoodieRecordType.SPARK), newSchema);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/avro/AvroRecordContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/AvroRecordContext.java
@@ -105,7 +105,7 @@ public class AvroRecordContext extends RecordContext<IndexedRecord> {
     // HoodieKey is not required so do not generate it if partitionPath is null
     HoodieKey hoodieKey = new HoodieKey(bufferedRecord.getRecordKey(), partitionPath);
 
-    if (bufferedRecord.isDelete()) {
+    if (bufferedRecord.getRecord() == null && bufferedRecord.isDelete()) {
       return generateEmptyAvroRecord(
           hoodieKey,
           bufferedRecord.getOrderingValue(),
@@ -124,7 +124,7 @@ public class AvroRecordContext extends RecordContext<IndexedRecord> {
     if (bufferedRecord.isDelete()) {
       return new HoodieEmptyRecord<>(hoodieKey, bufferedRecord.getHoodieOperation(), bufferedRecord.getOrderingValue(), HoodieRecord.HoodieRecordType.AVRO);
     }
-    return new HoodieAvroIndexedRecord(hoodieKey, bufferedRecord.getRecord(), bufferedRecord.getOrderingValue(), bufferedRecord.getHoodieOperation());
+    return new HoodieAvroIndexedRecord(hoodieKey, bufferedRecord.getRecord(), bufferedRecord.getOrderingValue(), bufferedRecord.getHoodieOperation(), bufferedRecord.isDelete());
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/RecordContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/RecordContext.java
@@ -220,6 +220,10 @@ public abstract class RecordContext<T> implements Serializable {
     return value;
   }
 
+  public Comparable convertValueFromEngineType(Comparable value) {
+    return value;
+  }
+
   /**
    * Converts the ordering value to the specific engine type.
    */
@@ -227,6 +231,12 @@ public abstract class RecordContext<T> implements Serializable {
     return value instanceof ArrayComparable
         ? ((ArrayComparable) value).apply(this::convertValueToEngineType)
         : convertValueToEngineType(value);
+  }
+
+  public final Comparable convertOrderingValueFromEngineType(Comparable value) {
+    return value instanceof ArrayComparable
+        ? ((ArrayComparable) value).apply(this::convertValueFromEngineType)
+        : convertValueFromEngineType(value);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/DefaultHoodieRecordPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/DefaultHoodieRecordPayload.java
@@ -74,11 +74,7 @@ public class DefaultHoodieRecordPayload extends OverwriteWithLatestAvroPayload {
 
   @Override
   public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema, Properties properties) throws IOException {
-    if (recordBytes.length == 0) {
-      return Option.empty();
-    }
-
-    GenericRecord incomingRecord = HoodieAvroUtils.bytesToAvro(recordBytes, schema);
+    Option<IndexedRecord> incomingRecord = recordBytes.length == 0 ? Option.empty() : Option.of(HoodieAvroUtils.bytesToAvro(recordBytes, schema));
 
     // Null check is needed here to support schema evolution. The record in storage may be from old schema where
     // the new ordering column might not be present and hence returns null.
@@ -87,12 +83,12 @@ public class DefaultHoodieRecordPayload extends OverwriteWithLatestAvroPayload {
     }
 
     if (!isDeleteComputed.getAndSet(true)) {
-      isDefaultRecordPayloadDeleted = isDeleteRecord(incomingRecord, properties);
+      isDefaultRecordPayloadDeleted = incomingRecord.map(record -> isDeleteRecord((GenericRecord) record, properties)).orElse(true);
     }
     /*
      * Now check if the incoming record is a delete record.
      */
-    return isDefaultRecordPayloadDeleted ? Option.empty() : Option.of(incomingRecord);
+    return isDefaultRecordPayloadDeleted ? Option.empty() : incomingRecord;
   }
 
   @Override
@@ -152,7 +148,7 @@ public class DefaultHoodieRecordPayload extends OverwriteWithLatestAvroPayload {
   }
 
   protected boolean needUpdatingPersistedRecord(IndexedRecord currentValue,
-                                                IndexedRecord incomingRecord, Properties properties) {
+                                                Option<IndexedRecord> incomingRecord, Properties properties) {
     /*
      * Combining strategy here returns currentValue on disk if incoming record is older.
      * The incoming record can be either a delete (sent as an upsert with _hoodie_is_deleted set to true)
@@ -172,10 +168,18 @@ public class DefaultHoodieRecordPayload extends OverwriteWithLatestAvroPayload {
     Comparable persistedOrderingVal = OrderingValues.create(
         orderingFields,
         field -> (Comparable) HoodieAvroUtils.getNestedFieldVal((GenericRecord) currentValue, field, true, consistentLogicalTimestampEnabled));
-    Comparable incomingOrderingVal = OrderingValues.create(
-        orderingFields,
-        field -> (Comparable) HoodieAvroUtils.getNestedFieldVal((GenericRecord) incomingRecord, field, true, consistentLogicalTimestampEnabled));
+    Comparable incomingOrderingVal = getIncomingOrderingVal(incomingRecord, orderingFields, consistentLogicalTimestampEnabled);
+    // If the incoming record is a delete record without an ordering value, it is processed as "commit time" ordering.
+    if (incomingRecord.isEmpty() && incomingOrderingVal == OrderingValues.getDefault()) {
+      return true;
+    }
     return persistedOrderingVal == null || persistedOrderingVal.compareTo(incomingOrderingVal) <= 0;
   }
 
+  protected Comparable getIncomingOrderingVal(Option<IndexedRecord> incomingRecord, String[] orderingFields, boolean consistentLogicalTimestampEnabled) {
+    return orderingVal != null ? orderingVal : incomingRecord.map(record -> OrderingValues.create(
+            orderingFields,
+        field -> (Comparable) HoodieAvroUtils.getNestedFieldVal((GenericRecord) record, field, true, consistentLogicalTimestampEnabled)))
+        .orElseGet(OrderingValues::getDefault);
+  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/EventTimeAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/EventTimeAvroPayload.java
@@ -47,14 +47,7 @@ public class EventTimeAvroPayload extends DefaultHoodieRecordPayload {
 
   @Override
   public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema, Properties properties) throws IOException {
-    /*
-     * Check if the incoming record is a delete record.
-     */
-    if (recordBytes.length == 0 || isDeletedRecord) {
-      return Option.empty();
-    }
-
-    GenericRecord incomingRecord = bytesToAvro(recordBytes, schema);
+    Option<IndexedRecord> incomingRecord = recordBytes.length == 0 || isDeletedRecord ? Option.empty() : Option.of(bytesToAvro(recordBytes, schema));
 
     // Null check is needed here to support schema evolution. The record in storage may be from old schema where
     // the new ordering column might not be present and hence returns null.
@@ -62,7 +55,7 @@ public class EventTimeAvroPayload extends DefaultHoodieRecordPayload {
       return Option.of(currentValue);
     }
 
-    return Option.of(incomingRecord);
+    return incomingRecord;
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroIndexedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroIndexedRecord.java
@@ -52,20 +52,20 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
   private SerializableIndexedRecord binaryRecord;
 
   public HoodieAvroIndexedRecord(IndexedRecord data) {
-    this(null, data, null, null, null);
+    this(data, (Comparable) null);
   }
 
   public HoodieAvroIndexedRecord(IndexedRecord data, Comparable orderingValue) {
-    this(null, data, null, null, null);
+    this(null, data);
     this.orderingValue = orderingValue;
   }
 
   public HoodieAvroIndexedRecord(HoodieKey key, IndexedRecord data) {
-    this(key, data, null, null, null);
+    this(key, data, null, null, (HoodieRecordLocation) null);
   }
 
   public HoodieAvroIndexedRecord(HoodieKey key, IndexedRecord data, HoodieOperation hoodieOperation) {
-    this(key, data, hoodieOperation, Option.empty());
+    this(key, data, hoodieOperation, Option.empty(), null);
   }
 
   public HoodieAvroIndexedRecord(HoodieKey key, IndexedRecord data, HoodieOperation hoodieOperation, HoodieRecordLocation currentLocation) {
@@ -73,13 +73,19 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
   }
 
   public HoodieAvroIndexedRecord(HoodieKey key, IndexedRecord data, Comparable<?> orderingValue) {
-    this(key, data, null, null, null);
+    this(key, data);
     this.orderingValue = orderingValue;
   }
 
   public HoodieAvroIndexedRecord(HoodieKey key, IndexedRecord data, Comparable<?> orderingValue, HoodieOperation operation) {
-    this(key, data, operation, null, null);
+    this(key, data, operation);
     this.orderingValue = orderingValue;
+  }
+
+  public HoodieAvroIndexedRecord(HoodieKey key, IndexedRecord data, Comparable<?> orderingValue, HoodieOperation operation, boolean isDelete) {
+    this(key, data, operation);
+    this.orderingValue = orderingValue;
+    this.isDelete = isDelete;
   }
 
   public HoodieAvroIndexedRecord(HoodieKey key, IndexedRecord data, HoodieOperation operation, HoodieRecordLocation currentLocation, HoodieRecordLocation newLocation) {
@@ -95,18 +101,29 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
       HoodieKey key,
       IndexedRecord data,
       HoodieOperation operation,
-      Option<Map<String, String>> metaData) {
+      Option<Map<String, String>> metaData,
+      Comparable orderingValue) {
     super(key, SerializableIndexedRecord.createInstance(data), operation, metaData);
     this.binaryRecord = (SerializableIndexedRecord) this.data;
+    this.orderingValue = orderingValue;
+  }
+
+  public HoodieAvroIndexedRecord(
+      HoodieKey key,
+      IndexedRecord data,
+      Option<Map<String, String>> metaData) {
+    this(key, data, null, metaData,  null);
   }
 
   private HoodieAvroIndexedRecord(
       HoodieKey key,
       SerializableIndexedRecord data,
       HoodieOperation operation,
-      Option<Map<String, String>> metaData) {
+      Option<Map<String, String>> metaData,
+      Comparable orderingValue) {
     super(key, data, operation, metaData);
     this.binaryRecord = (SerializableIndexedRecord) this.data;
+    this.orderingValue = orderingValue;
   }
 
   HoodieAvroIndexedRecord(HoodieAvroIndexedRecord record) {
@@ -128,12 +145,12 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
 
   @Override
   public HoodieRecord<IndexedRecord> newInstance(HoodieKey key, HoodieOperation op) {
-    return new HoodieAvroIndexedRecord(key, this.binaryRecord, op, metaData);
+    return new HoodieAvroIndexedRecord(key, this.binaryRecord, op, metaData, orderingValue);
   }
 
   @Override
   public HoodieRecord<IndexedRecord> newInstance(HoodieKey key) {
-    return new HoodieAvroIndexedRecord(key, this.binaryRecord, operation, metaData);
+    return new HoodieAvroIndexedRecord(key, this.binaryRecord, operation, metaData, orderingValue);
   }
 
   @Override
@@ -181,7 +198,7 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
   public HoodieRecord joinWith(HoodieRecord other, Schema targetSchema) {
     decodeRecord(targetSchema);
     GenericRecord record = HoodieAvroUtils.stitchRecords((GenericRecord) data, (GenericRecord) other.getData(), targetSchema);
-    return new HoodieAvroIndexedRecord(key, record, operation, metaData);
+    return new HoodieAvroIndexedRecord(key, record, operation, metaData, orderingValue);
   }
 
   @Override
@@ -189,7 +206,7 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
     decodeRecord(recordSchema);
     GenericRecord newAvroRecord = HoodieAvroUtils.rewriteRecordWithNewSchema(data, targetSchema);
     updateMetadataValuesInternal(newAvroRecord, metadataValues);
-    HoodieAvroIndexedRecord newRecord = new HoodieAvroIndexedRecord(key, newAvroRecord, operation, metaData);
+    HoodieAvroIndexedRecord newRecord = new HoodieAvroIndexedRecord(key, newAvroRecord, operation, metaData, orderingValue);
     newRecord.setNewLocation(this.newLocation);
     newRecord.setCurrentLocation(this.currentLocation);
     return newRecord;
@@ -199,14 +216,14 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
   public HoodieRecord updateMetaField(Schema recordSchema, int ordinal, String value) {
     decodeRecord(recordSchema);
     data.put(ordinal, value);
-    return new HoodieAvroIndexedRecord(key, data, operation, metaData);
+    return new HoodieAvroIndexedRecord(key, data, operation, metaData, orderingValue);
   }
 
   @Override
   public HoodieRecord rewriteRecordWithNewSchema(Schema recordSchema, Properties props, Schema newSchema, Map<String, String> renameCols) {
     decodeRecord(recordSchema);
     GenericRecord record = HoodieAvroUtils.rewriteRecordWithNewSchema(data, newSchema, renameCols);
-    return new HoodieAvroIndexedRecord(key, record, operation, metaData);
+    return new HoodieAvroIndexedRecord(key, record, operation, metaData, orderingValue);
   }
 
   @Override
@@ -218,6 +235,13 @@ public class HoodieAvroIndexedRecord extends HoodieRecord<IndexedRecord> {
 
   @Override
   protected boolean checkIsDelete(Schema recordSchema, Properties props) {
+    if (data == null) {
+      return true;
+    }
+
+    if (HoodieOperation.isDelete(getOperation())) {
+      return true;
+    }
     decodeRecord(recordSchema);
     if (getData().equals(SENTINEL)) {
       return false; // Sentinel record is not a delete

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecord.java
@@ -54,8 +54,13 @@ public class HoodieAvroRecord<T extends HoodieRecordPayload> extends HoodieRecor
     super(key, data);
   }
 
-  public HoodieAvroRecord(HoodieKey key, T data, HoodieOperation hoodieOperation, boolean isDelete) {
+  public HoodieAvroRecord(HoodieKey key, T data, HoodieOperation hoodieOperation, Boolean isDelete) {
     super(key, data, hoodieOperation, isDelete, Option.empty());
+  }
+
+  public HoodieAvroRecord(HoodieKey key, T data, HoodieOperation hoodieOperation, Comparable orderingValue, Boolean isDelete) {
+    super(key, data, hoodieOperation, isDelete, Option.empty());
+    this.orderingValue = orderingValue;
   }
 
   public HoodieAvroRecord(HoodieKey key, T data, HoodieOperation operation) {
@@ -85,12 +90,12 @@ public class HoodieAvroRecord<T extends HoodieRecordPayload> extends HoodieRecor
 
   @Override
   public HoodieRecord<T> newInstance(HoodieKey key, HoodieOperation op) {
-    return new HoodieAvroRecord<>(key, data, op);
+    return new HoodieAvroRecord<>(key, data, op, orderingValue, isDelete);
   }
 
   @Override
   public HoodieRecord<T> newInstance(HoodieKey key) {
-    return new HoodieAvroRecord<>(key, data);
+    return new HoodieAvroRecord<>(key, data, operation, orderingValue, isDelete);
   }
 
   @Override
@@ -251,7 +256,7 @@ public class HoodieAvroRecord<T extends HoodieRecordPayload> extends HoodieRecor
     Option<IndexedRecord> avroData = getData().getIndexedRecord(recordSchema, props);
     if (avroData.isPresent()) {
       HoodieAvroIndexedRecord record =
-          new HoodieAvroIndexedRecord(key, avroData.get(), operation, getData().getMetadata());
+          new HoodieAvroIndexedRecord(key, avroData.get(), operation, getData().getMetadata(), getData().getOrderingValue());
       return Option.of(record);
     } else {
       return Option.empty();

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodiePreCombineAvroRecordMerger.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodiePreCombineAvroRecordMerger.java
@@ -19,7 +19,6 @@
 package org.apache.hudi.common.model;
 
 import org.apache.hudi.common.config.TypedProperties;
-import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 
 import org.apache.avro.Schema;
@@ -35,8 +34,8 @@ public class HoodiePreCombineAvroRecordMerger extends HoodieAvroRecordMerger {
   public static final HoodiePreCombineAvroRecordMerger INSTANCE = new HoodiePreCombineAvroRecordMerger();
 
   @Override
-  public Option<Pair<HoodieRecord, Schema>> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException {
-    return Option.of(preCombine(older, oldSchema, newer, newSchema, props));
+  public Pair<HoodieRecord, Schema> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException {
+    return preCombine(older, oldSchema, newer, newSchema, props);
   }
 
   @SuppressWarnings("rawtypes, unchecked")

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
@@ -178,7 +178,7 @@ public abstract class HoodieRecord<T> implements HoodieRecordCompatibilityInterf
     this.metaData = metaData;
   }
 
-  public HoodieRecord(HoodieKey key, T data, HoodieOperation operation, boolean isDelete, Option<Map<String, String>> metaData) {
+  public HoodieRecord(HoodieKey key, T data, HoodieOperation operation, Boolean isDelete, Option<Map<String, String>> metaData) {
     this.key = key;
     this.data = data;
     this.currentLocation = null;

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordMerger.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordMerger.java
@@ -63,8 +63,15 @@ public interface HoodieRecordMerger extends Serializable {
    * It'd be associative operation: f(a, f(b, c)) = f(f(a, b), c) (which we can translate as having 3 versions A, B, C
    * of the single record, both orders of operations applications have to yield the same result)
    * This method takes only full records for merging.
+   *
+   * @param older     Older record in terms of commit time ordering.
+   * @param oldSchema The schema of the older record.
+   * @param newer     Newer record in terms of commit time ordering.
+   * @param newSchema The schema of the newer record.
+   * @param props     The additional properties for the merging operation.
+   * @return The merged record and schema. The record is expected to be non-null. If the record represents a deletion, the operation must be set as {@link HoodieOperation#DELETE}.
    */
-  Option<Pair<HoodieRecord, Schema>> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException;
+  Pair<HoodieRecord, Schema> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException;
 
   /**
    * Merges records which can contain partial updates, i.e., only subset of fields and values are
@@ -118,10 +125,10 @@ public interface HoodieRecordMerger extends Serializable {
    * @param readerSchema Reader schema containing all the fields to read. This is used to maintain
    *                     the ordering of the fields of the merged record.
    * @param props        Configuration in {@link TypedProperties}.
-   * @return The merged record and schema.
+   * @return The merged record and schema. The record is expected to be non-null. If the record represents a deletion, the operation must be set as {@link HoodieOperation#DELETE}.
    * @throws IOException upon merging error.
    */
-  default Option<Pair<HoodieRecord, Schema>> partialMerge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, Schema readerSchema, TypedProperties props) throws IOException {
+  default Pair<HoodieRecord, Schema> partialMerge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, Schema readerSchema, TypedProperties props) throws IOException {
     throw new UnsupportedOperationException("Partial merging logic is not implemented by " + this.getClass().getName());
   }
 
@@ -136,6 +143,7 @@ public interface HoodieRecordMerger extends Serializable {
    *
    * <p> This interface is experimental and might be evolved in the future.
    **/
+  @Deprecated
   default boolean shouldFlush(HoodieRecord record, Schema schema, TypedProperties props) throws IOException {
     return true;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestMerger.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestMerger.java
@@ -20,7 +20,6 @@
 package org.apache.hudi.common.model;
 
 import org.apache.hudi.common.config.TypedProperties;
-import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 
 import org.apache.avro.Schema;
@@ -33,8 +32,8 @@ import java.io.IOException;
 public class OverwriteWithLatestMerger implements HoodieRecordMerger {
 
   @Override
-  public Option<Pair<HoodieRecord, Schema>> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException {
-    return Option.of(Pair.of(newer, newSchema));
+  public Pair<HoodieRecord, Schema> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException {
+    return Pair.of(newer, newSchema);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
@@ -249,7 +249,7 @@ public class HoodieMergedLogRecordScanner extends AbstractHoodieLogRecordScanner
     if (prevRecord != null) {
       // Merge and store the combined record
       HoodieRecord<T> combinedRecord = (HoodieRecord<T>) recordMerger.merge(prevRecord, readerSchema,
-          newRecord, readerSchema, this.getPayloadProps()).get().getLeft();
+          newRecord, readerSchema, this.getPayloadProps()).getLeft();
       // If pre-combine returns existing record, no need to update it
       if (combinedRecord.getData() != prevRecord.getData()) {
         HoodieRecord latestHoodieRecord = getLatestHoodieRecord(newRecord, combinedRecord, key);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/BufferedRecords.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/BufferedRecords.java
@@ -66,6 +66,11 @@ public class BufferedRecords {
     return new BufferedRecord<>(recordKey, orderingValue, record, schemaId, isDelete ? HoodieOperation.DELETE : null);
   }
 
+  public static <T> BufferedRecord<T> fromEngineRecord(T record, Schema schema, RecordContext<T> recordContext, Comparable orderingValue, String recordKey, boolean isDelete) {
+    Integer schemaId = recordContext.encodeAvroSchema(schema);
+    return new BufferedRecord<>(recordKey, orderingValue, record, schemaId, isDelete ? HoodieOperation.DELETE : null);
+  }
+
   public static <T> BufferedRecord<T> fromDeleteRecord(DeleteRecord deleteRecord, RecordContext<T> recordContext) {
     return new BufferedRecord<>(deleteRecord.getRecordKey(), recordContext.getOrderingValue(deleteRecord), null, null, HoodieOperation.DELETE);
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/TestDefaultHoodieRecordPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/TestDefaultHoodieRecordPayload.java
@@ -78,8 +78,8 @@ public class TestDefaultHoodieRecordPayload {
     record2.put("ts", 1L);
     record2.put("_hoodie_is_deleted", false);
 
-    DefaultHoodieRecordPayload payload1 = new DefaultHoodieRecordPayload(record1, 1);
-    DefaultHoodieRecordPayload payload2 = new DefaultHoodieRecordPayload(record2, 2);
+    DefaultHoodieRecordPayload payload1 = new DefaultHoodieRecordPayload(record1, 0L);
+    DefaultHoodieRecordPayload payload2 = new DefaultHoodieRecordPayload(record2, 1L);
     assertEquals(payload1.preCombine(payload2, props), payload2);
     assertEquals(payload2.preCombine(payload1, props), payload2);
 
@@ -106,8 +106,8 @@ public class TestDefaultHoodieRecordPayload {
     delRecord1.put("ts", 1L);
     delRecord1.put("_hoodie_is_deleted", true);
 
-    DefaultHoodieRecordPayload payload1 = new DefaultHoodieRecordPayload(record1, 1);
-    DefaultHoodieRecordPayload payload2 = new DefaultHoodieRecordPayload(delRecord1, 2);
+    DefaultHoodieRecordPayload payload1 = new DefaultHoodieRecordPayload(record1, 0L);
+    DefaultHoodieRecordPayload payload2 = new DefaultHoodieRecordPayload(delRecord1, 1L);
     assertFalse(payload1.isDeleted(schema, props));
     assertTrue(payload2.isDeleted(schema, props));
     assertEquals(payload1.preCombine(payload2, props), payload2);
@@ -142,9 +142,9 @@ public class TestDefaultHoodieRecordPayload {
     defaultDeleteRecord.put("ts", 2L);
     defaultDeleteRecord.put("_hoodie_is_deleted", true);
 
-    DefaultHoodieRecordPayload payload = new DefaultHoodieRecordPayload(record, 1);
-    DefaultHoodieRecordPayload deletePayload = new DefaultHoodieRecordPayload(delRecord, 2);
-    DefaultHoodieRecordPayload defaultDeletePayload = new DefaultHoodieRecordPayload(defaultDeleteRecord, 2);
+    DefaultHoodieRecordPayload payload = new DefaultHoodieRecordPayload(record, 0L);
+    DefaultHoodieRecordPayload deletePayload = new DefaultHoodieRecordPayload(delRecord, 1L);
+    DefaultHoodieRecordPayload defaultDeletePayload = new DefaultHoodieRecordPayload(defaultDeleteRecord, 2L);
 
     assertFalse(payload.isDeleted(schema, props));
     assertTrue(deletePayload.isDeleted(schema, props));
@@ -168,7 +168,7 @@ public class TestDefaultHoodieRecordPayload {
     record.put("ts", 0L);
     record.put("_hoodie_is_deleted", false);
 
-    DefaultHoodieRecordPayload payload = new DefaultHoodieRecordPayload(record, 1);
+    DefaultHoodieRecordPayload payload = new DefaultHoodieRecordPayload(record, 1L);
 
     // Verify failure when DELETE_MARKER is not configured along with DELETE_KEY
     try {
@@ -179,7 +179,7 @@ public class TestDefaultHoodieRecordPayload {
     }
 
     try {
-      payload = new DefaultHoodieRecordPayload(record, 1);
+      payload = new DefaultHoodieRecordPayload(record, 1L);
       payload.combineAndGetUpdateValue(record, schema, props).get();
       fail("Should fail");
     } catch (IllegalArgumentException e) {

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/BaseTestFileGroupRecordBuffer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/BaseTestFileGroupRecordBuffer.java
@@ -80,7 +80,7 @@ public class BaseTestFileGroupRecordBuffer {
   }
 
   protected static List<HoodieRecord> convertToHoodieRecordsList(List<IndexedRecord> indexedRecords) {
-    return indexedRecords.stream().map(rec -> new HoodieAvroIndexedRecord(new HoodieKey(rec.get(0).toString(), ""), rec, null)).collect(Collectors.toList());
+    return indexedRecords.stream().map(rec -> new HoodieAvroIndexedRecord(new HoodieKey(rec.get(0).toString(), ""), rec)).collect(Collectors.toList());
   }
 
   protected static List<HoodieRecord> convertToHoodieRecordsListForDeletes(List<IndexedRecord> indexedRecords, boolean defaultOrderingValue) {
@@ -171,6 +171,9 @@ public class BaseTestFileGroupRecordBuffer {
 
     @Override
     public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema) throws IOException {
+      if (payloadRecord == null) {
+        return Option.empty();
+      }
       if (currentValue.get(2).equals(payloadRecord.get(2))) {
         // If the timestamps are the same, we do not update
         return Option.of(currentValue);
@@ -184,12 +187,12 @@ public class BaseTestFileGroupRecordBuffer {
 
     @Override
     public Option<IndexedRecord> getInsertValue(Schema schema) throws IOException {
-      return Option.of(payloadRecord);
+      return Option.ofNullable(payloadRecord);
     }
 
     @Override
     public Option<IndexedRecord> getIndexedRecord(Schema schema, Properties properties) {
-      return Option.of(payloadRecord);
+      return Option.ofNullable(payloadRecord);
     }
 
     @Override
@@ -202,19 +205,22 @@ public class BaseTestFileGroupRecordBuffer {
     private final String strategy = UUID.randomUUID().toString();
 
     @Override
-    public Option<Pair<HoodieRecord, Schema>> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException {
+    public Pair<HoodieRecord, Schema> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException {
+      if (newer.isDelete(newSchema, props)) {
+        return Pair.of(new HoodieEmptyRecord<>(newer.getKey(), HoodieOperation.DELETE, OrderingValues.getDefault(), HoodieRecord.HoodieRecordType.AVRO), SCHEMA);
+      }
       GenericRecord olderData = (GenericRecord) older.toIndexedRecord(oldSchema, props).get().getData();
       GenericRecord newerData = (GenericRecord) newer.toIndexedRecord(newSchema, props).get().getData();
       if (olderData.get(2).equals(newerData.get(2))) {
         // If the timestamps are the same, we do not update
-        return Option.of(Pair.of(older, oldSchema));
+        return Pair.of(older, oldSchema);
       }
       int result = (int) olderData.get(1) + (int) newerData.get(1);
       if (result > 2) {
-        return Option.empty();
+        return Pair.of(new HoodieEmptyRecord<>(newer.getKey(), HoodieOperation.DELETE, OrderingValues.getDefault(), HoodieRecord.HoodieRecordType.AVRO), SCHEMA);
       }
       HoodieKey hoodieKey = older.getKey();
-      return Option.of(Pair.of(new HoodieAvroIndexedRecord(createTestRecord(hoodieKey.getRecordKey(), result, (long) newerData.get(2))), SCHEMA));
+      return Pair.of(new HoodieAvroIndexedRecord(createTestRecord(hoodieKey.getRecordKey(), result, (long) newerData.get(2))), SCHEMA);
     }
 
     @Override

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestDataGenerator.java
@@ -865,8 +865,7 @@ Generate random record using TRIP_ENCODED_DECIMAL_SCHEMA
       populateKeysBySchema(schemaStr, currSize + i, kp);
       incrementNumExistingKeysBySchema(schemaStr);
       try {
-        return new HoodieAvroIndexedRecord(key, generateRandomValueAsPerSchema(schemaStr, key, instantTime, isFlattened),
-            null, Option.of(Collections.singletonMap("InputRecordCount_1506582000", "2")));
+        return new HoodieAvroIndexedRecord(key, generateRandomValueAsPerSchema(schemaStr, key, instantTime, isFlattened), Option.of(Collections.singletonMap("InputRecordCount_1506582000", "2")));
       } catch (IOException e) {
         throw new HoodieIOException(e.getMessage(), e);
       }

--- a/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/testutils/HoodieTestUtils.java
@@ -122,7 +122,7 @@ public class HoodieTestUtils {
     record.put("time", time);
     record.put("number", number);
     String partition = partitionPath.orElseGet(() -> extractPartitionFromTimeField(time));
-    return new HoodieAvroIndexedRecord(new HoodieKey(rowKey, partition), record, null, Option.of(Collections.singletonMap("InputRecordCount_1506582000", "2")));
+    return new HoodieAvroIndexedRecord(new HoodieKey(rowKey, partition), record, Option.of(Collections.singletonMap("InputRecordCount_1506582000", "2")));
   }
 
   public static String extractPartitionFromTimeField(String timeField) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/FlinkRecordContext.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/format/FlinkRecordContext.java
@@ -89,6 +89,11 @@ public class FlinkRecordContext extends RecordContext<RowData> {
   }
 
   @Override
+  public Comparable convertValueFromEngineType(Comparable value) {
+    return (Comparable) RowDataUtils.convertValueFromFlinkType(value);
+  }
+
+  @Override
   public GenericRecord convertToAvroRecord(RowData record, Schema schema) {
     return (GenericRecord) RowDataAvroQueryContexts.fromAvroSchema(schema).getRowDataToAvroConverter().convert(schema, record);
   }

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestCustomRecordMerger.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/common/table/read/TestCustomRecordMerger.java
@@ -23,6 +23,8 @@ import org.apache.hudi.avro.HoodieAvroReaderContext;
 import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
+import org.apache.hudi.common.model.HoodieEmptyRecord;
+import org.apache.hudi.common.model.HoodieOperation;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.table.HoodieTableConfig;
@@ -31,6 +33,7 @@ import org.apache.hudi.common.testutils.reader.HoodieFileGroupReaderTestHarness;
 import org.apache.hudi.common.testutils.reader.HoodieFileSliceTestUtils;
 import org.apache.hudi.common.util.ConfigUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
 
@@ -172,9 +175,8 @@ public class TestCustomRecordMerger extends HoodieFileGroupReaderTestHarness {
   public void testWithThreeLogFiles(boolean useRecordPositions) throws IOException, InterruptedException {
     shouldWritePositions = Arrays.asList(useRecordPositions, useRecordPositions, useRecordPositions, useRecordPositions);
     try (ClosableIterator<IndexedRecord> iterator = getFileGroupIterator(4, useRecordPositions)) {
-      // The records with keys 6 and 8 are deletes with lower ordering val
       List<String> leftKeysExpected =
-          Arrays.asList("1", "3", "6", "7", "8", "9", "10");
+          Arrays.asList("1", "3", "7", "9", "10");
       List<String> leftKeysActual = new ArrayList<>();
       while (iterator.hasNext()) {
         leftKeysActual.add(iterator.next()
@@ -242,7 +244,7 @@ public class TestCustomRecordMerger extends HoodieFileGroupReaderTestHarness {
     private String[] orderingFields;
 
     @Override
-    public Option<Pair<HoodieRecord, Schema>> merge(
+    public Pair<HoodieRecord, Schema> merge(
         HoodieRecord older,
         Schema oldSchema,
         HoodieRecord newer,
@@ -255,24 +257,24 @@ public class TestCustomRecordMerger extends HoodieFileGroupReaderTestHarness {
       if (newer.getOrderingValue(newSchema, props, orderingFields).compareTo(
           older.getOrderingValue(oldSchema, props, orderingFields)) >= 0) {
         if (newer.isDelete(newSchema, props)) {
-          return Option.empty();
+          return Pair.of(new HoodieEmptyRecord<>(newer.getKey(), HoodieOperation.DELETE, OrderingValues.getDefault(), AVRO), newSchema);
         }
         int id = Integer.parseInt(((HoodieAvroIndexedRecord) newer)
             .getData().get(newSchema.getField(ROW_KEY).pos()).toString());
         if (id % 2 == 1L) {
-          return Option.of(Pair.of(newer, newSchema));
+          return Pair.of(newer, newSchema);
         }
       } else {
         if (older.isDelete(oldSchema, props)) {
-          return Option.empty();
+          return Pair.of(new HoodieEmptyRecord<>(newer.getKey(), HoodieOperation.DELETE, OrderingValues.getDefault(), AVRO), newSchema);
         }
         int id = Integer.parseInt(((HoodieAvroIndexedRecord) older)
             .getData().get(oldSchema.getField(ROW_KEY).pos()).toString());
         if (id % 2 == 1L) {
-          return Option.of(Pair.of(older, oldSchema));
+          return Pair.of(older, oldSchema);
         }
       }
-      return Option.empty();
+      return Pair.of(new HoodieEmptyRecord<>(newer.getKey(), HoodieOperation.DELETE, OrderingValues.getDefault(), AVRO), newSchema);
     }
 
     @Override

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveRecordContext.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HiveRecordContext.java
@@ -25,7 +25,6 @@ import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.read.BufferedRecord;
-import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.hadoop.utils.HiveAvroSerializer;
 import org.apache.hudi.hadoop.utils.HiveJavaTypeConverter;
 import org.apache.hudi.hadoop.utils.HoodieArrayWritableAvroUtils;
@@ -78,12 +77,12 @@ public class HiveRecordContext extends RecordContext<ArrayWritable> {
       return new HoodieEmptyRecord<>(
           key,
           bufferedRecord.getHoodieOperation(),
-          OrderingValues.getDefault(),
+          bufferedRecord.getOrderingValue(),
           HoodieRecord.HoodieRecordType.HIVE);
     }
     Schema schema = getSchemaFromBufferRecord(bufferedRecord);
     ArrayWritable writable = bufferedRecord.getRecord();
-    return new HoodieHiveRecord(key, writable, schema, getHiveAvroSerializer(schema), bufferedRecord.getHoodieOperation(), bufferedRecord.isDelete());
+    return new HoodieHiveRecord(key, writable, schema, getHiveAvroSerializer(schema), bufferedRecord.getHoodieOperation(), bufferedRecord.getOrderingValue(), bufferedRecord.isDelete());
   }
 
   @Override
@@ -122,6 +121,25 @@ public class HiveRecordContext extends RecordContext<ArrayWritable> {
       return new DoubleWritable((double) value);
     } else if (value instanceof Boolean) {
       return new BooleanWritable((boolean) value);
+    }
+    return value;
+  }
+
+  public Comparable convertValueFromEngineType(Comparable value) {
+    if (value == null) {
+      return null;
+    } else if (value instanceof Text) {
+      return value.toString();
+    } else if (value instanceof IntWritable) {
+      return ((IntWritable) value).get();
+    } else if (value instanceof LongWritable) {
+      return ((LongWritable) value).get();
+    } else if (value instanceof FloatWritable) {
+      return ((FloatWritable) value).get();
+    } else if (value instanceof DoubleWritable) {
+      return ((DoubleWritable) value).get();
+    } else if (value instanceof BooleanWritable) {
+      return ((BooleanWritable) value).get();
     }
     return value;
   }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieHiveRecord.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieHiveRecord.java
@@ -70,8 +70,9 @@ public class HoodieHiveRecord extends HoodieRecord<ArrayWritable> {
     isDelete = data == null;
   }
 
-  public HoodieHiveRecord(HoodieKey key, ArrayWritable data, Schema schema, HiveAvroSerializer avroSerializer, HoodieOperation hoodieOperation, boolean isDelete) {
+  public HoodieHiveRecord(HoodieKey key, ArrayWritable data, Schema schema, HiveAvroSerializer avroSerializer, HoodieOperation hoodieOperation, Comparable orderingValue, boolean isDelete) {
     super(key, data, hoodieOperation, isDelete, Option.empty());
+    this.orderingValue = orderingValue;
     this.avroSerializer = avroSerializer;
     this.schema = schema;
     this.copy = false;
@@ -188,6 +189,9 @@ public class HoodieHiveRecord extends HoodieRecord<ArrayWritable> {
   @Override
   public boolean checkIsDelete(Schema recordSchema, Properties props) throws IOException {
     if (null == data) {
+      return true;
+    }
+    if (HoodieOperation.isDelete(getOperation())) {
       return true;
     }
     if (recordSchema.getField(HoodieRecord.HOODIE_IS_DELETED_FIELD) == null) {

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/OverwriteWithLatestHiveRecordMerger.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/OverwriteWithLatestHiveRecordMerger.java
@@ -21,7 +21,6 @@ package org.apache.hudi.hadoop;
 
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieRecord;
-import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 
 import org.apache.avro.Schema;
@@ -38,7 +37,7 @@ public class OverwriteWithLatestHiveRecordMerger extends HoodieHiveRecordMerger 
   }
 
   @Override
-  public Option<Pair<HoodieRecord, Schema>> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException {
-    return Option.of(Pair.of(newer, newSchema));
+  public Pair<HoodieRecord, Schema> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException {
+    return Pair.of(newer, newSchema);
   }
 }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/HoodieSparkValidateDuplicateKeyRecordMerger.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/hudi/command/HoodieSparkValidateDuplicateKeyRecordMerger.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.hudi.command.HoodieSparkValidateDuplicateKeyRecordMe
  */
 class HoodieSparkValidateDuplicateKeyRecordMerger extends HoodieSparkRecordMerger with OperationModeAwareness {
 
-  override def merge(older: HoodieRecord[_], oldSchema: Schema, newer: HoodieRecord[_], newSchema: Schema, props: TypedProperties): HOption[collection.Pair[HoodieRecord[_], Schema]] = {
+  override def merge(older: HoodieRecord[_], oldSchema: Schema, newer: HoodieRecord[_], newSchema: Schema, props: TypedProperties): collection.Pair[HoodieRecord[_], Schema] = {
     val key = older.getRecordKey(oldSchema, HoodieRecord.RECORD_KEY_METADATA_FIELD)
     throw new HoodieDuplicateKeyException(key)
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDefaultSparkRecordMerger.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestDefaultSparkRecordMerger.java
@@ -25,7 +25,6 @@ import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieSparkRecord;
 import org.apache.hudi.common.testutils.HoodieTestDataGenerator;
-import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 
 import org.apache.avro.Schema;
@@ -103,12 +102,12 @@ class TestDefaultSparkRecordMerger {
     props.setProperty(ORDERING_FIELDS.key(), INT_COLUMN_NAME);
     Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
         SPARK_SCHEMA, ANY_NAME, ANY_NAMESPACE);
-    Option<Pair<HoodieRecord, Schema>> merged =
+    Pair<HoodieRecord, Schema> merged =
         merger.merge(oldRecord, avroSchema, newRecord, avroSchema, props);
 
     assertEquals(
         InternalRow.apply(newValue.toSeq()),
-        merged.get().getLeft().getData());
+        merged.getLeft().getData());
   }
 
   /**
@@ -130,12 +129,12 @@ class TestDefaultSparkRecordMerger {
     props.setProperty(ORDERING_FIELDS.key(), INT_COLUMN_NAME);
     Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
         SPARK_SCHEMA, ANY_NAME, ANY_NAMESPACE);
-    Option<Pair<HoodieRecord, Schema>> r =
+    Pair<HoodieRecord, Schema> merged =
         merger.merge(oldRecord, avroSchema, newRecord, avroSchema, props);
 
     assertEquals(
         InternalRow.apply(oldValue.toSeq()),
-        r.get().getLeft().getData());
+        merged.getLeft().getData());
   }
 
   /**
@@ -154,9 +153,9 @@ class TestDefaultSparkRecordMerger {
     props.setProperty(ORDERING_FIELDS.key(), INT_COLUMN_NAME);
     Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
         SPARK_SCHEMA, ANY_NAME, ANY_NAMESPACE);
-    Option<Pair<HoodieRecord, Schema>> r =
+    Pair<HoodieRecord, Schema> merged =
         merger.merge(oldRecord, avroSchema, newRecord, avroSchema, props);
-    assertTrue(r.isEmpty());
+    assertTrue(merged.getLeft().isDelete(avroSchema, props));
   }
 
   /**
@@ -175,11 +174,10 @@ class TestDefaultSparkRecordMerger {
     props.setProperty(ORDERING_FIELDS.key(), INT_COLUMN_NAME);
     Schema avroSchema = AvroConversionUtils.convertStructTypeToAvroSchema(
         SPARK_SCHEMA, ANY_NAME, ANY_NAMESPACE);
-    Option<Pair<HoodieRecord, Schema>> r =
-        merger.merge(oldRecord, avroSchema, newRecord, avroSchema, props);
+    Pair<HoodieRecord, Schema> result = merger.merge(oldRecord, avroSchema, newRecord, avroSchema, props);
     assertEquals(
         InternalRow.apply(newValue.toSeq()),
-        r.get().getLeft().getData());
+        result.getLeft().getData());
   }
 
   static Row getSpecificValue(

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestPositionBasedFileGroupRecordBuffer.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestPositionBasedFileGroupRecordBuffer.java
@@ -266,7 +266,7 @@ public class TestPositionBasedFileGroupRecordBuffer extends SparkClientFunctiona
     }
 
     @Override
-    public Option<Pair<HoodieRecord, Schema>> merge(
+    public Pair<HoodieRecord, Schema> merge(
         HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props
     ) throws IOException {
       throw new IOException("Not implemented");

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBufferedRecordMerger.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestBufferedRecordMerger.java
@@ -22,11 +22,13 @@ package org.apache.hudi.functional;
 import org.apache.hudi.AvroConversionUtils;
 import org.apache.hudi.DefaultSparkRecordMerger;
 import org.apache.hudi.OverwriteWithLatestSparkRecordMerger;
+import org.apache.hudi.avro.HoodieAvroReaderContext;
 import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.engine.RecordContext;
 import org.apache.hudi.common.model.DeleteRecord;
+import org.apache.hudi.common.model.HoodieAvroRecordMerger;
 import org.apache.hudi.common.model.HoodieEmptyRecord;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieOperation;
@@ -34,23 +36,28 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.model.HoodieSparkRecord;
 import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.PartialUpdateMode;
 import org.apache.hudi.common.table.log.InstantRange;
 import org.apache.hudi.common.table.read.BufferedRecord;
 import org.apache.hudi.common.table.read.BufferedRecordMerger;
 import org.apache.hudi.common.table.read.BufferedRecordMergerFactory;
+import org.apache.hudi.common.table.read.FileGroupReaderSchemaHandler;
 import org.apache.hudi.common.util.DefaultJavaTypeConverter;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.OrderingValues;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.expression.Predicate;
+import org.apache.hudi.io.CustomMerger;
+import org.apache.hudi.io.CustomPayload;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.testutils.SparkClientFunctionalTestHarness;
 
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -63,6 +70,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -75,8 +83,8 @@ import java.util.stream.Stream;
 import static org.apache.hudi.BaseSparkInternalRecordContext.getFieldValueFromInternalRow;
 import static org.apache.hudi.common.config.RecordMergeMode.COMMIT_TIME_ORDERING;
 import static org.apache.hudi.common.config.RecordMergeMode.EVENT_TIME_ORDERING;
-import static org.apache.hudi.common.table.HoodieTableConfig.PARTIAL_UPDATE_UNAVAILABLE_VALUE;
 import static org.apache.hudi.common.table.HoodieTableConfig.ORDERING_FIELDS;
+import static org.apache.hudi.common.table.HoodieTableConfig.PARTIAL_UPDATE_UNAVAILABLE_VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -584,6 +592,107 @@ class TestBufferedRecordMerger extends SparkClientFunctionalTestHarness {
     result = merger.finalMerge(olderBufferedRecord, newerBufferedRecord);
     assertTrue(result.isDelete());
     assertEquals(newRecord, result.getRecord());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testCustomMerging(boolean usePayload) throws IOException {
+    // create a simple schema with _hoodie_is_delete field to track delete records
+    Schema customSchema = Schema.createRecord("CustomRecord", null, null, false);
+    Option<HoodieRecordMerger> recordMerger;
+    Option<String> payloadClassName;
+    if (usePayload) {
+      recordMerger = Option.of(new HoodieAvroRecordMerger());
+      payloadClassName = Option.of(CustomPayload.class.getName());
+    } else {
+      recordMerger = Option.of(new CustomMerger());
+      payloadClassName = Option.empty();
+    }
+    customSchema.setFields(Arrays.asList(new Schema.Field("id", Schema.create(Schema.Type.STRING), null, null),
+        new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null),
+        new Schema.Field("timestamp", Schema.create(Schema.Type.LONG), null, null),
+        new Schema.Field(HoodieRecord.HOODIE_IS_DELETED_FIELD, Schema.create(Schema.Type.BOOLEAN))));
+    // Configure reader context with custom schema
+    HoodieAvroReaderContext avroReaderContext = new HoodieAvroReaderContext(storageConfig, tableConfig, Option.empty(), Option.empty());
+    avroReaderContext.setHasLogFiles(false);
+    avroReaderContext.setHasBootstrapBaseFile(false);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    avroReaderContext.setSchemaHandler(new FileGroupReaderSchemaHandler<>(avroReaderContext, customSchema, customSchema, Option.empty(), props, metaClient));
+    avroReaderContext.getRecordContext().encodeAvroSchema(customSchema);
+
+    BufferedRecordMerger<IndexedRecord> merger = BufferedRecordMergerFactory.create(
+        avroReaderContext,
+        RecordMergeMode.CUSTOM,
+        false,
+        recordMerger,
+        Collections.emptyList(),
+        payloadClassName,
+        customSchema,
+        props,
+        Option.empty());
+
+    GenericRecord record1 = createCustomRecord(customSchema, "1", "Alice", 1000L, false);
+    BufferedRecord<IndexedRecord> bufferedRecord1 = new BufferedRecord<>("1", 1000L, record1, 0, null);
+    GenericRecord record2 = createCustomRecord(customSchema, "1", "Bob", 2000L, false);
+    BufferedRecord<IndexedRecord> bufferedRecord2 = new BufferedRecord<>("1", 2000L, record2, 0, null);
+    GenericRecord record3 = createCustomRecord(customSchema, "1", "Charlie", 3000L, true);
+    BufferedRecord<IndexedRecord> bufferedRecord3 = new BufferedRecord<>("1", 3000L, record3, 0, HoodieOperation.DELETE);
+    GenericRecord record4 = createCustomRecord(customSchema, "1", "Dexter", 4000L, false);
+    BufferedRecord<IndexedRecord> bufferedRecord4 = new BufferedRecord<>("1", 4000L, record4, 0, null);
+
+    // Custom merger applies a reverse ordering so the earliest record is kept
+    BufferedRecord<IndexedRecord> result = merger.finalMerge(bufferedRecord1, bufferedRecord2);
+    assertEquals(bufferedRecord1, result);
+    assertFalse(result.isDelete());
+    result = merger.finalMerge(bufferedRecord2, bufferedRecord3);
+    assertEquals(bufferedRecord2, result);
+    assertFalse(result.isDelete());
+    result = merger.finalMerge(bufferedRecord3, bufferedRecord4);
+    assertEquals(bufferedRecord3, result);
+    assertTrue(result.isDelete());
+    // flip ordering with delete to ensure behavior is consistent
+    result = merger.finalMerge(bufferedRecord4, bufferedRecord3);
+    assertEquals(bufferedRecord3, result);
+    assertTrue(result.isDelete());
+
+    // Validate delta merge
+    Option<BufferedRecord<IndexedRecord>> deltaMergeResult = merger.deltaMerge(bufferedRecord1, bufferedRecord2);
+    assertTrue(deltaMergeResult.isPresent());
+    assertEquals(bufferedRecord1, deltaMergeResult.get());
+    assertFalse(deltaMergeResult.get().isDelete());
+    deltaMergeResult = merger.deltaMerge(bufferedRecord2, bufferedRecord3);
+    assertTrue(deltaMergeResult.isPresent());
+    assertEquals(bufferedRecord2, deltaMergeResult.get());
+    assertFalse(deltaMergeResult.get().isDelete());
+    deltaMergeResult = merger.deltaMerge(bufferedRecord3, bufferedRecord4);
+    assertTrue(deltaMergeResult.isPresent());
+    assertEquals(bufferedRecord3, deltaMergeResult.get());
+    assertTrue(deltaMergeResult.get().isDelete());
+    // flip ordering and expect empty option
+    assertTrue(merger.deltaMerge(bufferedRecord4, bufferedRecord3).isEmpty());
+    assertTrue(merger.deltaMerge(bufferedRecord3, bufferedRecord2).isEmpty());
+    assertTrue(merger.deltaMerge(bufferedRecord2, bufferedRecord1).isEmpty());
+
+    // Validate merge with delete records
+    DeleteRecord deleteRecordWithHigherOrderValue = DeleteRecord.create("1", "anyPath", 5000L);
+    DeleteRecord deleteRecordWithLowerOrderValue = DeleteRecord.create("1", "anyPath", 1000L);
+    Option<DeleteRecord> deleteResult = merger.deltaMerge(deleteRecordWithHigherOrderValue, bufferedRecord2);
+    // delete is skipped because custom merger prefers lower ordering value
+    assertFalse(deleteResult.isPresent());
+    deleteResult = merger.deltaMerge(deleteRecordWithLowerOrderValue, bufferedRecord2);
+    // delete is applied because lower ordering value is preferred
+    assertTrue(deleteResult.isPresent());
+    assertEquals(deleteRecordWithLowerOrderValue, deleteResult.get());
+  }
+
+  private static GenericRecord createCustomRecord(Schema customSchema, String id, String name, long timestamp, boolean isDelete) {
+    GenericRecord record = new GenericData.Record(customSchema);
+    record.put("id", id);
+    record.put("name", name);
+    record.put("timestamp", timestamp);
+    record.put("_hoodie_is_deleted", isDelete);
+    return record;
   }
 
   // ============================================================================

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/CustomMerger.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/CustomMerger.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordMerger;
+import org.apache.hudi.common.util.collection.Pair;
+
+import org.apache.avro.Schema;
+
+import java.io.IOException;
+import java.util.UUID;
+
+public class CustomMerger implements HoodieRecordMerger {
+  private static final String STRATEGY_ID = UUID.randomUUID().toString();
+
+  public static String getStrategyId() {
+    return STRATEGY_ID;
+  }
+
+  @Override
+  public Pair<HoodieRecord, Schema> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException {
+    Long olderTimestamp = (Long) older.getOrderingValue(oldSchema, props, new String[0]);
+    Long newerTimestamp = (Long) newer.getOrderingValue(oldSchema, props, new String[0]);
+    if (olderTimestamp.equals(newerTimestamp)) {
+      // If the timestamps are the same, we do not update
+      return Pair.of(older, oldSchema);
+    } else if (olderTimestamp < newerTimestamp) {
+      // Custom merger chooses record with lower ordering value
+      return Pair.of(older, oldSchema);
+    } else {
+      // Custom merger chooses record with lower ordering value
+      return Pair.of(newer, newSchema);
+    }
+  }
+
+  @Override
+  public HoodieRecord.HoodieRecordType getRecordType() {
+    return HoodieRecord.HoodieRecordType.AVRO;
+  }
+
+  @Override
+  public String getMergingStrategy() {
+    return STRATEGY_ID;
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/CustomPayload.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/CustomPayload.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io;
+
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.util.Option;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+
+import java.io.IOException;
+
+public class CustomPayload implements HoodieRecordPayload<CustomPayload> {
+  private final GenericRecord record;
+  private final Comparable orderingValue;
+
+  public CustomPayload(GenericRecord record, Comparable orderingValue) {
+    this.record = record;
+    this.orderingValue = orderingValue;
+  }
+
+  @Override
+  public CustomPayload preCombine(CustomPayload other) {
+    return this; // No-op for this test
+  }
+
+  @Override
+  public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema) {
+    Long olderTimestamp = (Long) ((GenericRecord) currentValue).get("timestamp");
+    Long newerTimestamp = orderingValue == null ? (Long) record.get("timestamp") : (Long) orderingValue;
+    if (olderTimestamp.equals(newerTimestamp)) {
+      // If the timestamps are the same, we do not update
+      return handleDeleteRecord(currentValue);
+    } else if (olderTimestamp < newerTimestamp) {
+      // Custom merger chooses record with lower ordering value
+      return handleDeleteRecord(currentValue);
+    } else {
+      // Custom merger chooses record with lower ordering value
+      return handleDeleteRecord(record);
+    }
+  }
+
+  private Option<IndexedRecord> handleDeleteRecord(IndexedRecord data) {
+    // check for _hoodie_is_deleted field
+    boolean isDeleted = data == null || (boolean) ((GenericRecord) data).get(HoodieRecord.HOODIE_IS_DELETED_FIELD);
+    if (isDeleted) {
+      return Option.empty(); // If the record is marked as deleted, return empty
+    }
+    return Option.of(data);
+  }
+
+  @Override
+  public Option<IndexedRecord> getInsertValue(Schema schema) throws IOException {
+    return Option.ofNullable(record);
+  }
+
+  @Override
+  public Comparable getOrderingValue() {
+    return orderingValue;
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/TestMergeHandle.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/TestMergeHandle.java
@@ -37,7 +37,6 @@ import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordDelegate;
 import org.apache.hudi.common.model.HoodieRecordLocation;
-import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.OverwriteWithLatestAvroPayload;
@@ -83,7 +82,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -501,13 +499,14 @@ public class TestMergeHandle extends BaseTestHandle {
     recordsToDelete.add(deleteRecordSameOrderingValue);
     recordsToDelete.add(deleteRecordLowerOrderingValue);
     recordsToDelete.add(deleteRecordHigherOrderingValue);
+    // Custom merger chooses record with lower ordering value
+    if (!mergeMode.equals("CUSTOM_MERGER") && !mergeMode.equals("CUSTOM")) {
+      validDeletes.put(deleteRecordSameOrderingValue.getRecordKey(), deleteRecordSameOrderingValue);
+      validDeletes.put(deleteRecordHigherOrderingValue.getRecordKey(), deleteRecordHigherOrderingValue);
+      expectedDeletes += 2;
+    }
 
-    // Known Gap HUDI-9715: Currently the ordering provided by the custom mergers does not apply deletes.
-    validDeletes.put(deleteRecordSameOrderingValue.getRecordKey(), deleteRecordSameOrderingValue);
-    validDeletes.put(deleteRecordHigherOrderingValue.getRecordKey(), deleteRecordHigherOrderingValue);
-    expectedDeletes += 2;
-
-    if (mergeMode.equals(RecordMergeMode.COMMIT_TIME_ORDERING.name())) {
+    if (!mergeMode.equals(RecordMergeMode.EVENT_TIME_ORDERING.name())) {
       validDeletes.put(deleteRecordLowerOrderingValue.getRecordKey(), deleteRecordLowerOrderingValue);
       expectedDeletes += 1;
     }
@@ -671,76 +670,6 @@ public class TestMergeHandle extends BaseTestHandle {
 
     public Map<String, HoodieRecord> getValidDeletes() {
       return validDeletes;
-    }
-  }
-
-  public static class CustomMerger implements HoodieRecordMerger {
-    private static final String STRATEGY_ID = UUID.randomUUID().toString();
-
-    public static String getStrategyId() {
-      return STRATEGY_ID;
-    }
-
-    @Override
-    public Option<Pair<HoodieRecord, Schema>> merge(HoodieRecord older, Schema oldSchema, HoodieRecord newer, Schema newSchema, TypedProperties props) throws IOException {
-      GenericRecord olderData = (GenericRecord) older.getData();
-      GenericRecord newerData = (GenericRecord) newer.getData();
-      Long olderTimestamp = (Long) olderData.get("timestamp");
-      Long newerTimestamp = (Long) newerData.get("timestamp");
-      if (olderTimestamp.equals(newerTimestamp)) {
-        // If the timestamps are the same, we do not update
-        return Option.of(Pair.of(older, oldSchema));
-      } else if (olderTimestamp < newerTimestamp) {
-        // Custom merger chooses record with lower ordering value
-        return Option.of(Pair.of(older, oldSchema));
-      } else {
-        // Custom merger chooses record with lower ordering value
-        return Option.of(Pair.of(newer, newSchema));
-      }
-    }
-
-    @Override
-    public HoodieRecord.HoodieRecordType getRecordType() {
-      return HoodieRecord.HoodieRecordType.AVRO;
-    }
-
-    @Override
-    public String getMergingStrategy() {
-      return STRATEGY_ID;
-    }
-  }
-
-  public static class CustomPayload implements HoodieRecordPayload<CustomPayload> {
-    private final GenericRecord record;
-
-    public CustomPayload(GenericRecord record, Comparable orderingValue) {
-      this.record = record;
-    }
-
-    @Override
-    public CustomPayload preCombine(CustomPayload other) {
-      return this; // No-op for this test
-    }
-
-    @Override
-    public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema) throws IOException {
-      Long olderTimestamp = (Long) ((GenericRecord) currentValue).get("timestamp");
-      Long newerTimestamp = (Long) record.get("timestamp");
-      if (olderTimestamp.equals(newerTimestamp)) {
-        // If the timestamps are the same, we do not update
-        return Option.of(currentValue);
-      } else if (olderTimestamp < newerTimestamp) {
-        // Custom merger chooses record with lower ordering value
-        return Option.of(currentValue);
-      } else {
-        // Custom merger chooses record with lower ordering value
-        return Option.of(record);
-      }
-    }
-
-    @Override
-    public Option<IndexedRecord> getInsertValue(Schema schema) throws IOException {
-      return Option.of(record);
     }
   }
 }


### PR DESCRIPTION
### Change Logs

review 13742

### Impact

review 13742

### Risk level (write none, low medium or high below)

_If medium or high, explain what verification was done to mitigate the risks._

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Ordering value now propagates across records, enabling consistent merge ordering.
  - Added utilities to convert engine-native types back to Java types (Flink/Spark/Hive).
  - Explicit tombstone records improve delete representation in merges.
- Refactor
  - Standardized merge APIs to return direct results (no optionals) across engines; update integrations accordingly.
  - Simplified write/update and CDC paths for better consistency.
- Bug Fixes
  - More reliable delete detection and CDC logging.
  - Improved secondary index tracking and schema handling during merges.
- Tests
  - Expanded coverage for custom merge strategies and partial updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->