### PR TITLE
review bf for lance

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileWriterFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileWriterFactory.java
@@ -109,8 +109,10 @@ public class HoodieSparkFileWriterFactory extends HoodieFileWriterFactory {
                                                 TaskContextSupplier taskContextSupplier) throws IOException {
     boolean populateMetaFields = config.getBooleanOrDefault(HoodieTableConfig.POPULATE_META_FIELDS);
     StructType structType = HoodieInternalRowUtils.getCachedSchema(schema);
+    boolean enableBloomFilter = enableBloomFilter(populateMetaFields, config);
+    Option<BloomFilter> bloomFilter = enableBloomFilter ? Option.of(createBloomFilter(config)) : Option.empty();
 
-    return new HoodieSparkLanceWriter(path, structType, instantTime, taskContextSupplier, storage, populateMetaFields);
+    return new HoodieSparkLanceWriter(path, structType, instantTime, taskContextSupplier, storage, populateMetaFields, bloomFilter);
   }
 
   private static HoodieRowParquetWriteSupport getHoodieRowParquetWriteSupport(StorageConfiguration<?> conf, HoodieSchema schema,

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkLanceWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkLanceWriter.java
@@ -18,10 +18,13 @@
 
 package org.apache.hudi.io.storage;
 
+import org.apache.hudi.common.bloom.BloomFilter;
 import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.io.lance.HoodieBaseLanceWriter;
+import org.apache.hudi.io.storage.row.HoodieBloomFilterRowWriteSupport;
 import org.apache.hudi.io.storage.row.HoodieInternalRowFileWriter;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
@@ -49,8 +52,9 @@ import static org.apache.hudi.common.model.HoodieRecord.HoodieMetadataField.RECO
  *
  * This writer integrates with Hudi's storage I/O layer and supports:
  * - Hudi metadata field population
- * - Record key tracking (for bloom filters - TODO https://github.com/apache/hudi/issues/17664)
+ * - Record key tracking (for bloom filters)
  * - Sequence ID generation
+ * - Min/max record key tracking
  */
 public class HoodieSparkLanceWriter extends HoodieBaseLanceWriter<InternalRow>
     implements HoodieSparkFileWriter, HoodieInternalRowFileWriter {
@@ -73,15 +77,16 @@ public class HoodieSparkLanceWriter extends HoodieBaseLanceWriter<InternalRow>
    * @param taskContextSupplier Task context supplier for partition ID
    * @param storage HoodieStorage instance
    * @param populateMetaFields Whether to populate Hudi metadata fields
-   * @throws IOException if writer initialization fails
+   * @param bloomFilterOpt Optional bloom filter for record key tracking
    */
   public HoodieSparkLanceWriter(StoragePath file,
                                 StructType sparkSchema,
                                 String instantTime,
                                 TaskContextSupplier taskContextSupplier,
                                 HoodieStorage storage,
-                                boolean populateMetaFields) throws IOException {
-    super(file, DEFAULT_BATCH_SIZE);
+                                boolean populateMetaFields,
+                                Option<BloomFilter> bloomFilterOpt) {
+    super(file, DEFAULT_BATCH_SIZE, bloomFilterOpt.map(HoodieBloomFilterRowWriteSupport::new));
     this.sparkSchema = sparkSchema;
     this.arrowSchema = LanceArrowUtils.toArrowSchema(sparkSchema, DEFAULT_TIMEZONE, true, false);
     this.fileName = UTF8String.fromString(file.getName());
@@ -100,19 +105,20 @@ public class HoodieSparkLanceWriter extends HoodieBaseLanceWriter<InternalRow>
    * @param sparkSchema Spark schema for the data
    * @param taskContextSupplier Task context supplier for partition ID
    * @param storage HoodieStorage instance
-   * @throws IOException if writer initialization fails
    */
   public HoodieSparkLanceWriter(StoragePath file,
                                 StructType sparkSchema,
                                 TaskContextSupplier taskContextSupplier,
-                                HoodieStorage storage) throws IOException {
-    this(file, sparkSchema, null, taskContextSupplier, storage, false);
+                                HoodieStorage storage) {
+    this(file, sparkSchema, null, taskContextSupplier, storage, false, Option.empty());
   }
 
   @Override
   public void writeRowWithMetadata(HoodieKey key, InternalRow row) throws IOException {
     if (populateMetaFields) {
       UTF8String recordKey = UTF8String.fromString(key.getRecordKey());
+      bloomFilterWriteSupportOpt.ifPresent(bloomFilterWriteSupport ->
+          ((HoodieBloomFilterRowWriteSupport)bloomFilterWriteSupport).addKey(recordKey));
       updateRecordMetadata(row, recordKey, key.getPartitionPath(), getWrittenRecordCount());
       super.write(row);
     } else {
@@ -122,12 +128,15 @@ public class HoodieSparkLanceWriter extends HoodieBaseLanceWriter<InternalRow>
 
   @Override
   public void writeRow(String recordKey, InternalRow row) throws IOException {
+    bloomFilterWriteSupportOpt.ifPresent(bloomFilterWriteSupport ->
+        ((HoodieBloomFilterRowWriteSupport)bloomFilterWriteSupport).addKey(UTF8String.fromString(recordKey)));
     super.write(row);
   }
   
   @Override
   public void writeRow(UTF8String key, InternalRow row) throws IOException {
-    // Key reserved for future bloom filter support (https://github.com/apache/hudi/issues/17664)
+    bloomFilterWriteSupportOpt.ifPresent(bloomFilterWriteSupport ->
+        ((HoodieBloomFilterRowWriteSupport)bloomFilterWriteSupport).addKey(key));
     super.write(row);
   }
   

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieBloomFilterRowWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieBloomFilterRowWriteSupport.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io.storage.row;
+
+import org.apache.hudi.SparkAdapterSupport$;
+import org.apache.hudi.avro.HoodieBloomFilterWriteSupport;
+import org.apache.hudi.common.bloom.BloomFilter;
+
+import org.apache.spark.sql.HoodieUTF8StringFactory;
+import org.apache.spark.unsafe.types.UTF8String;
+
+/**
+ * Bloom filter write support implementation for Lance file format.
+ * Handles UTF8String record keys specific to Spark InternalRow.
+ */
+public class HoodieBloomFilterRowWriteSupport extends HoodieBloomFilterWriteSupport<UTF8String> {
+
+  private static final HoodieUTF8StringFactory UTF8STRING_FACTORY =
+      SparkAdapterSupport$.MODULE$.sparkAdapter().getUTF8StringFactory();
+
+  public HoodieBloomFilterRowWriteSupport(BloomFilter bloomFilter) {
+    super(bloomFilter);
+  }
+
+  @Override
+  protected int compareRecordKey(UTF8String a, UTF8String b) {
+    return UTF8STRING_FACTORY.wrapUTF8String(a).compareTo(UTF8STRING_FACTORY.wrapUTF8String(b));
+  }
+
+  @Override
+  protected byte[] getUTF8Bytes(UTF8String key) {
+    return key.getBytes();
+  }
+
+  @Override
+  protected UTF8String dereference(UTF8String key) {
+    // NOTE: [[clone]] is performed here (rather than [[copy]]) to only copy underlying buffer in
+    //       cases when [[UTF8String]] is pointing into a buffer storing the whole containing record,
+    //       and simply do a pass over when it holds a (immutable) buffer holding just the string
+    return key.clone();
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
@@ -45,7 +45,6 @@ import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Types;
-import org.apache.spark.sql.HoodieUTF8StringFactory;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.SpecializedGetters;
 import org.apache.spark.sql.catalyst.util.ArrayData;
@@ -382,34 +381,6 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
         }
       });
     };
-  }
-
-  private static class HoodieBloomFilterRowWriteSupport extends HoodieBloomFilterWriteSupport<UTF8String> {
-
-    private static final HoodieUTF8StringFactory UTF8STRING_FACTORY =
-        SparkAdapterSupport$.MODULE$.sparkAdapter().getUTF8StringFactory();
-
-    public HoodieBloomFilterRowWriteSupport(BloomFilter bloomFilter) {
-      super(bloomFilter);
-    }
-
-    @Override
-    protected int compareRecordKey(UTF8String a, UTF8String b) {
-      return UTF8STRING_FACTORY.wrapUTF8String(a).compareTo(UTF8STRING_FACTORY.wrapUTF8String(b));
-    }
-
-    @Override
-    protected byte[] getUTF8Bytes(UTF8String key) {
-      return key.getBytes();
-    }
-
-    @Override
-    protected UTF8String dereference(UTF8String key) {
-      // NOTE: [[clone]] is performed here (rather than [[copy]]) to only copy underlying buffer in
-      //       cases when [[UTF8String]] is pointing into a buffer storing the whole containing record,
-      //       and simply do a pass over when it holds a (immutable) buffer holding just the string
-      return key.clone();
-    }
   }
 
   public static HoodieRowParquetWriteSupport getHoodieRowParquetWriteSupport(Configuration conf, StructType structType,

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/lance/HoodieBaseLanceWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/lance/HoodieBaseLanceWriter.java
@@ -19,6 +19,8 @@
 
 package org.apache.hudi.io.lance;
 
+import org.apache.hudi.avro.HoodieBloomFilterWriteSupport;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.io.memory.HoodieArrowAllocator;
 import org.apache.hudi.storage.StoragePath;
@@ -34,6 +36,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * Base class for Hudi Lance file writers supporting different record types.
@@ -43,6 +46,7 @@ import java.io.IOException;
  * - BufferAllocator management
  * - Record buffering and batch flushing
  * - File size checks
+ * - Bloom filter metadata writing
  *
  * Subclasses must implement type-specific conversion to Arrow format.
  *
@@ -62,6 +66,7 @@ public abstract class HoodieBaseLanceWriter<R> implements Closeable {
   private int currentBatchSize = 0;
   private VectorSchemaRoot root;
   private ArrowWriter<R> arrowWriter;
+  protected final Option<HoodieBloomFilterWriteSupport<?>> bloomFilterWriteSupportOpt;
 
   private LanceFileWriter writer;
 
@@ -70,12 +75,15 @@ public abstract class HoodieBaseLanceWriter<R> implements Closeable {
    *
    * @param path Path where Lance file will be written
    * @param batchSize Number of records to buffer before flushing to Lance
+   * @param bloomFilterWriteSupportOpt Optional bloom filter write support for record key tracking
    */
-  protected HoodieBaseLanceWriter(StoragePath path, int batchSize) {
+  protected HoodieBaseLanceWriter(StoragePath path, int batchSize,
+                                  Option<HoodieBloomFilterWriteSupport<?>> bloomFilterWriteSupportOpt) {
     this.path = path;
     this.allocator = HoodieArrowAllocator.newChildAllocator(
         getClass().getSimpleName() + "-data-" + path.getName(), LANCE_DATA_ALLOCATOR_SIZE);
     this.batchSize = batchSize;
+    this.bloomFilterWriteSupportOpt = bloomFilterWriteSupportOpt;
   }
 
   /**
@@ -154,6 +162,14 @@ public abstract class HoodieBaseLanceWriter<R> implements Closeable {
       }
     } catch (Exception e) {
       primaryException = e;
+    }
+
+    // Finalize and write bloom filter metadata
+    if (writer != null && bloomFilterWriteSupportOpt.isPresent()) {
+      Map<String, String> metadata = bloomFilterWriteSupportOpt.get().finalizeMetadata();
+      if (!metadata.isEmpty()) {
+        writer.addSchemaMetadata(metadata);
+      }
     }
 
     // Close Lance writer

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/TestHoodieSparkLanceReader.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/TestHoodieSparkLanceReader.java
@@ -20,10 +20,13 @@ package org.apache.hudi.io.storage;
 
 import org.apache.hudi.HoodieSchemaConversionUtils;
 import org.apache.hudi.client.SparkTaskContextSupplier;
+import org.apache.hudi.common.bloom.BloomFilter;
+import org.apache.hudi.common.bloom.BloomFilterFactory;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.storage.HoodieStorage;
@@ -57,6 +60,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import static org.apache.hudi.common.bloom.BloomFilterTypeCode.SIMPLE;
 import static org.apache.hudi.io.storage.LanceTestUtils.createRow;
 import static org.apache.hudi.io.storage.LanceTestUtils.createRowWithMetaFields;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -75,12 +79,14 @@ public class TestHoodieSparkLanceReader {
   private HoodieStorage storage;
   private SparkTaskContextSupplier taskContextSupplier;
   private String instantTime;
+  private BloomFilter simpleBloomFilter;
 
   @BeforeEach
   public void setUp() throws IOException {
     storage = HoodieTestUtils.getStorage(tempDir.getAbsolutePath());
     taskContextSupplier = new SparkTaskContextSupplier();
     instantTime = "20251201120000000";
+    simpleBloomFilter = BloomFilterFactory.createBloomFilter(1000, 0.0001, 10000, SIMPLE.name());
   }
 
   @AfterEach
@@ -295,7 +301,7 @@ public class TestHoodieSparkLanceReader {
     StoragePath path = new StoragePath(tempDir.getAbsolutePath() + "/test_large.lance");
     int recordCount = 2500;
     try (HoodieSparkLanceWriter writer = new HoodieSparkLanceWriter(
-        path, schema, instantTime, taskContextSupplier, storage, false)) {
+        path, schema, instantTime, taskContextSupplier, storage, false, Option.of(simpleBloomFilter))) {
       for (int i = 0; i < recordCount; i++) {
         GenericInternalRow row = new GenericInternalRow(new Object[]{i, (long) i * 2});
         writer.writeRow("key" + i, row);
@@ -563,7 +569,7 @@ public class TestHoodieSparkLanceReader {
     
   private HoodieSparkLanceReader writeAndCreateReader(StoragePath path, StructType schema, List<InternalRow> rows, boolean populateMetaFields) throws IOException {
     try (HoodieSparkLanceWriter writer = new HoodieSparkLanceWriter(
-        path, schema, instantTime, taskContextSupplier, storage, populateMetaFields)) {
+        path, schema, instantTime, taskContextSupplier, storage, populateMetaFields, Option.of(simpleBloomFilter))) {
       for (int i = 0; i < rows.size(); i++) {
         HoodieKey key = new HoodieKey("key" + i, "default_partition");
         // Note writeRowWithMetadata implicitly handles case where populateMetaFields=false
@@ -589,7 +595,7 @@ public class TestHoodieSparkLanceReader {
     // Write Lance file with full schema
     StoragePath path = new StoragePath(tempDir.getAbsolutePath() + "/test_projection.lance");
     try (HoodieSparkLanceWriter writer = new HoodieSparkLanceWriter(
-        path, fullSchema, instantTime, taskContextSupplier, storage, false)) {
+        path, fullSchema, instantTime, taskContextSupplier, storage, false, Option.of(simpleBloomFilter))) {
       for (int i = 0; i < rows.size(); i++) {
         writer.writeRow("key" + i, rows.get(i));
       }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/TestHoodieSparkLanceWriter.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/storage/TestHoodieSparkLanceWriter.java
@@ -19,8 +19,11 @@
 package org.apache.hudi.io.storage;
 
 import org.apache.hudi.client.SparkTaskContextSupplier;
+import org.apache.hudi.common.bloom.BloomFilter;
+import org.apache.hudi.common.bloom.BloomFilterFactory;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.testutils.HoodieTestUtils;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.io.memory.HoodieArrowAllocator;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
@@ -53,6 +56,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.hudi.common.bloom.BloomFilterTypeCode.SIMPLE;
 import static org.apache.hudi.common.model.HoodieRecord.HoodieMetadataField.COMMIT_SEQNO_METADATA_FIELD;
 import static org.apache.hudi.common.model.HoodieRecord.HoodieMetadataField.COMMIT_TIME_METADATA_FIELD;
 import static org.apache.hudi.common.model.HoodieRecord.HoodieMetadataField.FILENAME_METADATA_FIELD;
@@ -77,12 +81,14 @@ public class TestHoodieSparkLanceWriter {
   private HoodieStorage storage;
   private SparkTaskContextSupplier taskContextSupplier;
   private String instantTime;
+  private BloomFilter simpleBloomFilter;
 
   @BeforeEach
   public void setUp() throws IOException {
     storage = HoodieTestUtils.getStorage(tempDir.getAbsolutePath());
     taskContextSupplier = new SparkTaskContextSupplier();
     instantTime = "20251201120000000";
+    simpleBloomFilter = BloomFilterFactory.createBloomFilter(1000, 0.0001, 10000, SIMPLE.name());
   }
 
   @AfterEach
@@ -99,7 +105,7 @@ public class TestHoodieSparkLanceWriter {
 
     StoragePath path = new StoragePath(tempDir.getAbsolutePath() + "/test_with_metadata.lance");
     try (HoodieSparkLanceWriter writer = new HoodieSparkLanceWriter(
-        path, schema, instantTime, taskContextSupplier, storage, true)) {
+        path, schema, instantTime, taskContextSupplier, storage, true, Option.of(simpleBloomFilter))) {
       // Write multiple records to test metadata population and sequence ID generation
       for (int i = 0; i < 3; i++) {
         InternalRow row = createRowWithMetaFields(i, "User" + i, 20L + i);
@@ -168,7 +174,7 @@ public class TestHoodieSparkLanceWriter {
 
     StoragePath path = new StoragePath(tempDir.getAbsolutePath() + "/test_without_metadata.lance");
     try (HoodieSparkLanceWriter writer = new HoodieSparkLanceWriter(
-        path, schema, instantTime, taskContextSupplier, storage, false)) {
+        path, schema, instantTime, taskContextSupplier, storage, false, Option.of(simpleBloomFilter))) {
       // Create row with just user data (no meta fields)
       InternalRow row = createRow(1, "Bob", 25L);
       HoodieKey key = new HoodieKey("key2", "partition2");
@@ -212,7 +218,7 @@ public class TestHoodieSparkLanceWriter {
 
     StoragePath path = new StoragePath(tempDir.getAbsolutePath() + "/test_simple_write.lance");
     try (HoodieSparkLanceWriter writer = new HoodieSparkLanceWriter(
-        path, schema, instantTime, taskContextSupplier, storage, false)) {
+        path, schema, instantTime, taskContextSupplier, storage, false, Option.of(simpleBloomFilter))) {
       InternalRow row = createRow(1, "Charlie", 35L);
       writer.writeRow("key3", row);
     }
@@ -233,7 +239,7 @@ public class TestHoodieSparkLanceWriter {
     // Write more than DEFAULT_BATCH_SIZE (1000) records
     int recordCount = 2500;
     try (HoodieSparkLanceWriter writer = new HoodieSparkLanceWriter(
-        path, schema, instantTime, taskContextSupplier, storage, false)) {
+        path, schema, instantTime, taskContextSupplier, storage, false, Option.of(simpleBloomFilter))) {
       for (int i = 0; i < recordCount; i++) {
         InternalRow row = createRow(i, "User" + i, 20L + i);
         writer.writeRow("key" + i, row);
@@ -261,7 +267,7 @@ public class TestHoodieSparkLanceWriter {
 
     StoragePath path = new StoragePath(tempDir.getAbsolutePath() + "/test_primitives.lance");
     try (HoodieSparkLanceWriter writer = new HoodieSparkLanceWriter(
-        path, schema, instantTime, taskContextSupplier, storage, false)) {
+        path, schema, instantTime, taskContextSupplier, storage, false, Option.of(simpleBloomFilter))) {
       GenericInternalRow row = new GenericInternalRow(new Object[]{
           42,                                    // int
           123456789L,                           // long
@@ -308,7 +314,7 @@ public class TestHoodieSparkLanceWriter {
 
     StoragePath path = new StoragePath(tempDir.getAbsolutePath() + "/test_nulls.lance");
     try (HoodieSparkLanceWriter writer = new HoodieSparkLanceWriter(
-        path, schema, instantTime, taskContextSupplier, storage, false)) {
+        path, schema, instantTime, taskContextSupplier, storage, false, Option.of(simpleBloomFilter))) {
       // Write rows with null values
       writer.writeRow("key1", createRow(1, "Alice", 30L));
       writer.writeRow("key2", createRow(2, null, 25L));  // null name
@@ -345,7 +351,7 @@ public class TestHoodieSparkLanceWriter {
 
     StoragePath path = new StoragePath(tempDir.getAbsolutePath() + "/test_empty.lance");
     try (HoodieSparkLanceWriter writer = new HoodieSparkLanceWriter(
-        path, schema, instantTime, taskContextSupplier, storage, false)) {
+        path, schema, instantTime, taskContextSupplier, storage, false, Option.of(simpleBloomFilter))) {
       // Close without writing any rows
     }
 
@@ -393,7 +399,7 @@ public class TestHoodieSparkLanceWriter {
 
     StoragePath path = new StoragePath(tempDir.getAbsolutePath() + "/test_struct.lance");
     try (HoodieSparkLanceWriter writer = new HoodieSparkLanceWriter(
-        path, schema, instantTime, taskContextSupplier, storage, false)) {
+        path, schema, instantTime, taskContextSupplier, storage, false, Option.of(simpleBloomFilter))) {
       for (int i = 0; i < rows.size(); i++) {
         writer.writeRow("key" + i, rows.get(i));
       }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bloom filter support is now integrated with Lance file writing. Bloom filters are conditionally created based on configuration and their metadata is written to Lance files. Record keys are tracked in bloom filters during write operations.

* **Tests**
  * Test suites updated to cover bloom filter creation and handling in Lance writer operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->