### PR TITLE
review 864

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/queue/DisruptorMessageQueue.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/queue/DisruptorMessageQueue.java
@@ -132,17 +132,24 @@ public class DisruptorMessageQueue<I, O> implements HoodieMessageQueue<I, O> {
     }
   }
 
-  protected void setHandlers(HoodieConsumer<O, ?> consumer) {
+  /**
+   * Sets the consumer handler for this queue.
+   */
+  public void setHandlers(HoodieConsumer<O, ?> consumer) {
     queue.handleEventsWith((event, sequence, endOfBatch) -> {
       try {
         consumer.consume(event.get());
       } catch (Exception e) {
         LOG.error("Failed consuming records", e);
+        markAsFailed(e);
       }
     });
   }
 
-  protected void start() {
+  /**
+   * Starts the disruptor queue.
+   */
+  public void start() {
     synchronized (this) {
       if (!isStarted) {
         queue.start();

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -657,24 +657,51 @@ public class FlinkOptions extends HoodieConfig {
       .key("write.buffer.sort.enabled")
       .booleanType()
       .defaultValue(false) // default no sort
-      .withDescription("Whether to enable buffer sort within append write function. Data is sorted within the buffer configured by number of records or buffer size."
-          + " The order of entire parquet file is not guaranteed.");
+      .withDescription("Deprecated: use write.buffer.type=DISRUPTOR instead. "
+          + "Whether to enable buffer sort within append write function. "
+          + "The order of entire written file is not guaranteed.");
 
   @AdvancedConfig
   public static final ConfigOption<String> WRITE_BUFFER_SORT_KEYS = ConfigOptions
       .key("write.buffer.sort.keys")
       .stringType()
       .noDefaultValue() // default no sort key
-      .withDescription("Sort keys concatenated by comma for buffer sort in append write function. Data is sorted within the buffer configured by number of records or buffer size."
-          + " The order of entire parquet file is not guaranteed.");
+      .withDescription("Sort keys concatenated by comma for buffer sort in append write function. "
+          + "Data is sorted within the buffer configured by number of records or buffer size. "
+          + "The order of entire written file is not guaranteed.");
 
   @AdvancedConfig
   public static final ConfigOption<Long> WRITE_BUFFER_SIZE = ConfigOptions
       .key("write.buffer.size")
       .longType()
       .defaultValue(1000L) // 1000 records
-      .withDescription("Buffer size of each partition key for buffer sort in append write function. Data is sorted within the buffer configured by number of records."
-          +  " The order of entire parquet file is not guaranteed.");
+      .withDescription("Record count threshold for flushing the sort buffer in append write function. "
+          + "When buffer reaches this count, it is sorted and written. "
+          + "The order of entire written file is not guaranteed.");
+
+  @AdvancedConfig
+  public static final ConfigOption<String> WRITE_BUFFER_TYPE = ConfigOptions
+      .key("write.buffer.type")
+      .stringType()
+      .defaultValue("NONE")
+      .withDescription("Buffer type for append write function: "
+          + "NONE (no buffer sort, default), "
+          + "BOUNDED_IN_MEMORY (double buffer with async write), "
+          + "DISRUPTOR (ring buffer with async write, recommended for better throughput)");
+
+  @AdvancedConfig
+  public static final ConfigOption<Integer> WRITE_BUFFER_DISRUPTOR_RING_SIZE = ConfigOptions
+      .key("write.buffer.disruptor.ring.size")
+      .intType()
+      .defaultValue(16384)
+      .withDescription("Ring buffer size for Disruptor (must be power of 2), default 16384");
+
+  @AdvancedConfig
+  public static final ConfigOption<String> WRITE_BUFFER_DISRUPTOR_WAIT_STRATEGY = ConfigOptions
+      .key("write.buffer.disruptor.wait.strategy")
+      .stringType()
+      .defaultValue("BLOCKING_WAIT")
+      .withDescription("Wait strategy for Disruptor: BLOCKING_WAIT (default), SLEEPING_WAIT, YIELDING_WAIT, BUSY_SPIN_WAIT");
 
   @AdvancedConfig
   public static final ConfigOption<Long> WRITE_RATE_LIMIT = ConfigOptions

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunction.java
@@ -19,8 +19,8 @@
 package org.apache.hudi.sink.append;
 
 import org.apache.hudi.client.WriteStatus;
-
 import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.sink.buffer.BufferType;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.metrics.FlinkStreamWriteMetrics;
@@ -51,6 +51,7 @@ import java.util.Map;
  *
  * @param <I> Type of the input record
  * @see StreamWriteOperatorCoordinator
+ * @see BufferType#NONE
  */
 @Slf4j
 public class AppendWriteFunction<I> extends AbstractStreamWriteFunction<I> {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunctionWithBIMBufferSort.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunctionWithBIMBufferSort.java
@@ -18,10 +18,12 @@
 
 package org.apache.hudi.sink.append;
 
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.sink.StreamWriteOperatorCoordinator;
+import org.apache.hudi.sink.buffer.BufferType;
 import org.apache.hudi.sink.buffer.MemorySegmentPoolFactory;
 import org.apache.hudi.sink.bulk.sort.SortOperatorGen;
 import org.apache.hudi.sink.utils.BufferUtils;
@@ -39,8 +41,6 @@ import org.apache.flink.table.runtime.operators.sort.BinaryInMemorySortBuffer;
 import org.apache.flink.table.runtime.util.MemorySegmentPool;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Collector;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -54,18 +54,21 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 /**
- * Sink function to write the data to the underneath filesystem with buffer sort
+ * Sink function to write the data to the underneath filesystem with bounded in-memory buffer sort
  * to improve the parquet compression rate.
  *
+ * <p>Uses a pair of buffers where one accumulates records while the other is being sorted and
+ * written asynchronously.
+ *
  * <p>The function writes base files directly for each checkpoint,
- * the file may roll over when it’s size hits the configured threshold.
+ * the file may roll over when its size hits the configured threshold.
  *
  * @param <T> Type of the input record
  * @see StreamWriteOperatorCoordinator
+ * @see BufferType#BOUNDED_IN_MEMORY
  */
 @Slf4j
-public class AppendWriteFunctionWithBufferSort<T> extends AppendWriteFunction<T> {
-  private static final Logger LOG = LoggerFactory.getLogger(AppendWriteFunctionWithBufferSort.class);
+public class AppendWriteFunctionWithBIMBufferSort<T> extends AppendWriteFunction<T> {
 
   private final long writeBufferSize;
   private transient BinaryInMemorySortBuffer activeBuffer;
@@ -74,7 +77,7 @@ public class AppendWriteFunctionWithBufferSort<T> extends AppendWriteFunction<T>
   private transient AtomicReference<CompletableFuture<Void>> asyncWriteTask;
   private transient AtomicBoolean isBackgroundBufferBeingProcessed;
 
-  public AppendWriteFunctionWithBufferSort(Configuration config, RowType rowType) {
+  public AppendWriteFunctionWithBIMBufferSort(Configuration config, RowType rowType) {
     super(config, rowType);
     this.writeBufferSize = config.get(FlinkOptions.WRITE_BUFFER_SIZE);
   }
@@ -82,11 +85,17 @@ public class AppendWriteFunctionWithBufferSort<T> extends AppendWriteFunction<T>
   @Override
   public void open(Configuration parameters) throws Exception {
     super.open(parameters);
-    String sortKeys = config.get(FlinkOptions.WRITE_BUFFER_SORT_KEYS);
-    if (sortKeys == null) {
-      throw new IllegalArgumentException("Sort keys can't be null for append write with buffer sort.");
+
+    // Resolve sort keys (defaults to record key if not specified)
+    String sortKeys = AppendWriteFunctions.resolveSortKeys(config);
+    if (StringUtils.isNullOrEmpty(sortKeys)) {
+      throw new IllegalArgumentException("Sort keys can't be null or empty for append write with buffer sort. "
+          + "Either set write.buffer.sort.keys or ensure record key field is configured.");
     }
-    List<String> sortKeyList = Arrays.stream(sortKeys.split(",")).map(key -> key.trim()).collect(Collectors.toList());
+
+    List<String> sortKeyList = Arrays.stream(sortKeys.split(","))
+        .map(String::trim)
+        .collect(Collectors.toList());
     SortOperatorGen sortOperatorGen = new SortOperatorGen(rowType, sortKeyList.toArray(new String[0]));
     SortCodeGenerator codeGenerator = sortOperatorGen.createSortCodeGenerator();
     GeneratedNormalizedKeyComputer keyComputer = codeGenerator.generateNormalizedKeyComputer("SortComputer");
@@ -94,13 +103,13 @@ public class AppendWriteFunctionWithBufferSort<T> extends AppendWriteFunction<T>
     MemorySegmentPool memorySegmentPool = MemorySegmentPoolFactory.createMemorySegmentPool(config);
 
     this.activeBuffer = BufferUtils.createBuffer(rowType,
-            memorySegmentPool,
-            keyComputer.newInstance(Thread.currentThread().getContextClassLoader()),
-            recordComparator.newInstance(Thread.currentThread().getContextClassLoader()));
+        memorySegmentPool,
+        keyComputer.newInstance(Thread.currentThread().getContextClassLoader()),
+        recordComparator.newInstance(Thread.currentThread().getContextClassLoader()));
     this.backgroundBuffer = BufferUtils.createBuffer(rowType,
-            memorySegmentPool,
-            keyComputer.newInstance(Thread.currentThread().getContextClassLoader()),
-            recordComparator.newInstance(Thread.currentThread().getContextClassLoader()));
+        memorySegmentPool,
+        keyComputer.newInstance(Thread.currentThread().getContextClassLoader()),
+        recordComparator.newInstance(Thread.currentThread().getContextClassLoader()));
 
     this.asyncWriteExecutor = Executors.newSingleThreadExecutor(r -> {
       Thread t = new Thread(r, "async-write-thread");
@@ -110,7 +119,8 @@ public class AppendWriteFunctionWithBufferSort<T> extends AppendWriteFunction<T>
     this.asyncWriteTask = new AtomicReference<>(null);
     this.isBackgroundBufferBeingProcessed = new AtomicBoolean(false);
 
-    LOG.info("{} is initialized successfully with double buffer.", getClass().getSimpleName());
+    log.info("{} initialized with bounded in-memory buffer, sort keys: {}",
+        getClass().getSimpleName(), sortKeys);
   }
 
   @Override
@@ -173,7 +183,7 @@ public class AppendWriteFunctionWithBufferSort<T> extends AppendWriteFunction<T>
         try {
           sortAndSend(backgroundBuffer);
         } catch (IOException e) {
-          LOG.error("Error during async write", e);
+          log.error("Error during async write", e);
           throw new RuntimeException(e);
         } finally {
           isBackgroundBufferBeingProcessed.set(false);
@@ -196,7 +206,7 @@ public class AppendWriteFunctionWithBufferSort<T> extends AppendWriteFunction<T>
         }
       }
     } catch (Exception e) {
-      LOG.error("Error waiting for async write completion", e);
+      log.error("Error waiting for async write completion", e);
       throw new RuntimeException(e);
     }
   }
@@ -214,18 +224,14 @@ public class AppendWriteFunctionWithBufferSort<T> extends AppendWriteFunction<T>
     if (this.writerHelper == null) {
       initWriterHelper();
     }
-    sort(buffer);
-    Iterator<BinaryRowData> iterator =
-            new MutableIteratorWrapperIterator<>(
-                    buffer.getIterator(), () -> new BinaryRowData(rowType.getFieldCount()));
+    new QuickSort().sort(buffer);
+    Iterator<BinaryRowData> iterator = new MutableIteratorWrapperIterator<>(
+        buffer.getIterator(),
+        () -> new BinaryRowData(rowType.getFieldCount()));
     while (iterator.hasNext()) {
       writerHelper.write(iterator.next());
     }
     buffer.reset();
-  }
-
-  private static void sort(BinaryInMemorySortBuffer dataBuffer) {
-    new QuickSort().sort(dataBuffer);
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunctionWithDisruptorBufferSort.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunctionWithDisruptorBufferSort.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.append;
+
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.common.util.queue.DisruptorMessageQueue;
+import org.apache.hudi.common.util.queue.HoodieConsumer;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.sink.StreamWriteOperatorCoordinator;
+import org.apache.hudi.sink.buffer.BufferType;
+import org.apache.hudi.sink.buffer.MemorySegmentPoolFactory;
+import org.apache.hudi.sink.bulk.sort.SortOperatorGen;
+import org.apache.hudi.sink.utils.BufferUtils;
+import org.apache.hudi.util.MutableIteratorWrapperIterator;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.operators.sort.QuickSort;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.planner.codegen.sort.SortCodeGenerator;
+import org.apache.flink.table.runtime.generated.GeneratedNormalizedKeyComputer;
+import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
+import org.apache.flink.table.runtime.operators.sort.BinaryInMemorySortBuffer;
+import org.apache.flink.table.runtime.util.MemorySegmentPool;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.Collector;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Sink function to write the data to the underneath filesystem using LMAX Disruptor
+ * as a lock-free ring buffer for better throughput.
+ *
+ * <p>Uses Flink's native {@link BinaryInMemorySortBuffer} with code-generated comparators
+ * for efficient sorting.
+ *
+ * <p>The function writes base files directly for each checkpoint,
+ * the file may roll over when its size hits the configured threshold.
+ *
+ * @param <T> Type of the input record
+ * @see StreamWriteOperatorCoordinator
+ * @see BufferType#DISRUPTOR
+ */
+@Slf4j
+public class AppendWriteFunctionWithDisruptorBufferSort<T> extends AppendWriteFunction<T> {
+
+  // writeBufferSize: record count threshold for flushing sort buffer to disk
+  private final long writeBufferSize;
+  // ringBufferSize: Disruptor ring buffer capacity (queue between producer and consumer threads)
+  private final int ringBufferSize;
+  private final String waitStrategy;
+
+  private transient MemorySegmentPool memorySegmentPool;
+  private transient GeneratedNormalizedKeyComputer keyComputer;
+  private transient GeneratedRecordComparator recordComparator;
+  private transient DisruptorMessageQueue<RowData, RowData> disruptorQueue;
+  private transient BinaryInMemorySortBuffer sortBuffer;
+  private transient SortingConsumer sortingConsumer;
+
+  public AppendWriteFunctionWithDisruptorBufferSort(Configuration config, RowType rowType) {
+    super(config, rowType);
+    this.writeBufferSize = config.get(FlinkOptions.WRITE_BUFFER_SIZE);
+    this.ringBufferSize = config.get(FlinkOptions.WRITE_BUFFER_DISRUPTOR_RING_SIZE);
+    this.waitStrategy = config.get(FlinkOptions.WRITE_BUFFER_DISRUPTOR_WAIT_STRATEGY);
+  }
+
+  @Override
+  public void open(Configuration parameters) throws Exception {
+    super.open(parameters);
+
+    // Resolve sort keys (defaults to record key if not specified)
+    String sortKeys = AppendWriteFunctions.resolveSortKeys(config);
+    if (StringUtils.isNullOrEmpty(sortKeys)) {
+      throw new IllegalArgumentException("Sort keys can't be null or empty for append write with disruptor sort. "
+          + "Either set write.buffer.sort.keys or ensure record key field is configured.");
+    }
+
+    List<String> sortKeyList = Arrays.stream(sortKeys.split(","))
+        .map(String::trim)
+        .collect(Collectors.toList());
+
+    // Create Flink-native sort components
+    SortOperatorGen sortOperatorGen = new SortOperatorGen(rowType, sortKeyList.toArray(new String[0]));
+    SortCodeGenerator codeGenerator = sortOperatorGen.createSortCodeGenerator();
+    this.keyComputer = codeGenerator.generateNormalizedKeyComputer("SortComputer");
+    this.recordComparator = codeGenerator.generateRecordComparator("SortComparator");
+    this.memorySegmentPool = MemorySegmentPoolFactory.createMemorySegmentPool(config);
+
+    initDisruptorBuffer();
+
+    log.info("{} initialized with disruptor buffer, sort keys: {}, ring size: {}",
+        getClass().getSimpleName(), sortKeys, ringBufferSize);
+  }
+
+  private void initDisruptorBuffer() throws Exception {
+    this.sortBuffer = BufferUtils.createBuffer(rowType,
+        memorySegmentPool,
+        keyComputer.newInstance(Thread.currentThread().getContextClassLoader()),
+        recordComparator.newInstance(Thread.currentThread().getContextClassLoader()));
+
+    this.sortingConsumer = new SortingConsumer();
+
+    this.disruptorQueue = new DisruptorMessageQueue<>(
+        ringBufferSize,
+        Function.identity(),
+        waitStrategy,
+        1,  // single producer (Flink operator thread)
+        null
+    );
+    disruptorQueue.setHandlers(sortingConsumer);
+    disruptorQueue.start();
+  }
+
+  @Override
+  public void processElement(T value, Context ctx, Collector<RowData> out) throws Exception {
+    disruptorQueue.insertRecord((RowData) value);
+  }
+
+  @Override
+  public void snapshotState() {
+    try {
+      flushDisruptor();
+      reinitDisruptorAfterCheckpoint();
+    } catch (Exception e) {
+      throw new HoodieException("Fail to flush data during snapshot state.", e);
+    }
+    super.snapshotState();
+  }
+
+  @Override
+  public void endInput() {
+    try {
+      flushDisruptor();
+    } catch (Exception e) {
+      throw new HoodieException("Fail to flush data during endInput.", e);
+    }
+    super.endInput();
+  }
+
+  private void flushDisruptor() {
+    disruptorQueue.close();
+    // Check if any errors occurred during event processing
+    Throwable error = disruptorQueue.getThrowable();
+    if (error != null) {
+      throw new HoodieException("Error processing records in disruptor buffer", error);
+    }
+    sortingConsumer.finish();
+  }
+
+  private void reinitDisruptorAfterCheckpoint() throws Exception {
+    this.sortBuffer = BufferUtils.createBuffer(rowType,
+        memorySegmentPool,
+        keyComputer.newInstance(Thread.currentThread().getContextClassLoader()),
+        recordComparator.newInstance(Thread.currentThread().getContextClassLoader()));
+
+    this.sortingConsumer = new SortingConsumer();
+
+    this.disruptorQueue = new DisruptorMessageQueue<>(
+        ringBufferSize,
+        Function.identity(),
+        waitStrategy,
+        1,
+        null
+    );
+    disruptorQueue.setHandlers(sortingConsumer);
+    disruptorQueue.start();
+  }
+
+  private void sortAndSend(BinaryInMemorySortBuffer buffer) throws IOException {
+    if (buffer.isEmpty()) {
+      return;
+    }
+    if (this.writerHelper == null) {
+      initWriterHelper();
+    }
+    new QuickSort().sort(buffer);
+    Iterator<BinaryRowData> iterator = new MutableIteratorWrapperIterator<>(
+        buffer.getIterator(),
+        () -> new BinaryRowData(rowType.getFieldCount()));
+    while (iterator.hasNext()) {
+      writerHelper.write(iterator.next());
+    }
+    buffer.reset();
+  }
+
+  @Override
+  public void close() throws Exception {
+    try {
+      if (disruptorQueue != null) {
+        disruptorQueue.close();
+      }
+    } finally {
+      super.close();
+    }
+  }
+
+  /**
+   * Consumer for disruptor buffer that uses Flink's native sorting.
+   * Accumulates records into a sort buffer and flushes when full.
+   */
+  private class SortingConsumer implements HoodieConsumer<RowData, Void> {
+
+    @Override
+    public void consume(RowData record) throws Exception {
+      boolean success = sortBuffer.write(record);
+      if (!success) {
+        flushSortBuffer();
+        success = sortBuffer.write(record);
+        if (!success) {
+          throw new HoodieException("Sort buffer is too small to hold a single record.");
+        }
+      }
+
+      if (sortBuffer.size() >= writeBufferSize) {
+        flushSortBuffer();
+      }
+    }
+
+    private void flushSortBuffer() throws IOException {
+      sortAndSend(sortBuffer);
+    }
+
+    @Override
+    public Void finish() {
+      try {
+        flushSortBuffer();
+      } catch (IOException e) {
+        throw new HoodieIOException("Failed to flush sort buffer on finish.", e);
+      }
+      return null;
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunctions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/append/AppendWriteFunctions.java
@@ -18,18 +18,25 @@
 
 package org.apache.hudi.sink.append;
 
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.sink.buffer.BufferType;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.types.logical.RowType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Utilities for {@link AppendWriteFunction} to handle rate limit if it was set.
+ * Factory utilities for creating {@link AppendWriteFunction} instances based on configuration.
+ * Handles buffer type selection, sort key resolution, and rate limiting.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public abstract class AppendWriteFunctions {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AppendWriteFunctions.class);
 
   /**
    * Creates a {@link AppendWriteFunction} instance based on the given configuration.
@@ -37,10 +44,45 @@ public abstract class AppendWriteFunctions {
   public static <I> AppendWriteFunction<I> create(Configuration conf, RowType rowType) {
     if (conf.get(FlinkOptions.WRITE_RATE_LIMIT) > 0) {
       return new AppendWriteFunctionWithRateLimit<>(rowType, conf);
-    } else if (conf.get(FlinkOptions.WRITE_BUFFER_SORT_ENABLED)) {
-      return new AppendWriteFunctionWithBufferSort<>(conf, rowType);
-    } else {
-      return new AppendWriteFunction<>(conf, rowType);
     }
+
+    String bufferType = resolveBufferType(conf);
+    if (BufferType.DISRUPTOR.name().equalsIgnoreCase(bufferType)) {
+      return new AppendWriteFunctionWithDisruptorBufferSort<>(conf, rowType);
+    } else if (BufferType.BOUNDED_IN_MEMORY.name().equalsIgnoreCase(bufferType)) {
+      return new AppendWriteFunctionWithBIMBufferSort<>(conf, rowType);
+    }
+    return new AppendWriteFunction<>(conf, rowType);
+  }
+
+  /**
+   * Resolves the buffer type from configuration, handling backward compatibility.
+   */
+  public static String resolveBufferType(Configuration conf) {
+    // New config takes precedence
+    String bufferType = conf.get(FlinkOptions.WRITE_BUFFER_TYPE);
+    if (!BufferType.NONE.name().equalsIgnoreCase(bufferType)) {
+      return bufferType;
+    }
+
+    // Backward compatibility: write.buffer.sort.enabled=true → DISRUPTOR
+    if (conf.get(FlinkOptions.WRITE_BUFFER_SORT_ENABLED)) {
+      LOG.info("write.buffer.sort.enabled is deprecated. Use write.buffer.type=DISRUPTOR instead.");
+      return BufferType.DISRUPTOR.name();
+    }
+
+    return BufferType.NONE.name();
+  }
+
+  /**
+   * Resolves sort keys from configuration, defaulting to record key field(s) if not specified.
+   */
+  public static String resolveSortKeys(Configuration conf) {
+    String sortKeys = conf.get(FlinkOptions.WRITE_BUFFER_SORT_KEYS);
+    if (StringUtils.isNullOrEmpty(sortKeys)) {
+      // Default to record key field(s)
+      return conf.get(FlinkOptions.RECORD_KEY_FIELD);
+    }
+    return sortKeys;
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/buffer/BufferType.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/buffer/BufferType.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.buffer;
+
+import org.apache.hudi.common.config.EnumDescription;
+import org.apache.hudi.common.config.EnumFieldDescription;
+
+/**
+ * Types of write buffer for buffered append write operations.
+ */
+@EnumDescription("Types of write buffer used by append write functions to buffer and sort records before writing to storage.")
+public enum BufferType {
+
+  @EnumFieldDescription("No buffering. Records are written directly without sorting.")
+  NONE,
+
+  @EnumFieldDescription("Bounded in-memory buffer with async write. Uses a pair of buffers where one accumulates "
+      + "records while the other is being sorted and written asynchronously.")
+  BOUNDED_IN_MEMORY,
+
+  @EnumFieldDescription("Lock-free ring buffer using LMAX Disruptor. Provides better throughput for high-volume "
+      + "write operations by decoupling record ingestion from sorting and writing.")
+  DISRUPTOR
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/append/ITTestAppendWriteFunctionWithBIMBufferSort.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/append/ITTestAppendWriteFunctionWithBIMBufferSort.java
@@ -1,0 +1,332 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.sink.append;
+
+import org.apache.hudi.sink.buffer.BufferType;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.sink.utils.TestWriteBase;
+import org.apache.hudi.utils.TestConfigurations;
+import org.apache.hudi.utils.TestData;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.File;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test cases for {@link AppendWriteFunctionWithBIMBufferSort} (BOUNDED_IN_MEMORY buffer type).
+ */
+public class ITTestAppendWriteFunctionWithBIMBufferSort extends TestWriteBase {
+
+  private Configuration conf;
+  private RowType rowType;
+
+  @BeforeEach
+  public void before(@TempDir File tempDir) throws Exception {
+    super.before();
+    this.conf = TestConfigurations.getDefaultConf(tempDir.getAbsolutePath());
+    this.conf.set(FlinkOptions.WRITE_BUFFER_TYPE, BufferType.BOUNDED_IN_MEMORY.name());
+    this.conf.set(FlinkOptions.OPERATION, "insert");
+    this.conf.set(FlinkOptions.WRITE_BUFFER_SORT_KEYS, "name,age");
+    this.conf.set(FlinkOptions.WRITE_BUFFER_SIZE, 100L);
+
+    List<RowType.RowField> fields = new ArrayList<>();
+    fields.add(new RowType.RowField("uuid", VarCharType.STRING_TYPE));
+    fields.add(new RowType.RowField("name", VarCharType.STRING_TYPE));
+    fields.add(new RowType.RowField("age", new IntType()));
+    fields.add(new RowType.RowField("ts", new TimestampType()));
+    fields.add(new RowType.RowField("partition", VarCharType.STRING_TYPE));
+    this.rowType = new RowType(fields);
+  }
+
+  @Test
+  public void testBufferFlushOnRecordNumberLimit() throws Exception {
+    // Create test data that exceeds buffer size (150 records > 100 buffer size)
+    List<RowData> inputData = new ArrayList<>();
+    for (int i = 0; i < 150; i++) {
+      inputData.add(createRowData("uuid" + i, "Name" + i, i, "1970-01-01 00:00:01.123", "p1"));
+    }
+
+    // Write the data
+    TestWriteBase.TestHarness.instance()
+        .preparePipeline(tempFile, conf)
+        .consume(inputData)
+        .endInput();
+
+    // Verify all data was written
+    List<GenericRecord> actualData = TestData.readAllData(new File(conf.get(FlinkOptions.PATH)), rowType, 1);
+    assertEquals(150, actualData.size());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testBufferFlush(boolean flushOnCheckpoint) throws Exception {
+    // Create test data
+    List<RowData> inputData = Arrays.asList(
+        createRowData("uuid1", "Bob", 30, "1970-01-01 00:00:01.123", "p1"),
+        createRowData("uuid1", "Alice", 25, "1970-01-01 00:00:01.124", "p1")
+    );
+
+    // Write the data and flush either on checkpoint or endInput
+    TestHarness testHarness =
+        TestWriteBase.TestHarness.instance()
+            .preparePipeline(tempFile, conf)
+            .consume(inputData);
+    if (flushOnCheckpoint) {
+      testHarness.checkpoint(1);
+    } else {
+      testHarness.endInput();
+    }
+
+    // Verify all data was written
+    List<GenericRecord> actualData = TestData.readAllData(new File(conf.get(FlinkOptions.PATH)), rowType, 1);
+    assertEquals(2, actualData.size());
+  }
+
+  @Test
+  public void testBufferFlushOnBufferSizeLimit() throws Exception {
+    // Configure large record count limit but small memory limit to trigger memory-based flush
+    this.conf.set(FlinkOptions.WRITE_BUFFER_SIZE, 10000L);
+    this.conf.set(FlinkOptions.WRITE_TASK_MAX_SIZE, 400.1D);
+
+    // Create large dataset
+    List<RowData> inputData = new ArrayList<>();
+    for (int i = 0; i < 2000; i++) {
+      inputData.add(createRowData("uuid" + i, "Name" + i, i, "1970-01-01 00:00:01.123", "p1"));
+    }
+
+    // Write the data
+    TestWriteBase.TestHarness.instance()
+        .preparePipeline(tempFile, conf)
+        .consume(inputData)
+        .endInput();
+
+    // Verify all data was written
+    List<GenericRecord> actualData = TestData.readAllData(new File(conf.get(FlinkOptions.PATH)), rowType, 1);
+    assertEquals(2000, actualData.size());
+  }
+
+  @Test
+  public void testSortedResult() throws Exception {
+    // Create test data with unsorted records (sort keys: name, age)
+    List<RowData> inputData = Arrays.asList(
+        createRowData("uuid1", "Bob", 30, "1970-01-01 00:00:01.123", "p1"),
+        createRowData("uuid1", "Alice", 25, "1970-01-01 00:00:01.124", "p1"),
+        createRowData("uuid1", "Bob", 21, "1970-01-01 00:00:31.124", "p1")
+    );
+
+    // Expected order after sorting by name, then age
+    List<String> expected = Arrays.asList(
+        "uuid1,Alice,25,1970-01-01 00:00:01.124,p1",
+        "uuid1,Bob,21,1970-01-01 00:00:31.124,p1",
+        "uuid1,Bob,30,1970-01-01 00:00:01.123,p1");
+
+    // Write the data
+    TestWriteBase.TestHarness.instance()
+        .preparePipeline(tempFile, conf)
+        .consume(inputData)
+        .checkpoint(1)
+        .endInput();
+
+    // Verify data is sorted correctly
+    List<GenericRecord> result = TestData.readAllData(new File(conf.get(FlinkOptions.PATH)), rowType, 1);
+    assertEquals(3, result.size());
+
+    List<String> filteredResult =
+        result.stream().map(TestData::filterOutVariablesWithoutHudiMetadata).collect(Collectors.toList());
+
+    assertArrayEquals(expected.toArray(), filteredResult.toArray());
+  }
+
+  @Test
+  public void testMultipleCheckpoints() throws Exception {
+    // Create first batch of test data
+    List<RowData> batch1 = Arrays.asList(
+        createRowData("uuid1", "Charlie", 35, "1970-01-01 00:00:01.123", "p1"),
+        createRowData("uuid2", "Alice", 25, "1970-01-01 00:00:01.124", "p1")
+    );
+
+    // Create second batch of test data
+    List<RowData> batch2 = Arrays.asList(
+        createRowData("uuid3", "Bob", 30, "1970-01-01 00:00:01.125", "p1"),
+        createRowData("uuid4", "Diana", 28, "1970-01-01 00:00:01.126", "p1")
+    );
+
+    // Write batches with checkpoints between them
+    TestHarness testHarness = TestWriteBase.TestHarness.instance()
+        .preparePipeline(tempFile, conf);
+
+    testHarness.consume(batch1).checkpoint(1);
+    testHarness.consume(batch2).checkpoint(2);
+    testHarness.endInput();
+
+    // Verify all data from both batches was written
+    List<GenericRecord> actualData = TestData.readAllData(new File(conf.get(FlinkOptions.PATH)), rowType, 1);
+    assertEquals(4, actualData.size());
+  }
+
+  @Test
+  public void testLargeDatasetWithMultipleFlushes() throws Exception {
+    // Configure small buffer to force multiple flushes
+    this.conf.set(FlinkOptions.WRITE_BUFFER_SIZE, 50L);
+
+    // Create large dataset across multiple partitions
+    List<RowData> inputData = new ArrayList<>();
+    for (int i = 0; i < 500; i++) {
+      inputData.add(createRowData("uuid" + i, "Name" + (i % 10), i % 100, "1970-01-01 00:00:01.123", "p" + (i % 3)));
+    }
+
+    // Write the data
+    TestWriteBase.TestHarness.instance()
+        .preparePipeline(tempFile, conf)
+        .consume(inputData)
+        .endInput();
+
+    // Verify all data was written across all partitions
+    List<GenericRecord> actualData = TestData.readAllData(new File(conf.get(FlinkOptions.PATH)), rowType, 3);
+    assertEquals(500, actualData.size());
+  }
+
+  @Test
+  public void testSortStabilityWithDuplicateKeys() throws Exception {
+    // Create test data with duplicate sort keys (same name and age for first 3 records)
+    List<RowData> inputData = Arrays.asList(
+        createRowData("uuid1", "Alice", 25, "1970-01-01 00:00:01.123", "p1"),
+        createRowData("uuid2", "Alice", 25, "1970-01-01 00:00:01.124", "p1"),
+        createRowData("uuid3", "Alice", 25, "1970-01-01 00:00:01.125", "p1"),
+        createRowData("uuid4", "Bob", 30, "1970-01-01 00:00:01.126", "p1")
+    );
+
+    // Write the data
+    TestWriteBase.TestHarness.instance()
+        .preparePipeline(tempFile, conf)
+        .consume(inputData)
+        .endInput();
+
+    // Verify all data was written and sorted (Alice records before Bob)
+    List<GenericRecord> actualData = TestData.readAllData(new File(conf.get(FlinkOptions.PATH)), rowType, 1);
+    assertEquals(4, actualData.size());
+
+    List<String> filteredResult = actualData.stream()
+        .map(TestData::filterOutVariablesWithoutHudiMetadata)
+        .collect(Collectors.toList());
+
+    assertTrue(filteredResult.get(0).contains("Alice"));
+    assertTrue(filteredResult.get(1).contains("Alice"));
+    assertTrue(filteredResult.get(2).contains("Alice"));
+    assertTrue(filteredResult.get(3).contains("Bob"));
+  }
+
+  @Test
+  public void testDifferentPartitions() throws Exception {
+    // Create test data across different partitions
+    List<RowData> inputData = Arrays.asList(
+        createRowData("uuid1", "Alice", 25, "1970-01-01 00:00:01.123", "p1"),
+        createRowData("uuid2", "Bob", 30, "1970-01-01 00:00:01.124", "p2"),
+        createRowData("uuid3", "Charlie", 35, "1970-01-01 00:00:01.125", "p3"),
+        createRowData("uuid4", "Diana", 28, "1970-01-01 00:00:01.126", "p1")
+    );
+
+    // Write the data
+    TestWriteBase.TestHarness.instance()
+        .preparePipeline(tempFile, conf)
+        .consume(inputData)
+        .endInput();
+
+    // Verify all data was written across all partitions
+    List<GenericRecord> actualData = TestData.readAllData(new File(conf.get(FlinkOptions.PATH)), rowType, 3);
+    assertEquals(4, actualData.size());
+  }
+
+  @Test
+  public void testConcurrentWriteScenario() throws Exception {
+    // Configure small buffer to trigger frequent async writes
+    this.conf.set(FlinkOptions.WRITE_BUFFER_SIZE, 20L);
+
+    // Create test data
+    List<RowData> inputData = new ArrayList<>();
+    for (int i = 0; i < 200; i++) {
+      inputData.add(createRowData("uuid" + i, "Name" + (i % 5), i % 50, "1970-01-01 00:00:01.123", "p1"));
+    }
+
+    // Write data in small batches with periodic checkpoints
+    TestHarness testHarness = TestWriteBase.TestHarness.instance()
+        .preparePipeline(tempFile, conf);
+
+    for (int i = 0; i < inputData.size(); i += 10) {
+      List<RowData> batch = inputData.subList(i, Math.min(i + 10, inputData.size()));
+      testHarness.consume(batch);
+      if (i % 50 == 0) {
+        testHarness.checkpoint(i / 50 + 1);
+      }
+    }
+    testHarness.endInput();
+
+    // Verify all data was written
+    List<GenericRecord> actualData = TestData.readAllData(new File(conf.get(FlinkOptions.PATH)), rowType, 1);
+    assertEquals(200, actualData.size());
+  }
+
+  @Test
+  public void testSortKeysDefaultToRecordKey() throws Exception {
+    // Remove explicit sort keys config
+    conf.removeConfig(FlinkOptions.WRITE_BUFFER_SORT_KEYS);
+
+    // Verify sort keys default to record key field
+    String resolvedSortKeys = AppendWriteFunctions.resolveSortKeys(conf);
+    assertEquals(conf.get(FlinkOptions.RECORD_KEY_FIELD), resolvedSortKeys);
+  }
+
+  @Test
+  public void testCustomSortKeysOverrideDefault() throws Exception {
+    // Set custom sort keys
+    conf.set(FlinkOptions.WRITE_BUFFER_SORT_KEYS, "age,name");
+
+    // Verify custom sort keys take precedence
+    String resolvedSortKeys = AppendWriteFunctions.resolveSortKeys(conf);
+    assertEquals("age,name", resolvedSortKeys);
+  }
+
+  private GenericRowData createRowData(String uuid, String name, int age, String timestamp, String partition) {
+    return GenericRowData.of(StringData.fromString(uuid), StringData.fromString(name),
+        age, TimestampData.fromTimestamp(Timestamp.valueOf(timestamp)), StringData.fromString(partition));
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/append/ITTestAppendWriteFunctionWithDisruptorBufferSort.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/append/ITTestAppendWriteFunctionWithDisruptorBufferSort.java
@@ -18,10 +18,7 @@
 
 package org.apache.hudi.sink.append;
 
-import org.apache.flink.table.types.logical.IntType;
-import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.TimestampType;
-import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.hudi.sink.buffer.BufferType;
 import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.sink.utils.TestWriteBase;
 import org.apache.hudi.utils.TestConfigurations;
@@ -33,12 +30,13 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
-
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.VarCharType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.sql.Timestamp;
@@ -52,9 +50,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Test cases for {@link AppendWriteFunctionWithBufferSort}.
+ * Test cases for {@link AppendWriteFunctionWithDisruptorBufferSort} (DISRUPTOR buffer type).
  */
-public class ITTestAppendWriteFunctionWithBufferSort extends TestWriteBase {
+public class ITTestAppendWriteFunctionWithDisruptorBufferSort extends TestWriteBase {
 
   private Configuration conf;
   private RowType rowType;
@@ -63,12 +61,11 @@ public class ITTestAppendWriteFunctionWithBufferSort extends TestWriteBase {
   public void before(@TempDir File tempDir) throws Exception {
     super.before();
     this.conf = TestConfigurations.getDefaultConf(tempDir.getAbsolutePath());
-    this.conf.set(FlinkOptions.WRITE_BUFFER_SORT_ENABLED, true);
+    this.conf.set(FlinkOptions.WRITE_BUFFER_TYPE, BufferType.DISRUPTOR.name());
     this.conf.set(FlinkOptions.OPERATION, "insert");
     this.conf.set(FlinkOptions.WRITE_BUFFER_SORT_KEYS, "name,age");
     this.conf.set(FlinkOptions.WRITE_BUFFER_SIZE, 100L);
 
-    // Define the row type with fields: name (STRING), age (INT), partition (STRING)
     List<RowType.RowField> fields = new ArrayList<>();
     fields.add(new RowType.RowField("uuid", VarCharType.STRING_TYPE));
     fields.add(new RowType.RowField("name", VarCharType.STRING_TYPE));
@@ -80,7 +77,9 @@ public class ITTestAppendWriteFunctionWithBufferSort extends TestWriteBase {
 
   @Test
   public void testBufferFlushOnRecordNumberLimit() throws Exception {
-    // Create test data that exceeds buffer size
+    conf.set(FlinkOptions.WRITE_BUFFER_DISRUPTOR_RING_SIZE, 1024);
+
+    // Create test data that exceeds buffer size (150 records > 100 buffer size)
     List<RowData> inputData = new ArrayList<>();
     for (int i = 0; i < 150; i++) {
       inputData.add(createRowData("uuid" + i, "Name" + i, i, "1970-01-01 00:00:01.123", "p1"));
@@ -97,98 +96,74 @@ public class ITTestAppendWriteFunctionWithBufferSort extends TestWriteBase {
     assertEquals(150, actualData.size());
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void testBufferFlush(boolean flushOnCheckpoint) throws Exception {
+  @Test
+  public void testBufferFlushOnCheckpoint() throws Exception {
     // Create test data
     List<RowData> inputData = Arrays.asList(
         createRowData("uuid1", "Bob", 30, "1970-01-01 00:00:01.123", "p1"),
-        createRowData("uuid1", "Alice", 25, "1970-01-01 00:00:01.124", "p1")
+        createRowData("uuid2", "Alice", 25, "1970-01-01 00:00:01.124", "p1")
     );
 
-    // Write the data and wait for timer
-    TestHarness testHarness =
-        TestWriteBase.TestHarness.instance()
-            .preparePipeline(tempFile, conf)
-            .consume(inputData);
-    if (flushOnCheckpoint) {
-      testHarness.checkpoint(1);
-    } else {
-      testHarness.endInput();
-    }
+    // Write the data and flush on checkpoint
+    TestWriteBase.TestHarness.instance()
+        .preparePipeline(tempFile, conf)
+        .consume(inputData)
+        .checkpoint(1)
+        .endInput();
 
-    // Verify data was written
+    // Verify all data was written
     List<GenericRecord> actualData = TestData.readAllData(new File(conf.get(FlinkOptions.PATH)), rowType, 1);
     assertEquals(2, actualData.size());
   }
 
   @Test
-  public void testBufferFlushOnBufferSizeLimit() throws Exception {
-    // enlarge the wirte buffer record size
-    this.conf.set(FlinkOptions.WRITE_BUFFER_SIZE, 10000L);
-    // use a very small buffer memory size here
-    this.conf.set(FlinkOptions.WRITE_TASK_MAX_SIZE, 400.1D);
+  public void testSortedResult() throws Exception {
+    // Create test data with unsorted records (sort keys: name, age)
+    List<RowData> inputData = Arrays.asList(
+        createRowData("uuid1", "Bob", 30, "1970-01-01 00:00:01.123", "p1"),
+        createRowData("uuid2", "Alice", 25, "1970-01-01 00:00:01.124", "p1"),
+        createRowData("uuid3", "Bob", 21, "1970-01-01 00:00:31.124", "p1")
+    );
 
-    // Create test data that exceeds buffer size
-    List<RowData> inputData = new ArrayList<>();
-    for (int i = 0; i < 2000; i++) {
-      inputData.add(createRowData("uuid" + i, "Name" + i, i, "1970-01-01 00:00:01.123", "p1"));
-    }
+    // Expected order after sorting by name, then age
+    List<String> expected = Arrays.asList(
+        "uuid2,Alice,25,1970-01-01 00:00:01.124,p1",
+        "uuid3,Bob,21,1970-01-01 00:00:31.124,p1",
+        "uuid1,Bob,30,1970-01-01 00:00:01.123,p1");
 
     // Write the data
     TestWriteBase.TestHarness.instance()
-            .preparePipeline(tempFile, conf)
-            .consume(inputData)
-            .endInput();
+        .preparePipeline(tempFile, conf)
+        .consume(inputData)
+        .checkpoint(1)
+        .endInput();
 
-    // Verify all data was written
-    List<GenericRecord> actualData = TestData.readAllData(new File(conf.get(FlinkOptions.PATH)), rowType, 1);
-    assertEquals(2000, actualData.size());
-  }
-
-  @Test
-  public void testSortedResult() throws Exception {
-    // Create test data
-    List<RowData> inputData = Arrays.asList(
-            createRowData("uuid1", "Bob", 30, "1970-01-01 00:00:01.123", "p1"),
-            createRowData("uuid1", "Alice", 25, "1970-01-01 00:00:01.124", "p1"),
-            createRowData("uuid1", "Bob", 21, "1970-01-01 00:00:31.124", "p1")
-    );
-
-    List<String> expected = Arrays.asList(
-            "uuid1,Alice,25,1970-01-01 00:00:01.124,p1",
-            "uuid1,Bob,21,1970-01-01 00:00:31.124,p1",
-            "uuid1,Bob,30,1970-01-01 00:00:01.123,p1");
-
-    // Write the data and wait for timer
-    TestWriteBase.TestHarness.instance()
-            .preparePipeline(tempFile, conf)
-            .consume(inputData)
-            .checkpoint(1)
-            .endInput();
-
-    // Verify data was written
+    // Verify data is sorted correctly
     List<GenericRecord> result = TestData.readAllData(new File(conf.get(FlinkOptions.PATH)), rowType, 1);
     assertEquals(3, result.size());
 
-    List<String> filteredResult =
-            result.stream().map(TestData::filterOutVariablesWithoutHudiMetadata).collect(Collectors.toList());
+    List<String> filteredResult = result.stream()
+        .map(TestData::filterOutVariablesWithoutHudiMetadata)
+        .collect(Collectors.toList());
 
     assertArrayEquals(expected.toArray(), filteredResult.toArray());
   }
 
   @Test
   public void testMultipleCheckpoints() throws Exception {
+    // Create first batch of test data
     List<RowData> batch1 = Arrays.asList(
         createRowData("uuid1", "Charlie", 35, "1970-01-01 00:00:01.123", "p1"),
         createRowData("uuid2", "Alice", 25, "1970-01-01 00:00:01.124", "p1")
     );
 
+    // Create second batch of test data
     List<RowData> batch2 = Arrays.asList(
         createRowData("uuid3", "Bob", 30, "1970-01-01 00:00:01.125", "p1"),
         createRowData("uuid4", "Diana", 28, "1970-01-01 00:00:01.126", "p1")
     );
 
+    // Write batches with checkpoints between them
     TestHarness testHarness = TestWriteBase.TestHarness.instance()
         .preparePipeline(tempFile, conf);
 
@@ -196,30 +171,36 @@ public class ITTestAppendWriteFunctionWithBufferSort extends TestWriteBase {
     testHarness.consume(batch2).checkpoint(2);
     testHarness.endInput();
 
+    // Verify all data from both batches was written
     List<GenericRecord> actualData = TestData.readAllData(new File(conf.get(FlinkOptions.PATH)), rowType, 1);
     assertEquals(4, actualData.size());
   }
 
   @Test
   public void testLargeDatasetWithMultipleFlushes() throws Exception {
-    this.conf.set(FlinkOptions.WRITE_BUFFER_SIZE, 50L);
+    // Configure small buffer to force multiple flushes
+    conf.set(FlinkOptions.WRITE_BUFFER_SIZE, 50L);
 
+    // Create large dataset across multiple partitions
     List<RowData> inputData = new ArrayList<>();
     for (int i = 0; i < 500; i++) {
       inputData.add(createRowData("uuid" + i, "Name" + (i % 10), i % 100, "1970-01-01 00:00:01.123", "p" + (i % 3)));
     }
 
+    // Write the data
     TestWriteBase.TestHarness.instance()
         .preparePipeline(tempFile, conf)
         .consume(inputData)
         .endInput();
 
+    // Verify all data was written across all partitions
     List<GenericRecord> actualData = TestData.readAllData(new File(conf.get(FlinkOptions.PATH)), rowType, 3);
     assertEquals(500, actualData.size());
   }
 
   @Test
   public void testSortStabilityWithDuplicateKeys() throws Exception {
+    // Create test data with duplicate sort keys (same name and age for first 3 records)
     List<RowData> inputData = Arrays.asList(
         createRowData("uuid1", "Alice", 25, "1970-01-01 00:00:01.123", "p1"),
         createRowData("uuid2", "Alice", 25, "1970-01-01 00:00:01.124", "p1"),
@@ -227,11 +208,13 @@ public class ITTestAppendWriteFunctionWithBufferSort extends TestWriteBase {
         createRowData("uuid4", "Bob", 30, "1970-01-01 00:00:01.126", "p1")
     );
 
+    // Write the data
     TestWriteBase.TestHarness.instance()
         .preparePipeline(tempFile, conf)
         .consume(inputData)
         .endInput();
 
+    // Verify all data was written and sorted (Alice records before Bob)
     List<GenericRecord> actualData = TestData.readAllData(new File(conf.get(FlinkOptions.PATH)), rowType, 1);
     assertEquals(4, actualData.size());
 
@@ -247,6 +230,7 @@ public class ITTestAppendWriteFunctionWithBufferSort extends TestWriteBase {
 
   @Test
   public void testDifferentPartitions() throws Exception {
+    // Create test data across different partitions
     List<RowData> inputData = Arrays.asList(
         createRowData("uuid1", "Alice", 25, "1970-01-01 00:00:01.123", "p1"),
         createRowData("uuid2", "Bob", 30, "1970-01-01 00:00:01.124", "p2"),
@@ -254,42 +238,55 @@ public class ITTestAppendWriteFunctionWithBufferSort extends TestWriteBase {
         createRowData("uuid4", "Diana", 28, "1970-01-01 00:00:01.126", "p1")
     );
 
+    // Write the data
     TestWriteBase.TestHarness.instance()
         .preparePipeline(tempFile, conf)
         .consume(inputData)
         .endInput();
 
+    // Verify all data was written across all partitions
     List<GenericRecord> actualData = TestData.readAllData(new File(conf.get(FlinkOptions.PATH)), rowType, 3);
     assertEquals(4, actualData.size());
   }
 
   @Test
-  public void testConcurrentWriteScenario() throws Exception {
-    this.conf.set(FlinkOptions.WRITE_BUFFER_SIZE, 20L);
+  public void testBackwardCompatibilityWithSortEnabled() throws Exception {
+    // Use deprecated write.buffer.sort.enabled=true (should resolve to DISRUPTOR)
+    conf.removeConfig(FlinkOptions.WRITE_BUFFER_TYPE);
+    conf.set(FlinkOptions.WRITE_BUFFER_SORT_ENABLED, true);
 
-    List<RowData> inputData = new ArrayList<>();
-    for (int i = 0; i < 200; i++) {
-      inputData.add(createRowData("uuid" + i, "Name" + (i % 5), i % 50, "1970-01-01 00:00:01.123", "p1"));
-    }
+    // Verify deprecated config resolves to DISRUPTOR
+    assertEquals(BufferType.DISRUPTOR.name(), AppendWriteFunctions.resolveBufferType(conf));
 
-    TestHarness testHarness = TestWriteBase.TestHarness.instance()
-        .preparePipeline(tempFile, conf);
+    // Create test data
+    List<RowData> inputData = Arrays.asList(
+        createRowData("uuid1", "Bob", 30, "1970-01-01 00:00:01.123", "p1"),
+        createRowData("uuid2", "Alice", 25, "1970-01-01 00:00:01.124", "p1")
+    );
 
-    for (int i = 0; i < inputData.size(); i += 10) {
-      List<RowData> batch = inputData.subList(i, Math.min(i + 10, inputData.size()));
-      testHarness.consume(batch);
-      if (i % 50 == 0) {
-        testHarness.checkpoint(i / 50 + 1);
-      }
-    }
-    testHarness.endInput();
+    // Write the data
+    TestWriteBase.TestHarness.instance()
+        .preparePipeline(tempFile, conf)
+        .consume(inputData)
+        .endInput();
 
+    // Verify all data was written
     List<GenericRecord> actualData = TestData.readAllData(new File(conf.get(FlinkOptions.PATH)), rowType, 1);
-    assertEquals(200, actualData.size());
+    assertEquals(2, actualData.size());
+  }
+
+  @Test
+  public void testExplicitBufferTypeTakesPrecedence() throws Exception {
+    // Set both new and deprecated config
+    conf.set(FlinkOptions.WRITE_BUFFER_TYPE, BufferType.BOUNDED_IN_MEMORY.name());
+    conf.set(FlinkOptions.WRITE_BUFFER_SORT_ENABLED, true);
+
+    // Verify explicit write.buffer.type takes precedence over deprecated write.buffer.sort.enabled
+    assertEquals(BufferType.BOUNDED_IN_MEMORY.name(), AppendWriteFunctions.resolveBufferType(conf));
   }
 
   private GenericRowData createRowData(String uuid, String name, int age, String timestamp, String partition) {
     return GenericRowData.of(StringData.fromString(uuid), StringData.fromString(name),
         age, TimestampData.fromTimestamp(Timestamp.valueOf(timestamp)), StringData.fromString(partition));
   }
-} 
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three write buffer strategies for the Flink sink: none, bounded in-memory, and lock-free Disruptor, and a Disruptor-backed sink option for higher throughput.

* **Configuration Changes**
  * New buffer-type and Disruptor tuning options (ring size, wait strategy); deprecated the old sort-enabled flag with backward-compatible resolution.

* **Bug Fixes / Robustness**
  * Improved error handling and lifecycle robustness for disruptor-based buffering.

* **Tests**
  * Added integration tests covering new buffers, sort behavior, flush triggers, checkpoints, and backward compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->