### PR TITLE
review 872

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -307,6 +307,13 @@ public class FlinkOptions extends HoodieConfig {
       .noDefaultValue()
       .withDescription("Source avro schema string, the parsed schema is used for deserialization");
 
+  @AdvancedConfig
+  public static final ConfigOption<Integer> SOURCE_READER_FETCH_BATCH_RECORD_COUNT =
+      ConfigOptions.key("source.fetch-batch-record-count")
+          .intType()
+          .defaultValue(2048)
+          .withDescription("The target number of records for Hoodie reader fetch batch.");
+
   public static final String QUERY_TYPE_SNAPSHOT = "snapshot";
   public static final String QUERY_TYPE_READ_OPTIMIZED = "read_optimized";
   public static final String QUERY_TYPE_INCREMENTAL = "incremental";

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/BatchReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/BatchReader.java
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 
-package org.apache.hudi.source.reader.function;
+package org.apache.hudi.source.reader;
 
-import org.apache.hudi.source.reader.HoodieRecordWithPosition;
+import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.source.split.HoodieSourceSplit;
 
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
@@ -27,11 +27,18 @@ import org.apache.flink.util.CloseableIterator;
 import java.io.Serializable;
 
 /**
- * Interface for split read function.
+ * Interface for batch read.
+ *
+ * @param <T> record type
  */
-public interface SplitReaderFunction<T> extends Serializable {
+public interface BatchReader<T> extends Serializable {
 
-  CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<T>>> read(HoodieSourceSplit split);
-
-  void close() throws Exception;
+  /**
+   * Read data from input iterator batch by batch
+   * @param split Hoodie source split
+   * @param inputIterator iterator for hudi reader
+   * @return iterator for batches of records
+   */
+  CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<T>>> batch(
+      HoodieSourceSplit split, ClosableIterator<T> inputIterator);
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/DefaultBatchReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/DefaultBatchReader.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source.reader;
+
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.source.split.HoodieSourceSplit;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.util.CloseableIterator;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * Default batch reader implementation.
+ *
+ * @param <T> record type
+ */
+public class DefaultBatchReader<T> implements BatchReader<T> {
+
+  private final int batchSize;
+
+  public DefaultBatchReader(Configuration configuration) {
+    this.batchSize = configuration.get(FlinkOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT);
+  }
+
+  @Override
+  public CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<T>>> batch(
+      HoodieSourceSplit split, ClosableIterator<T> inputIterator) {
+    return new ListBatchIterator(split, inputIterator);
+  }
+
+  private class ListBatchIterator implements CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<T>>> {
+    private final ClosableIterator<T> inputIterator;
+    private final HoodieSourceSplit split;
+
+    ListBatchIterator(HoodieSourceSplit split, ClosableIterator<T> inputIterator) {
+      this.inputIterator = inputIterator;
+      this.split = split;
+      seek();
+    }
+
+    @Override
+    public boolean hasNext() {
+      return inputIterator.hasNext();
+    }
+
+    @Override
+    public RecordsWithSplitIds<HoodieRecordWithPosition<T>> next() {
+      if (!inputIterator.hasNext()) {
+        throw new NoSuchElementException();
+      }
+
+      final List<T> batch = new ArrayList<>(batchSize);
+      int recordCount = 0;
+      while (inputIterator.hasNext() && recordCount < batchSize) {
+        T nextRecord = inputIterator.next();
+        split.consume();
+        batch.add(nextRecord);
+        recordCount++;
+      }
+
+      return BatchRecords.forRecords(
+          split.splitId(), ClosableIterator.wrap(batch.iterator()), split.getFileOffset(), split.getConsumed() - recordCount);
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (inputIterator != null) {
+        inputIterator.close();
+      }
+    }
+
+    private void seek() {
+      for (long i = 0; i < split.getConsumed(); ++i) {
+        if (inputIterator.hasNext()) {
+          inputIterator.next();
+        } else {
+          throw new IllegalStateException(
+              String.format(
+                  "Invalid starting record offset %d for split %s",
+                  split.getConsumed(),
+                  split.splitId()));
+        }
+      }
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/HoodieSourceSplitReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/HoodieSourceSplitReader.java
@@ -24,6 +24,7 @@ import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
+import org.apache.flink.util.CloseableIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +33,7 @@ import org.apache.hudi.source.split.HoodieSourceSplit;
 import org.apache.hudi.source.split.SerializableComparator;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -54,6 +56,7 @@ public class HoodieSourceSplitReader<T> implements SplitReader<HoodieRecordWithP
 
   private HoodieSourceSplit currentSplit;
   private String currentSplitId;
+  private CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<T>>> currentReader;
 
   public HoodieSourceSplitReader(
       SourceReaderContext context,
@@ -67,15 +70,27 @@ public class HoodieSourceSplitReader<T> implements SplitReader<HoodieRecordWithP
 
   @Override
   public RecordsWithSplitIds<HoodieRecordWithPosition<T>> fetch() throws IOException {
-    HoodieSourceSplit nextSplit = splits.poll();
-    if (nextSplit != null) {
-      currentSplit = nextSplit;
-      currentSplitId = nextSplit.splitId();
-      return readerFunction.read(currentSplit);
+    if (currentReader == null) {
+      HoodieSourceSplit nextSplit = splits.poll();
+      if (nextSplit != null) {
+        currentSplit = nextSplit;
+        currentSplitId = nextSplit.splitId();
+        currentReader = readerFunction.read(currentSplit);
+      } else {
+        // return an empty result, which will lead to split fetch to be idle.
+        // SplitFetcherManager will then close idle fetcher.
+        return new RecordsBySplits<>(Collections.emptyMap(), Collections.emptySet());
+      }
+    }
+
+    if (currentReader.hasNext()) {
+      try {
+        return currentReader.next();
+      } catch (UncheckedIOException e) {
+        throw e.getCause();
+      }
     } else {
-      // return an empty result, which will lead to split fetch to be idle.
-      // SplitFetcherManager will then close idle fetcher.
-      return new RecordsBySplits<>(Collections.emptyMap(), Collections.emptySet());
+      return finishSplit();
     }
   }
 
@@ -119,5 +134,17 @@ public class HoodieSourceSplitReader<T> implements SplitReader<HoodieRecordWithP
   public void pauseOrResumeSplits(
       Collection<HoodieSourceSplit> splitsToPause,
       Collection<HoodieSourceSplit> splitsToResume) {
+  }
+
+  private RecordsWithSplitIds<HoodieRecordWithPosition<T>> finishSplit() throws IOException {
+    if (currentReader != null) {
+      try {
+        currentReader.close();
+      } catch (Exception e) {
+        throw new IOException(e);
+      }
+      currentReader = null;
+    }
+    return new RecordsBySplits<>(Collections.emptyMap(), Collections.singleton(currentSplitId));
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/function/MergeOnReadSplitReaderFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/function/MergeOnReadSplitReaderFunction.java
@@ -32,13 +32,15 @@ import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.internal.schema.InternalSchema;
-import org.apache.hudi.source.reader.BatchRecords;
 import org.apache.hudi.source.reader.HoodieRecordWithPosition;
+import org.apache.hudi.source.reader.DefaultBatchReader;
 import org.apache.hudi.source.split.HoodieSourceSplit;
 import org.apache.hudi.table.HoodieTable;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.CloseableIterator;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -52,6 +54,7 @@ public class MergeOnReadSplitReaderFunction<I, K, O> implements SplitReaderFunct
   private final HoodieReaderContext<RowData> readerContext;
   private final HoodieSchema tableSchema;
   private final HoodieSchema requiredSchema;
+  private final Configuration configuration;
   private final Option<InternalSchema> internalSchemaOption;
   private final TypedProperties props;
   private HoodieFileGroupReader<RowData> fileGroupReader;
@@ -59,6 +62,7 @@ public class MergeOnReadSplitReaderFunction<I, K, O> implements SplitReaderFunct
   public MergeOnReadSplitReaderFunction(
       HoodieTable<RowData, I, K, O> hoodieTable,
       HoodieReaderContext<RowData> readerContext,
+      Configuration configuration,
       HoodieSchema tableSchema,
       HoodieSchema requiredSchema,
       String mergeType,
@@ -70,6 +74,7 @@ public class MergeOnReadSplitReaderFunction<I, K, O> implements SplitReaderFunct
     this.hoodieTable = hoodieTable;
     this.readerContext = readerContext;
     this.tableSchema = tableSchema;
+    this.configuration = configuration;
     this.requiredSchema = requiredSchema;
     this.internalSchemaOption = internalSchemaOption;
     this.props = new TypedProperties();
@@ -78,14 +83,12 @@ public class MergeOnReadSplitReaderFunction<I, K, O> implements SplitReaderFunct
   }
 
   @Override
-  public RecordsWithSplitIds<HoodieRecordWithPosition<RowData>> read(HoodieSourceSplit split) {
-    final String splitId = split.splitId();
+  public CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<RowData>>> read(HoodieSourceSplit split) {
     try {
       this.fileGroupReader = createFileGroupReader(split);
       final ClosableIterator<RowData> recordIterator = fileGroupReader.getClosableIterator();
-      BatchRecords<RowData> records = BatchRecords.forRecords(splitId, recordIterator, split.getFileOffset(), split.getConsumed());
-      records.seek(split.getConsumed());
-      return records;
+      DefaultBatchReader<RowData> defaultBatchReader = new DefaultBatchReader<RowData>(configuration);
+      return defaultBatchReader.batch(split, recordIterator);
     } catch (IOException e) {
       throw new HoodieIOException("Failed to read from file group: " + split.getFileId(), e);
     }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestBatchReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestBatchReader.java
@@ -1,0 +1,334 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source.reader;
+
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.source.split.HoodieSourceSplit;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.util.CloseableIterator;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for {@link BatchReader} interface and its implementations.
+ */
+public class TestBatchReader {
+
+  @Test
+  public void testBatchReaderInterface() throws Exception {
+    // Test that custom BatchReader implementations work correctly
+    CustomBatchReader<String> customReader = new CustomBatchReader<>(5);
+
+    List<String> data = createTestData(20);
+    HoodieSourceSplit split = createTestSplit(0);
+
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> batchIterator =
+        customReader.batch(split, createClosableIterator(data));
+
+    int totalRecords = 0;
+    int batchCount = 0;
+
+    while (batchIterator.hasNext()) {
+      RecordsWithSplitIds<HoodieRecordWithPosition<String>> batch = batchIterator.next();
+      assertNotNull(batch);
+
+      HoodieRecordWithPosition<String> record;
+      while ((record = batch.nextRecordFromSplit()) != null) {
+        totalRecords++;
+      }
+      batchCount++;
+    }
+
+    assertEquals(20, totalRecords);
+    assertEquals(4, batchCount); // 20 records / 5 per batch = 4 batches
+
+    batchIterator.close();
+  }
+
+  @Test
+  public void testDefaultBatchReaderImplementation() throws Exception {
+    Configuration config = new Configuration();
+    config.set(FlinkOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 50);
+
+    BatchReader<String> batchReader = new DefaultBatchReader<>(config);
+
+    List<String> data = createTestData(150);
+    HoodieSourceSplit split = createTestSplit(0);
+
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> batchIterator =
+        batchReader.batch(split, createClosableIterator(data));
+
+    int batchCount = 0;
+    List<Integer> batchSizes = new ArrayList<>();
+
+    while (batchIterator.hasNext()) {
+      RecordsWithSplitIds<HoodieRecordWithPosition<String>> batch = batchIterator.next();
+      int batchSize = 0;
+
+      while (batch.nextRecordFromSplit() != null) {
+        batchSize++;
+      }
+
+      batchSizes.add(batchSize);
+      batchCount++;
+    }
+
+    assertEquals(3, batchCount); // 150 / 50 = 3 batches
+    assertEquals(50, batchSizes.get(0));
+    assertEquals(50, batchSizes.get(1));
+    assertEquals(50, batchSizes.get(2));
+
+    batchIterator.close();
+  }
+
+  @Test
+  public void testBatchReaderWithDifferentDataTypes() throws Exception {
+    // Test with Integer type
+    Configuration config = new Configuration();
+    config.set(FlinkOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 10);
+
+    BatchReader<Integer> intBatchReader = new DefaultBatchReader<>(config);
+
+    List<Integer> intData = new ArrayList<>();
+    for (int i = 0; i < 25; i++) {
+      intData.add(i);
+    }
+
+    HoodieSourceSplit split = createTestSplit(0);
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<Integer>>> batchIterator =
+        intBatchReader.batch(split, createClosableIterator(intData));
+
+    int totalSum = 0;
+    int recordCount = 0;
+
+    while (batchIterator.hasNext()) {
+      RecordsWithSplitIds<HoodieRecordWithPosition<Integer>> batch = batchIterator.next();
+      HoodieRecordWithPosition<Integer> record;
+
+      while ((record = batch.nextRecordFromSplit()) != null) {
+        totalSum += record.record();
+        recordCount++;
+      }
+    }
+
+    assertEquals(25, recordCount);
+    assertEquals(300, totalSum); // Sum of 0..24 = 300
+
+    batchIterator.close();
+  }
+
+  @Test
+  public void testBatchReaderSerialization() {
+    // BatchReader interface extends Serializable
+    Configuration config = new Configuration();
+    BatchReader<String> batchReader = new DefaultBatchReader<>(config);
+
+    // Verify it's serializable
+    assertTrue(batchReader instanceof java.io.Serializable);
+  }
+
+  @Test
+  public void testBatchReaderWithEmptyIterator() throws Exception {
+    Configuration config = new Configuration();
+    BatchReader<String> batchReader = new DefaultBatchReader<>(config);
+
+    HoodieSourceSplit split = createTestSplit(0);
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> batchIterator =
+        batchReader.batch(split, createClosableIterator(Collections.emptyList()));
+
+    assertFalse(batchIterator.hasNext());
+
+    batchIterator.close();
+  }
+
+  @Test
+  public void testMultipleBatchReadersOnSameSplit() throws Exception {
+    Configuration config1 = new Configuration();
+    config1.set(FlinkOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 10);
+
+    Configuration config2 = new Configuration();
+    config2.set(FlinkOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 20);
+
+    BatchReader<String> batchReader1 = new DefaultBatchReader<>(config1);
+    BatchReader<String> batchReader2 = new DefaultBatchReader<>(config2);
+
+    List<String> data = createTestData(100);
+
+    // Use first reader
+    HoodieSourceSplit split1 = createTestSplit(0);
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> iter1 =
+        batchReader1.batch(split1, createClosableIterator(data));
+
+    int batches1 = 0;
+    while (iter1.hasNext()) {
+      iter1.next();
+      batches1++;
+    }
+    assertEquals(10, batches1); // 100 / 10 = 10 batches
+    iter1.close();
+
+    // Use second reader on different split
+    HoodieSourceSplit split2 = createTestSplit(0);
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> iter2 =
+        batchReader2.batch(split2, createClosableIterator(data));
+
+    int batches2 = 0;
+    while (iter2.hasNext()) {
+      iter2.next();
+      batches2++;
+    }
+    assertEquals(5, batches2); // 100 / 20 = 5 batches
+    iter2.close();
+  }
+
+  @Test
+  public void testBatchReaderPreservesRecordPosition() throws Exception {
+    Configuration config = new Configuration();
+    config.set(FlinkOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 5);
+
+    BatchReader<String> batchReader = new DefaultBatchReader<>(config);
+
+    List<String> data = createTestData(10);
+    HoodieSourceSplit split = createTestSplit(0);
+
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> batchIterator =
+        batchReader.batch(split, createClosableIterator(data));
+
+    List<String> allRecords = new ArrayList<>();
+
+    while (batchIterator.hasNext()) {
+      RecordsWithSplitIds<HoodieRecordWithPosition<String>> batch = batchIterator.next();
+      HoodieRecordWithPosition<String> record;
+
+      while ((record = batch.nextRecordFromSplit()) != null) {
+        allRecords.add(record.record());
+      }
+    }
+
+    // Verify order is preserved
+    assertEquals(data, allRecords);
+
+    batchIterator.close();
+  }
+
+  // Helper methods
+
+  private List<String> createTestData(int count) {
+    List<String> data = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      data.add("record-" + i);
+    }
+    return data;
+  }
+
+  private HoodieSourceSplit createTestSplit(long consumed) {
+    HoodieSourceSplit split = new HoodieSourceSplit(
+        1,
+        "base-path",
+        Option.of(Collections.emptyList()),
+        "/test/table",
+        "/test/partition",
+        "read_optimized",
+        "file-1"
+    );
+    for (long i = 0; i < consumed; i++) {
+      split.consume();
+    }
+    return split;
+  }
+
+  private <T> ClosableIterator<T> createClosableIterator(List<T> items) {
+    Iterator<T> iterator = items.iterator();
+    return new ClosableIterator<T>() {
+      @Override
+      public void close() {
+        // No-op
+      }
+
+      @Override
+      public boolean hasNext() {
+        return iterator.hasNext();
+      }
+
+      @Override
+      public T next() {
+        return iterator.next();
+      }
+    };
+  }
+
+  /**
+   * Custom BatchReader implementation for testing the interface.
+   */
+  private static class CustomBatchReader<T> implements BatchReader<T> {
+    private final int batchSize;
+
+    public CustomBatchReader(int batchSize) {
+      this.batchSize = batchSize;
+    }
+
+    @Override
+    public CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<T>>> batch(
+        HoodieSourceSplit split, ClosableIterator<T> inputIterator) {
+      return new CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<T>>>() {
+        @Override
+        public boolean hasNext() {
+          return inputIterator.hasNext();
+        }
+
+        @Override
+        public RecordsWithSplitIds<HoodieRecordWithPosition<T>> next() {
+          List<T> batch = new ArrayList<>(batchSize);
+          int count = 0;
+
+          while (inputIterator.hasNext() && count < batchSize) {
+            batch.add(inputIterator.next());
+            split.consume();
+            count++;
+          }
+
+          return BatchRecords.forRecords(
+              split.splitId(),
+              ClosableIterator.wrap(batch.iterator()),
+              split.getFileOffset(),
+              split.getConsumed() - count);
+        }
+
+        @Override
+        public void close() throws IOException {
+          inputIterator.close();
+        }
+      };
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestDefaultBatchReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestDefaultBatchReader.java
@@ -1,0 +1,538 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.source.reader;
+
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.source.split.HoodieSourceSplit;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.util.CloseableIterator;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test cases for {@link DefaultBatchReader}.
+ */
+public class TestDefaultBatchReader {
+
+  @Test
+  public void testBatchWithDefaultSize() throws Exception {
+    Configuration config = new Configuration();
+    // Default batch size is 2048
+    DefaultBatchReader<String> batchReader = new DefaultBatchReader<>(config);
+
+    List<String> data = createTestData(5000);
+    HoodieSourceSplit split = createTestSplit(0);
+
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> batchIterator =
+        batchReader.batch(split, createClosableIterator(data));
+
+    // First batch should have 2048 records
+    assertTrue(batchIterator.hasNext());
+    RecordsWithSplitIds<HoodieRecordWithPosition<String>> firstBatch = batchIterator.next();
+    assertNotNull(firstBatch);
+    assertEquals(split.splitId(), firstBatch.nextSplit());
+
+    int firstBatchCount = countRecords(firstBatch);
+    assertEquals(2048, firstBatchCount);
+
+    // Second batch should have 2048 records
+    assertTrue(batchIterator.hasNext());
+    RecordsWithSplitIds<HoodieRecordWithPosition<String>> secondBatch = batchIterator.next();
+    int secondBatchCount = countRecords(secondBatch);
+    assertEquals(2048, secondBatchCount);
+
+    // Third batch should have remaining 904 records (5000 - 2048 - 2048)
+    assertTrue(batchIterator.hasNext());
+    RecordsWithSplitIds<HoodieRecordWithPosition<String>> thirdBatch = batchIterator.next();
+    int thirdBatchCount = countRecords(thirdBatch);
+    assertEquals(904, thirdBatchCount);
+
+    // No more batches
+    assertFalse(batchIterator.hasNext());
+
+    batchIterator.close();
+  }
+
+  @Test
+  public void testBatchWithCustomSize() throws Exception {
+    Configuration config = new Configuration();
+    config.set(FlinkOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 100);
+    DefaultBatchReader<String> batchReader = new DefaultBatchReader<>(config);
+
+    List<String> data = createTestData(250);
+    HoodieSourceSplit split = createTestSplit(0);
+
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> batchIterator =
+        batchReader.batch(split, createClosableIterator(data));
+
+    // First batch should have 100 records
+    assertTrue(batchIterator.hasNext());
+    RecordsWithSplitIds<HoodieRecordWithPosition<String>> firstBatch = batchIterator.next();
+    assertEquals(100, countRecords(firstBatch));
+
+    // Second batch should have 100 records
+    assertTrue(batchIterator.hasNext());
+    RecordsWithSplitIds<HoodieRecordWithPosition<String>> secondBatch = batchIterator.next();
+    assertEquals(100, countRecords(secondBatch));
+
+    // Third batch should have 50 records
+    assertTrue(batchIterator.hasNext());
+    RecordsWithSplitIds<HoodieRecordWithPosition<String>> thirdBatch = batchIterator.next();
+    assertEquals(50, countRecords(thirdBatch));
+
+    assertFalse(batchIterator.hasNext());
+
+    batchIterator.close();
+  }
+
+  @Test
+  public void testBatchWithEmptyInput() throws Exception {
+    Configuration config = new Configuration();
+    DefaultBatchReader<String> batchReader = new DefaultBatchReader<>(config);
+
+    List<String> data = Collections.emptyList();
+    HoodieSourceSplit split = createTestSplit(0);
+
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> batchIterator =
+        batchReader.batch(split, createClosableIterator(data));
+
+    assertFalse(batchIterator.hasNext());
+
+    batchIterator.close();
+  }
+
+  @Test
+  public void testBatchWithSingleRecord() throws Exception {
+    Configuration config = new Configuration();
+    config.set(FlinkOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 10);
+    DefaultBatchReader<String> batchReader = new DefaultBatchReader<>(config);
+
+    List<String> data = Collections.singletonList("single-record");
+    HoodieSourceSplit split = createTestSplit(0);
+
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> batchIterator =
+        batchReader.batch(split, createClosableIterator(data));
+
+    assertTrue(batchIterator.hasNext());
+    RecordsWithSplitIds<HoodieRecordWithPosition<String>> batch = batchIterator.next();
+    assertEquals(1, countRecords(batch));
+
+    assertFalse(batchIterator.hasNext());
+
+    batchIterator.close();
+  }
+
+  @Test
+  public void testBatchWithExactBatchSize() throws Exception {
+    Configuration config = new Configuration();
+    config.set(FlinkOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 100);
+    DefaultBatchReader<String> batchReader = new DefaultBatchReader<>(config);
+
+    List<String> data = createTestData(100);
+    HoodieSourceSplit split = createTestSplit(0);
+
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> batchIterator =
+        batchReader.batch(split, createClosableIterator(data));
+
+    assertTrue(batchIterator.hasNext());
+    RecordsWithSplitIds<HoodieRecordWithPosition<String>> batch = batchIterator.next();
+    assertEquals(100, countRecords(batch));
+
+    assertFalse(batchIterator.hasNext());
+
+    batchIterator.close();
+  }
+
+  @Test
+  public void testBatchWithLessThanBatchSize() throws Exception {
+    Configuration config = new Configuration();
+    config.set(FlinkOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 1000);
+    DefaultBatchReader<String> batchReader = new DefaultBatchReader<>(config);
+
+    List<String> data = createTestData(50);
+    HoodieSourceSplit split = createTestSplit(0);
+
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> batchIterator =
+        batchReader.batch(split, createClosableIterator(data));
+
+    assertTrue(batchIterator.hasNext());
+    RecordsWithSplitIds<HoodieRecordWithPosition<String>> batch = batchIterator.next();
+    assertEquals(50, countRecords(batch));
+
+    assertFalse(batchIterator.hasNext());
+
+    batchIterator.close();
+  }
+
+  @Test
+  public void testNextWithoutHasNext() throws Exception {
+    Configuration config = new Configuration();
+    config.set(FlinkOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 10);
+    DefaultBatchReader<String> batchReader = new DefaultBatchReader<>(config);
+
+    List<String> data = createTestData(5);
+    HoodieSourceSplit split = createTestSplit(0);
+
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> batchIterator =
+        batchReader.batch(split, createClosableIterator(data));
+
+    // Should work without calling hasNext() first
+    RecordsWithSplitIds<HoodieRecordWithPosition<String>> batch = batchIterator.next();
+    assertEquals(5, countRecords(batch));
+
+    // Calling next() when there's no data should throw
+    assertThrows(NoSuchElementException.class, () -> batchIterator.next());
+
+    batchIterator.close();
+  }
+
+  @Test
+  public void testSeekWithConsumedRecords() throws Exception {
+    Configuration config = new Configuration();
+    config.set(FlinkOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 10);
+    DefaultBatchReader<String> batchReader = new DefaultBatchReader<>(config);
+
+    List<String> data = createTestData(100);
+    // Create a split with 20 already consumed records
+    HoodieSourceSplit split = createTestSplit(20);
+
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> batchIterator =
+        batchReader.batch(split, createClosableIterator(data));
+
+    // Should skip first 20 records and return remaining 80 in batches
+    int totalRead = 0;
+    while (batchIterator.hasNext()) {
+      RecordsWithSplitIds<HoodieRecordWithPosition<String>> batch = batchIterator.next();
+      totalRead += countRecords(batch);
+    }
+
+    assertEquals(80, totalRead);
+
+    batchIterator.close();
+  }
+
+  @Test
+  public void testSeekBeyondAvailableRecords() {
+    Configuration config = new Configuration();
+    config.set(FlinkOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 10);
+    DefaultBatchReader<String> batchReader = new DefaultBatchReader<>(config);
+
+    List<String> data = createTestData(50);
+    // Try to consume from position 100, but only 50 records available
+    HoodieSourceSplit split = createTestSplit(100);
+
+    assertThrows(IllegalStateException.class, () -> {
+      batchReader.batch(split, createClosableIterator(data));
+    });
+  }
+
+  @Test
+  public void testCloseIterator() throws Exception {
+    Configuration config = new Configuration();
+    DefaultBatchReader<String> batchReader = new DefaultBatchReader<>(config);
+
+    List<String> data = createTestData(10);
+    HoodieSourceSplit split = createTestSplit(0);
+
+    TestClosableIterator<String> closableIterator = new TestClosableIterator<>(data.iterator());
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> batchIterator =
+        batchReader.batch(split, closableIterator);
+
+    assertFalse(closableIterator.isClosed());
+
+    batchIterator.close();
+
+    assertTrue(closableIterator.isClosed());
+  }
+
+  @Test
+  public void testMultipleSplitsWithDifferentOffsets() throws Exception {
+    Configuration config = new Configuration();
+    config.set(FlinkOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 10);
+    DefaultBatchReader<String> batchReader = new DefaultBatchReader<>(config);
+
+    // Test first split with no consumed records
+    List<String> data1 = createTestData(30);
+    HoodieSourceSplit split1 = createTestSplit(0);
+
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> iter1 =
+        batchReader.batch(split1, createClosableIterator(data1));
+    int total1 = 0;
+    while (iter1.hasNext()) {
+      total1 += countRecords(iter1.next());
+    }
+    assertEquals(30, total1);
+    iter1.close();
+
+    // Test second split with 10 consumed records
+    List<String> data2 = createTestData(30);
+    HoodieSourceSplit split2 = createTestSplit(10);
+
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> iter2 =
+        batchReader.batch(split2, createClosableIterator(data2));
+    int total2 = 0;
+    while (iter2.hasNext()) {
+      total2 += countRecords(iter2.next());
+    }
+    assertEquals(20, total2);
+    iter2.close();
+  }
+
+  @Test
+  public void testBatchPreservesRecordOrder() throws Exception {
+    Configuration config = new Configuration();
+    config.set(FlinkOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 5);
+    DefaultBatchReader<String> batchReader = new DefaultBatchReader<>(config);
+
+    List<String> data = Arrays.asList("A", "B", "C", "D", "E", "F", "G", "H", "I", "J");
+    HoodieSourceSplit split = createTestSplit(0);
+
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> batchIterator =
+        batchReader.batch(split, createClosableIterator(data));
+
+    // First batch: A, B, C, D, E
+    assertTrue(batchIterator.hasNext());
+    RecordsWithSplitIds<HoodieRecordWithPosition<String>> batch1 = batchIterator.next();
+    List<String> batch1Records = collectRecordData(batch1);
+    assertEquals(Arrays.asList("A", "B", "C", "D", "E"), batch1Records);
+
+    // Second batch: F, G, H, I, J
+    assertTrue(batchIterator.hasNext());
+    RecordsWithSplitIds<HoodieRecordWithPosition<String>> batch2 = batchIterator.next();
+    List<String> batch2Records = collectRecordData(batch2);
+    assertEquals(Arrays.asList("F", "G", "H", "I", "J"), batch2Records);
+
+    assertFalse(batchIterator.hasNext());
+
+    batchIterator.close();
+  }
+
+  @Test
+  public void testSplitConsumptionTracking() throws Exception {
+    Configuration config = new Configuration();
+    config.set(FlinkOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 10);
+    DefaultBatchReader<String> batchReader = new DefaultBatchReader<>(config);
+
+    List<String> data = createTestData(25);
+    HoodieSourceSplit split = createTestSplit(0);
+
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> batchIterator =
+        batchReader.batch(split, createClosableIterator(data));
+
+    // After first batch (10 records)
+    batchIterator.next();
+    assertEquals(10, split.getConsumed());
+
+    // After second batch (10 more records, total 20)
+    batchIterator.next();
+    assertEquals(20, split.getConsumed());
+
+    // After third batch (5 more records, total 25)
+    batchIterator.next();
+    assertEquals(25, split.getConsumed());
+
+    batchIterator.close();
+  }
+
+  @Test
+  public void testBatchSizeOfOne() throws Exception {
+    Configuration config = new Configuration();
+    config.set(FlinkOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 1);
+    DefaultBatchReader<String> batchReader = new DefaultBatchReader<>(config);
+
+    List<String> data = createTestData(5);
+    HoodieSourceSplit split = createTestSplit(0);
+
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> batchIterator =
+        batchReader.batch(split, createClosableIterator(data));
+
+    // Should get 5 batches of 1 record each
+    for (int i = 0; i < 5; i++) {
+      assertTrue(batchIterator.hasNext());
+      RecordsWithSplitIds<HoodieRecordWithPosition<String>> batch = batchIterator.next();
+      assertEquals(1, countRecords(batch));
+    }
+
+    assertFalse(batchIterator.hasNext());
+
+    batchIterator.close();
+  }
+
+  @Test
+  public void testLargeBatchSize() throws Exception {
+    Configuration config = new Configuration();
+    config.set(FlinkOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 100000);
+    DefaultBatchReader<String> batchReader = new DefaultBatchReader<>(config);
+
+    List<String> data = createTestData(1000);
+    HoodieSourceSplit split = createTestSplit(0);
+
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> batchIterator =
+        batchReader.batch(split, createClosableIterator(data));
+
+    // Should get all 1000 records in one batch
+    assertTrue(batchIterator.hasNext());
+    RecordsWithSplitIds<HoodieRecordWithPosition<String>> batch = batchIterator.next();
+    assertEquals(1000, countRecords(batch));
+
+    assertFalse(batchIterator.hasNext());
+
+    batchIterator.close();
+  }
+
+  @Test
+  public void testMultipleHasNextCalls() throws Exception {
+    Configuration config = new Configuration();
+    config.set(FlinkOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 10);
+    DefaultBatchReader<String> batchReader = new DefaultBatchReader<>(config);
+
+    List<String> data = createTestData(15);
+    HoodieSourceSplit split = createTestSplit(0);
+
+    CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> batchIterator =
+        batchReader.batch(split, createClosableIterator(data));
+
+    // Multiple hasNext() calls should not affect the result
+    assertTrue(batchIterator.hasNext());
+    assertTrue(batchIterator.hasNext());
+    assertTrue(batchIterator.hasNext());
+
+    RecordsWithSplitIds<HoodieRecordWithPosition<String>> batch1 = batchIterator.next();
+    assertEquals(10, countRecords(batch1));
+
+    assertTrue(batchIterator.hasNext());
+    assertTrue(batchIterator.hasNext());
+
+    RecordsWithSplitIds<HoodieRecordWithPosition<String>> batch2 = batchIterator.next();
+    assertEquals(5, countRecords(batch2));
+
+    assertFalse(batchIterator.hasNext());
+    assertFalse(batchIterator.hasNext());
+
+    batchIterator.close();
+  }
+
+  // Helper methods
+
+  private List<String> createTestData(int count) {
+    List<String> data = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      data.add("record-" + i);
+    }
+    return data;
+  }
+
+  private HoodieSourceSplit createTestSplit(long consumed) {
+    HoodieSourceSplit split = new HoodieSourceSplit(
+        1,
+        "base-path",
+        Option.of(Collections.emptyList()),
+        "/test/table",
+        "/test/partition",
+        "read_optimized",
+        "file-1"
+    );
+    // Simulate consumed records
+    for (long i = 0; i < consumed; i++) {
+      split.consume();
+    }
+    return split;
+  }
+
+  private ClosableIterator<String> createClosableIterator(List<String> items) {
+    Iterator<String> iterator = items.iterator();
+    return new ClosableIterator<String>() {
+      @Override
+      public void close() {
+        // No-op
+      }
+
+      @Override
+      public boolean hasNext() {
+        return iterator.hasNext();
+      }
+
+      @Override
+      public String next() {
+        return iterator.next();
+      }
+    };
+  }
+
+  private int countRecords(RecordsWithSplitIds<HoodieRecordWithPosition<String>> records) {
+    int count = 0;
+    while (records.nextRecordFromSplit() != null) {
+      count++;
+    }
+    return count;
+  }
+
+  private List<String> collectRecordData(RecordsWithSplitIds<HoodieRecordWithPosition<String>> records) {
+    List<String> result = new ArrayList<>();
+    HoodieRecordWithPosition<String> record;
+    while ((record = records.nextRecordFromSplit()) != null) {
+      result.add(record.record());
+    }
+    return result;
+  }
+
+  private static class TestClosableIterator<T> implements ClosableIterator<T> {
+    private final Iterator<T> iterator;
+    private boolean closed = false;
+
+    public TestClosableIterator(Iterator<T> iterator) {
+      this.iterator = iterator;
+    }
+
+    @Override
+    public void close() {
+      closed = true;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return iterator.hasNext();
+    }
+
+    @Override
+    public T next() {
+      return iterator.next();
+    }
+
+    public boolean isClosed() {
+      return closed;
+    }
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestHoodieSourceSplitReader.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestHoodieSourceSplitReader.java
@@ -20,18 +20,21 @@ package org.apache.hudi.source.reader;
 
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.configuration.FlinkOptions;
 import org.apache.hudi.source.reader.function.SplitReaderFunction;
 import org.apache.hudi.source.split.HoodieSourceSplit;
-import org.apache.hudi.source.split.SerializableComparator;
 
 import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
+import org.apache.flink.util.CloseableIterator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
@@ -88,94 +91,6 @@ public class TestHoodieSourceSplitReader {
 
     assertNotNull(result);
     assertEquals(split.splitId(), result.nextSplit());
-  }
-
-  @Test
-  public void testFetchWithMultipleSplits() throws IOException {
-    List<String> testData = Arrays.asList("record1", "record2");
-    TestSplitReaderFunction readerFunction = new TestSplitReaderFunction(testData);
-
-    HoodieSourceSplitReader<String> reader =
-        new HoodieSourceSplitReader<>(mockContext, readerFunction, null);
-
-    HoodieSourceSplit split1 = createTestSplit(1, "file1");
-    HoodieSourceSplit split2 = createTestSplit(2, "file2");
-    HoodieSourceSplit split3 = createTestSplit(3, "file3");
-
-    SplitsAddition<HoodieSourceSplit> splitsChange =
-        new SplitsAddition<>(Arrays.asList(split1, split2, split3));
-    reader.handleSplitsChanges(splitsChange);
-
-    // Fetch first split
-    RecordsWithSplitIds<HoodieRecordWithPosition<String>> result1 = reader.fetch();
-    assertNotNull(result1);
-    assertEquals(split1.splitId(), result1.nextSplit());
-
-    // Fetch second split
-    RecordsWithSplitIds<HoodieRecordWithPosition<String>> result2 = reader.fetch();
-    assertNotNull(result2);
-    assertEquals(split2.splitId(), result2.nextSplit());
-
-    // Fetch third split
-    RecordsWithSplitIds<HoodieRecordWithPosition<String>> result3 = reader.fetch();
-    assertNotNull(result3);
-    assertEquals(split3.splitId(), result3.nextSplit());
-
-    // No more splits
-    RecordsWithSplitIds<HoodieRecordWithPosition<String>> result4 = reader.fetch();
-    assertNotNull(result4);
-    assertNull(result4.nextSplit());
-  }
-
-  @Test
-  public void testHandleSplitsChangesWithComparator() throws IOException {
-    List<String> testData = Collections.singletonList("record");
-    TestSplitReaderFunction readerFunction = new TestSplitReaderFunction(testData);
-
-    // Comparator that sorts by file ID in reverse order
-    SerializableComparator<HoodieSourceSplit> comparator =
-        (s1, s2) -> s2.getFileId().compareTo(s1.getFileId());
-
-    HoodieSourceSplitReader<String> reader =
-        new HoodieSourceSplitReader<>(mockContext, readerFunction, comparator);
-
-    HoodieSourceSplit split1 = createTestSplit(1, "file1");
-    HoodieSourceSplit split2 = createTestSplit(2, "file2");
-    HoodieSourceSplit split3 = createTestSplit(3, "file3");
-
-    // Add splits in forward order
-    SplitsAddition<HoodieSourceSplit> splitsChange =
-        new SplitsAddition<>(Arrays.asList(split1, split2, split3));
-    reader.handleSplitsChanges(splitsChange);
-
-    // Should fetch in reverse order due to comparator
-    assertEquals(split3.splitId(), reader.fetch().nextSplit());
-    assertEquals(split2.splitId(), reader.fetch().nextSplit());
-    assertEquals(split1.splitId(), reader.fetch().nextSplit());
-  }
-
-  @Test
-  public void testAddingSplitsInMultipleBatches() throws IOException {
-    List<String> testData = Collections.singletonList("record");
-    TestSplitReaderFunction readerFunction = new TestSplitReaderFunction(testData);
-
-    HoodieSourceSplitReader<String> reader =
-        new HoodieSourceSplitReader<>(mockContext, readerFunction, null);
-
-    // First batch
-    HoodieSourceSplit split1 = createTestSplit(1, "file1");
-    reader.handleSplitsChanges(new SplitsAddition<>(Collections.singletonList(split1)));
-
-    // Second batch
-    HoodieSourceSplit split2 = createTestSplit(2, "file2");
-    HoodieSourceSplit split3 = createTestSplit(3, "file3");
-    reader.handleSplitsChanges(new SplitsAddition<>(Arrays.asList(split2, split3)));
-
-    // Verify all splits can be fetched
-    assertEquals(split1.splitId(), reader.fetch().nextSplit());
-    assertEquals(split2.splitId(), reader.fetch().nextSplit());
-    assertEquals(split3.splitId(), reader.fetch().nextSplit());
-    assertNull(reader.fetch().nextSplit());
   }
 
   @Test
@@ -241,35 +156,6 @@ public class TestHoodieSourceSplitReader {
   }
 
   @Test
-  public void testComparatorSortsSplitsCorrectly() throws IOException {
-    List<String> testData = Collections.singletonList("record");
-    TestSplitReaderFunction readerFunction = new TestSplitReaderFunction(testData);
-
-    // Comparator that sorts by split number
-    SerializableComparator<HoodieSourceSplit> comparator =
-        (s1, s2) -> Integer.compare(s1.getSplitNum(), s2.getSplitNum());
-
-    HoodieSourceSplitReader<String> reader =
-        new HoodieSourceSplitReader<>(mockContext, readerFunction, comparator);
-
-    // Add splits in random order
-    HoodieSourceSplit split5 = createTestSplit(5, "file5");
-    HoodieSourceSplit split2 = createTestSplit(2, "file2");
-    HoodieSourceSplit split8 = createTestSplit(8, "file8");
-    HoodieSourceSplit split1 = createTestSplit(1, "file1");
-
-    SplitsAddition<HoodieSourceSplit> splitsChange =
-        new SplitsAddition<>(Arrays.asList(split5, split2, split8, split1));
-    reader.handleSplitsChanges(splitsChange);
-
-    // Should fetch in sorted order: 1, 2, 5, 8
-    assertEquals(split1.splitId(), reader.fetch().nextSplit());
-    assertEquals(split2.splitId(), reader.fetch().nextSplit());
-    assertEquals(split5.splitId(), reader.fetch().nextSplit());
-    assertEquals(split8.splitId(), reader.fetch().nextSplit());
-  }
-
-  @Test
   public void testContextIndexRetrieved() {
     TestSplitReaderFunction readerFunction = new TestSplitReaderFunction();
 
@@ -305,48 +191,160 @@ public class TestHoodieSourceSplitReader {
   }
 
   @Test
-  public void testSplitOrderPreservedWithoutComparator() throws IOException {
-    List<String> testData = Collections.singletonList("record");
-    TestSplitReaderFunction readerFunction = new TestSplitReaderFunction(testData);
+  public void testMiniBatchReading() throws IOException {
+    // Create data that will be split into multiple mini batches
+    List<String> testData = new ArrayList<>();
+    for (int i = 0; i < 5000; i++) {
+      testData.add("record-" + i);
+    }
 
-    // No comparator - should preserve insertion order
+    TestSplitReaderFunction readerFunction = new TestSplitReaderFunction(testData);
     HoodieSourceSplitReader<String> reader =
         new HoodieSourceSplitReader<>(mockContext, readerFunction, null);
 
-    HoodieSourceSplit split3 = createTestSplit(3, "file3");
-    HoodieSourceSplit split1 = createTestSplit(1, "file1");
-    HoodieSourceSplit split2 = createTestSplit(2, "file2");
+    HoodieSourceSplit split = createTestSplit(1, "file1");
+    reader.handleSplitsChanges(new SplitsAddition<>(Collections.singletonList(split)));
 
-    SplitsAddition<HoodieSourceSplit> splitsChange =
-        new SplitsAddition<>(Arrays.asList(split3, split1, split2));
-    reader.handleSplitsChanges(splitsChange);
+    // Fetch multiple batches from the same split
+    // Default batch size is 2048, so we should get 3 batches (2048 + 2048 + 904)
+    int totalBatches = 0;
+    int totalRecords = 0;
 
-    // Should fetch in insertion order: 3, 1, 2
-    assertEquals(split3.splitId(), reader.fetch().nextSplit());
-    assertEquals(split1.splitId(), reader.fetch().nextSplit());
-    assertEquals(split2.splitId(), reader.fetch().nextSplit());
+    while (true) {
+      RecordsWithSplitIds<HoodieRecordWithPosition<String>> result = reader.fetch();
+      String splitId = result.nextSplit();
+
+      if (splitId == null) {
+        // Empty result - no more splits
+        break;
+      }
+
+      totalBatches++;
+
+      // Count records in this batch
+      HoodieRecordWithPosition<String> record;
+      while ((record = result.nextRecordFromSplit()) != null) {
+        totalRecords++;
+      }
+
+      // Check if this split is finished
+      if (result.finishedSplits().contains(split.splitId())) {
+        break;
+      }
+    }
+
+    // Verify we got multiple batches and all records
+    assertTrue(totalBatches >= 3, "Should have at least 3 batches for 5000 records");
+    assertEquals(5000, totalRecords, "Should read all 5000 records");
   }
 
   @Test
-  public void testCurrentSplitTracking() throws IOException {
+  public void testMiniBatchWithSmallBatchSize() throws IOException {
+    List<String> testData = Arrays.asList("A", "B", "C", "D", "E", "F", "G", "H", "I", "J");
+
+    // Use a small custom batch size
+    TestSplitReaderFunctionWithBatchSize readerFunction =
+        new TestSplitReaderFunctionWithBatchSize(testData, 3);
+
+    HoodieSourceSplitReader<String> reader =
+        new HoodieSourceSplitReader<>(mockContext, readerFunction, null);
+
+    HoodieSourceSplit split = createTestSplit(1, "file1");
+    reader.handleSplitsChanges(new SplitsAddition<>(Collections.singletonList(split)));
+
+    List<Integer> batchSizes = new ArrayList<>();
+
+    while (true) {
+      RecordsWithSplitIds<HoodieRecordWithPosition<String>> result = reader.fetch();
+      String splitId = result.nextSplit();
+
+      if (splitId == null) {
+        break;
+      }
+
+      int batchSize = 0;
+      while (result.nextRecordFromSplit() != null) {
+        batchSize++;
+      }
+
+      if (batchSize > 0) {
+        batchSizes.add(batchSize);
+      }
+
+      if (result.finishedSplits().contains(split.splitId())) {
+        break;
+      }
+    }
+
+    // With batch size 3 and 10 records, expect: 3, 3, 3, 1
+    assertEquals(Arrays.asList(3, 3, 3, 1), batchSizes);
+  }
+
+  @Test
+  public void testReaderIteratorClosedOnSplitFinish() throws IOException {
     List<String> testData = Arrays.asList("record1", "record2");
     TestSplitReaderFunction readerFunction = new TestSplitReaderFunction(testData);
 
     HoodieSourceSplitReader<String> reader =
         new HoodieSourceSplitReader<>(mockContext, readerFunction, null);
 
-    HoodieSourceSplit split1 = createTestSplit(1, "file1");
-    HoodieSourceSplit split2 = createTestSplit(2, "file2");
+    HoodieSourceSplit split = createTestSplit(1, "file1");
+    reader.handleSplitsChanges(new SplitsAddition<>(Collections.singletonList(split)));
 
-    reader.handleSplitsChanges(new SplitsAddition<>(Arrays.asList(split1, split2)));
+    // Fetch all batches until split is finished
+    while (true) {
+      RecordsWithSplitIds<HoodieRecordWithPosition<String>> result = reader.fetch();
+      String splitId = result.nextSplit();
 
-    // Fetch first split
-    reader.fetch();
-    assertEquals(split1, readerFunction.getLastReadSplit());
+      if (splitId == null || result.finishedSplits().contains(split.splitId())) {
+        break;
+      }
 
-    // Fetch second split
-    reader.fetch();
-    assertEquals(split2, readerFunction.getLastReadSplit());
+      // Drain the batch
+      while (result.nextRecordFromSplit() != null) {
+        // Continue
+      }
+    }
+
+    // After finishing, fetch should return empty result
+    RecordsWithSplitIds<HoodieRecordWithPosition<String>> emptyResult = reader.fetch();
+    assertNull(emptyResult.nextSplit());
+  }
+
+  @Test
+  public void testMultipleFetchesFromSameSplit() throws IOException {
+    List<String> testData = new ArrayList<>();
+    for (int i = 0; i < 100; i++) {
+      testData.add("record-" + i);
+    }
+
+    TestSplitReaderFunctionWithBatchSize readerFunction =
+        new TestSplitReaderFunctionWithBatchSize(testData, 10);
+
+    HoodieSourceSplitReader<String> reader =
+        new HoodieSourceSplitReader<>(mockContext, readerFunction, null);
+
+    HoodieSourceSplit split = createTestSplit(1, "file1");
+    reader.handleSplitsChanges(new SplitsAddition<>(Collections.singletonList(split)));
+
+    // First fetch should return first batch
+    RecordsWithSplitIds<HoodieRecordWithPosition<String>> result1 = reader.fetch();
+    assertEquals(split.splitId(), result1.nextSplit());
+    int count1 = 0;
+    while (result1.nextRecordFromSplit() != null) {
+      count1++;
+    }
+    assertEquals(10, count1);
+    assertTrue(result1.finishedSplits().isEmpty());
+
+    // Second fetch should return second batch from same split
+    RecordsWithSplitIds<HoodieRecordWithPosition<String>> result2 = reader.fetch();
+    assertEquals(split.splitId(), result2.nextSplit());
+    int count2 = 0;
+    while (result2.nextRecordFromSplit() != null) {
+      count2++;
+    }
+    assertEquals(10, count2);
   }
 
   /**
@@ -382,16 +380,12 @@ public class TestHoodieSourceSplitReader {
     }
 
     @Override
-    public RecordsWithSplitIds<HoodieRecordWithPosition<String>> read(HoodieSourceSplit split) {
+    public CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> read(HoodieSourceSplit split) {
       readCount++;
       lastReadSplit = split;
       ClosableIterator<String> iterator = createClosableIterator(testData);
-      return BatchRecords.forRecords(
-          split.splitId(),
-          iterator,
-          split.getFileOffset(),
-          split.getConsumed()
-      );
+      DefaultBatchReader<String> reader = new DefaultBatchReader<String>(new Configuration());
+      return reader.batch(split, iterator);
     }
 
     @Override
@@ -409,6 +403,53 @@ public class TestHoodieSourceSplitReader {
 
     public boolean isClosed() {
       return closed;
+    }
+
+    private ClosableIterator<String> createClosableIterator(List<String> items) {
+      Iterator<String> iterator = items.iterator();
+      return new ClosableIterator<String>() {
+        @Override
+        public void close() {
+          // No-op
+        }
+
+        @Override
+        public boolean hasNext() {
+          return iterator.hasNext();
+        }
+
+        @Override
+        public String next() {
+          return iterator.next();
+        }
+      };
+    }
+  }
+
+  /**
+   * Test implementation of SplitReaderFunction with custom batch size.
+   */
+  private static class TestSplitReaderFunctionWithBatchSize implements SplitReaderFunction<String> {
+    private final List<String> testData;
+    private final int batchSize;
+
+    public TestSplitReaderFunctionWithBatchSize(List<String> testData, int batchSize) {
+      this.testData = testData;
+      this.batchSize = batchSize;
+    }
+
+    @Override
+    public CloseableIterator<RecordsWithSplitIds<HoodieRecordWithPosition<String>>> read(HoodieSourceSplit split) {
+      ClosableIterator<String> iterator = createClosableIterator(testData);
+      Configuration config = new Configuration();
+      config.set(FlinkOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, batchSize);
+      DefaultBatchReader<String> reader = new DefaultBatchReader<String>(config);
+      return reader.batch(split, iterator);
+    }
+
+    @Override
+    public void close() throws Exception {
+      // No-op
     }
 
     private ClosableIterator<String> createClosableIterator(List<String> items) {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/function/TestMergeOnReadSplitReaderFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/function/TestMergeOnReadSplitReaderFunction.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.internal.schema.InternalSchema;
 import org.apache.hudi.table.HoodieTable;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.RowData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -68,6 +69,7 @@ public class TestMergeOnReadSplitReaderFunction {
       new MergeOnReadSplitReaderFunction<>(
           mockTable,
           mockReaderContext,
+          new Configuration(),
           null,  // null tableSchema should throw
           requiredSchema,
           "AVRO_PAYLOAD",
@@ -83,6 +85,7 @@ public class TestMergeOnReadSplitReaderFunction {
       new MergeOnReadSplitReaderFunction<>(
           mockTable,
           mockReaderContext,
+          new Configuration(),
           tableSchema,
           null,  // null requiredSchema should throw
           "AVRO_PAYLOAD",
@@ -98,6 +101,7 @@ public class TestMergeOnReadSplitReaderFunction {
         new MergeOnReadSplitReaderFunction<>(
             mockTable,
             mockReaderContext,
+            new Configuration(),
             tableSchema,
             requiredSchema,
             "AVRO_PAYLOAD",
@@ -115,6 +119,7 @@ public class TestMergeOnReadSplitReaderFunction {
         new MergeOnReadSplitReaderFunction<>(
             mockTable,
             mockReaderContext,
+            new Configuration(),
             tableSchema,
             requiredSchema,
             "AVRO_PAYLOAD",
@@ -130,6 +135,7 @@ public class TestMergeOnReadSplitReaderFunction {
         new MergeOnReadSplitReaderFunction<>(
             mockTable,
             mockReaderContext,
+            new Configuration(),
             tableSchema,
             requiredSchema,
             "AVRO_PAYLOAD",
@@ -154,6 +160,7 @@ public class TestMergeOnReadSplitReaderFunction {
           new MergeOnReadSplitReaderFunction<>(
               mockTable,
               mockReaderContext,
+              new Configuration(),
               tableSchema,
               requiredSchema,
               mergeType,
@@ -170,6 +177,7 @@ public class TestMergeOnReadSplitReaderFunction {
         new MergeOnReadSplitReaderFunction<>(
             mockTable,
             mockReaderContext,
+            new Configuration(),
             tableSchema,
             requiredSchema,
             "AVRO_PAYLOAD",
@@ -191,6 +199,7 @@ public class TestMergeOnReadSplitReaderFunction {
         new MergeOnReadSplitReaderFunction<>(
             mockTable,
             mockReaderContext,
+            new Configuration(),
             customTableSchema,
             customRequiredSchema,
             "AVRO_PAYLOAD",
@@ -210,6 +219,7 @@ public class TestMergeOnReadSplitReaderFunction {
         new MergeOnReadSplitReaderFunction<>(
             mockTable,
             mockReaderContext,
+            new Configuration(),
             tableSchema,
             requiredSchema,
             "AVRO_PAYLOAD",
@@ -222,6 +232,7 @@ public class TestMergeOnReadSplitReaderFunction {
         new MergeOnReadSplitReaderFunction<>(
             mockTable,
             mockReaderContext,
+            new Configuration(),
             tableSchema,
             requiredSchema,
             "AVRO_PAYLOAD",
@@ -234,6 +245,7 @@ public class TestMergeOnReadSplitReaderFunction {
         new MergeOnReadSplitReaderFunction<>(
             mockTable,
             mockReaderContext,
+            new Configuration(),
             tableSchema,
             requiredSchema,
             "AVRO_PAYLOAD",
@@ -254,6 +266,7 @@ public class TestMergeOnReadSplitReaderFunction {
         new MergeOnReadSplitReaderFunction<>(
             customTable,
             mockReaderContext,
+            new Configuration(),
             tableSchema,
             requiredSchema,
             "AVRO_PAYLOAD",
@@ -272,6 +285,7 @@ public class TestMergeOnReadSplitReaderFunction {
         new MergeOnReadSplitReaderFunction<>(
             mockTable,
             customContext,
+            new Configuration(),
             tableSchema,
             requiredSchema,
             "AVRO_PAYLOAD",
@@ -279,5 +293,43 @@ public class TestMergeOnReadSplitReaderFunction {
         );
 
     assertNotNull(function);
+  }
+
+  @Test
+  public void testConfigurationIsStored() {
+    Configuration config = new Configuration();
+    config.setString("test.key", "test.value");
+
+    MergeOnReadSplitReaderFunction<?, ?, ?> function =
+        new MergeOnReadSplitReaderFunction<>(
+            mockTable,
+            mockReaderContext,
+            config,
+            tableSchema,
+            requiredSchema,
+            "AVRO_PAYLOAD",
+            Option.empty()
+        );
+
+    assertNotNull(function);
+  }
+
+  @Test
+  public void testReadMethodSignature() {
+    // Verify that the read method returns CloseableIterator
+    MergeOnReadSplitReaderFunction<?, ?, ?> function =
+        new MergeOnReadSplitReaderFunction<>(
+            mockTable,
+            mockReaderContext,
+            new Configuration(),
+            tableSchema,
+            requiredSchema,
+            "AVRO_PAYLOAD",
+            Option.empty()
+        );
+
+    assertNotNull(function);
+    // The read method signature has changed to return CloseableIterator<RecordsWithSplitIds<...>>
+    // This test verifies the function can be constructed with the new signature
   }
 }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch reading configuration option to control the number of records fetched per batch (default: 2048 records).
  * Introduced batch-oriented reading capability in the Flink datasource for more efficient record processing.

* **Improvements**
  * Enhanced record iteration with batched processing to improve data throughput and resource utilization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->